### PR TITLE
[BugFix] #1.1 - Fix Maven configuration and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@
 ## Permissions
 - `lobby.admin.setspawn` : permettre de définir le spawn du lobby.
 - `lobby.command.spawn` : permettre l'utilisation de `/spawn`.
+
+## Comment compiler
+
+Ce projet utilise Maven. Pour compiler le plugin et exécuter les tests, lancez :
+
+```bash
+mvn clean verify
+```
+
+Le fichier `.jar` généré se trouvera dans le dossier `target`.

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,17 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>papermc-repo</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- Add PaperMC repository to resolve Velocity API
- Update Spigot API to Minecraft 1.21
- Document build steps in README

## Testing
- ⚠️ `mvn -Djava.net.preferIPv4Stack=true clean verify` *(Could not resolve maven-clean-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b8a16a8c83298d4b6a7315a4259c