### PR TITLE
[LobbyCore] #2 - Sélecteur de Serveurs via GUI (Design Spécifique)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## [Unreleased]
 ### ✨ Ajouts
 - Ajout du système de spawn principal (/setspawn, /spawn, téléportation à la connexion).
+- Implémentation du sélecteur de serveurs via GUI, avec item "Terre" (slot 0), design visuel spécifique, et descriptions détaillées des jeux (Bedwars, Zombie, Nexus, Inédit).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,3 +1,4 @@
 # Roadmap
 
 - [x] Module de Base et Gestion du Spawn (#1)
+- [x] Sélecteur de serveurs via GUI (#2)

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.10.2</version>

--- a/src/main/java/fr/heneria/lobby/LobbyPlugin.java
+++ b/src/main/java/fr/heneria/lobby/LobbyPlugin.java
@@ -1,9 +1,11 @@
 package fr.heneria.lobby;
 
 import fr.heneria.lobby.commands.LobbyCommand;
+import fr.heneria.lobby.commands.ServersCommand;
 import fr.heneria.lobby.commands.SpawnCommand;
 import fr.heneria.lobby.listeners.PlayerListener;
 import fr.heneria.lobby.messages.MessageManager;
+import fr.heneria.lobby.selector.ServerSelectorManager;
 import fr.heneria.lobby.spawn.SpawnManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -13,6 +15,7 @@ public class LobbyPlugin extends JavaPlugin {
 
     private SpawnManager spawnManager;
     private MessageManager messageManager;
+    private ServerSelectorManager serverSelectorManager;
 
     @Override
     public void onEnable() {
@@ -21,11 +24,16 @@ public class LobbyPlugin extends JavaPlugin {
         File spawnFile = new File(getDataFolder(), "locations.yml");
         this.spawnManager = new SpawnManager(spawnFile);
         this.spawnManager.load();
+        this.serverSelectorManager = new ServerSelectorManager(this);
+        this.serverSelectorManager.load();
 
         getCommand("lobby").setExecutor(new LobbyCommand(this));
         getCommand("spawn").setExecutor(new SpawnCommand(this));
+        getCommand("servers").setExecutor(new ServersCommand(this));
 
         getServer().getPluginManager().registerEvents(new PlayerListener(this), this);
+        getServer().getPluginManager().registerEvents(serverSelectorManager, this);
+        getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
     }
 
     public SpawnManager getSpawnManager() {
@@ -34,5 +42,9 @@ public class LobbyPlugin extends JavaPlugin {
 
     public MessageManager getMessageManager() {
         return messageManager;
+    }
+
+    public ServerSelectorManager getServerSelectorManager() {
+        return serverSelectorManager;
     }
 }

--- a/src/main/java/fr/heneria/lobby/commands/ServersCommand.java
+++ b/src/main/java/fr/heneria/lobby/commands/ServersCommand.java
@@ -1,0 +1,31 @@
+package fr.heneria.lobby.commands;
+
+import fr.heneria.lobby.LobbyPlugin;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class ServersCommand implements CommandExecutor {
+
+    private final LobbyPlugin plugin;
+
+    public ServersCommand(LobbyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        Player player = (Player) sender;
+        if (!player.hasPermission("lobby.command.servers")) {
+            player.sendMessage(plugin.getMessageManager().get("no-permission"));
+            return true;
+        }
+        plugin.getServerSelectorManager().open(player);
+        return true;
+    }
+}

--- a/src/main/java/fr/heneria/lobby/listeners/PlayerListener.java
+++ b/src/main/java/fr/heneria/lobby/listeners/PlayerListener.java
@@ -22,6 +22,7 @@ public class PlayerListener implements Listener {
         if (spawn != null) {
             event.getPlayer().teleport(spawn);
         }
+        plugin.getServerSelectorManager().giveItem(event.getPlayer());
     }
 
     @EventHandler

--- a/src/main/java/fr/heneria/lobby/selector/ServerSelectorManager.java
+++ b/src/main/java/fr/heneria/lobby/selector/ServerSelectorManager.java
@@ -1,0 +1,194 @@
+package fr.heneria.lobby.selector;
+
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import fr.heneria.lobby.LobbyPlugin;
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.profile.PlayerProfile;
+import org.bukkit.profile.ProfileProperty;
+
+import java.io.File;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Manages the server selector GUI and item.
+ */
+public class ServerSelectorManager implements Listener {
+
+    private final LobbyPlugin plugin;
+    private ItemStack selectorItem;
+    private int selectorSlot;
+    private String menuTitle;
+    private int menuSize;
+    private final Map<Integer, ItemStack> templates = new HashMap<>();
+    private final Map<Integer, String> actions = new HashMap<>();
+
+    public ServerSelectorManager(LobbyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void load() {
+        // Load item from config.yml
+        FileConfiguration cfg = plugin.getConfig();
+        ConfigurationSection itemSec = cfg.getConfigurationSection("server-selector-item");
+        if (itemSec == null) {
+            plugin.getLogger().warning("server-selector-item section missing in config.yml");
+            return;
+        }
+        selectorSlot = itemSec.getInt("slot", 0);
+        Material mat = Material.matchMaterial(itemSec.getString("material", "PLAYER_HEAD"));
+        selectorItem = new ItemStack(mat);
+        ItemMeta meta = selectorItem.getItemMeta();
+        meta.setDisplayName(color(itemSec.getString("name", "")));
+        meta.setLore(itemSec.getStringList("lore").stream().map(this::color).collect(Collectors.toList()));
+        meta.setUnbreakable(true);
+        if (meta instanceof SkullMeta) {
+            String texture = itemSec.getString("texture-value");
+            if (texture != null && !texture.isEmpty()) {
+                PlayerProfile profile = Bukkit.createProfile(UUID.randomUUID());
+                profile.setProperty(new ProfileProperty("textures", texture));
+                ((SkullMeta) meta).setPlayerProfile(profile);
+            }
+        }
+        selectorItem.setItemMeta(meta);
+
+        // Load menu from server-selector.yml
+        File file = new File(plugin.getDataFolder(), "server-selector.yml");
+        if (!file.exists()) {
+            plugin.saveResource("server-selector.yml", false);
+        }
+        FileConfiguration menuCfg = YamlConfiguration.loadConfiguration(file);
+        menuTitle = color(menuCfg.getString("menu-title", "Menu"));
+        menuSize = menuCfg.getInt("menu-size", 3) * 9;
+        templates.clear();
+        actions.clear();
+        ConfigurationSection itemsSec = menuCfg.getConfigurationSection("items");
+        if (itemsSec != null) {
+            for (String key : itemsSec.getKeys(false)) {
+                ConfigurationSection sec = itemsSec.getConfigurationSection(key);
+                if (sec == null) continue;
+                int slot = sec.getInt("slot");
+                Material material = Material.matchMaterial(sec.getString("material", "STONE"));
+                ItemStack item = new ItemStack(material);
+                ItemMeta im = item.getItemMeta();
+                im.setDisplayName(color(sec.getString("name", "")));
+                im.setLore(sec.getStringList("lore").stream().map(this::color).collect(Collectors.toList()));
+                item.setItemMeta(im);
+                templates.put(slot, item);
+                String action = sec.getString("action");
+                if (action != null) {
+                    actions.put(slot, action);
+                }
+            }
+        }
+    }
+
+    public void giveItem(Player player) {
+        if (selectorItem != null) {
+            player.getInventory().setItem(selectorSlot, selectorItem.clone());
+        }
+    }
+
+    public void open(Player player) {
+        Inventory inv = Bukkit.createInventory(null, menuSize, menuTitle);
+        for (Map.Entry<Integer, ItemStack> entry : templates.entrySet()) {
+            ItemStack item = entry.getValue().clone();
+            ItemMeta meta = item.getItemMeta();
+            if (meta != null) {
+                if (meta.hasDisplayName()) {
+                    meta.setDisplayName(applyPlaceholders(player, meta.getDisplayName()));
+                }
+                if (meta.getLore() != null) {
+                    List<String> lore = meta.getLore().stream().map(line -> applyPlaceholders(player, line)).collect(Collectors.toList());
+                    meta.setLore(lore);
+                }
+                item.setItemMeta(meta);
+            }
+            inv.setItem(entry.getKey(), item);
+        }
+        player.openInventory(inv);
+    }
+
+    private String applyPlaceholders(Player player, String text) {
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            return PlaceholderAPI.setPlaceholders(player, text);
+        }
+        return text;
+    }
+
+    private String color(String text) {
+        return ChatColor.translateAlternateColorCodes('&', text == null ? "" : text);
+    }
+
+    private boolean isSelector(ItemStack stack) {
+        return stack != null && selectorItem != null && stack.isSimilar(selectorItem);
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        ItemStack item = event.getItem();
+        if (isSelector(item)) {
+            event.setCancelled(true);
+            open(event.getPlayer());
+        }
+    }
+
+    @EventHandler
+    public void onDrop(PlayerDropItemEvent event) {
+        if (isSelector(event.getItemDrop().getItemStack())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        ItemStack current = event.getCurrentItem();
+        if (isSelector(current)) {
+            event.setCancelled(true);
+            return;
+        }
+        if (event.getView().getTitle().equals(menuTitle)) {
+            event.setCancelled(true);
+            String action = actions.get(event.getSlot());
+            if (action != null && action.startsWith("server:")) {
+                String server = action.substring("server:".length());
+                Player player = (Player) event.getWhoClicked();
+                connect(player, server);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onInventoryDrag(InventoryDragEvent event) {
+        if (isSelector(event.getOldCursor()) || event.getNewItems().values().stream().anyMatch(this::isSelector)) {
+            event.setCancelled(true);
+        }
+    }
+
+    private void connect(Player player, String server) {
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        out.writeUTF("Connect");
+        out.writeUTF(server);
+        player.sendPluginMessage(plugin, "BungeeCord", out.toByteArray());
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,7 @@
+server-selector-item:
+  material: PLAYER_HEAD
+  texture-value: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjFkZDRmZTRhNDI5YWJkNjY1ZGZkYjNlMjEzMjFkMjIzNDuhOTE0Y2ZlMjFjZDVlY2Y4ZDk2ZjdjYjhhNTM3In19fQ=="
+  slot: 0
+  name: '&aSélecteur de Jeux'
+  lore:
+    - '&7Cliquez pour choisir votre jeu !'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: HeneriaLobby
 version: 0.1.0-SNAPSHOT
 main: fr.heneria.lobby.LobbyPlugin
 api-version: '1.20'
+softdepend: [PlaceholderAPI]
 commands:
   lobby:
     description: Commands administratives du lobby
@@ -9,6 +10,9 @@ commands:
   spawn:
     description: Teleporte au spawn du lobby
     permission: lobby.command.spawn
+  servers:
+    description: Ouvre le menu des serveurs
+    permission: lobby.command.servers
 permissions:
   lobby.command.spawn:
     description: Utiliser /spawn
@@ -16,3 +20,6 @@ permissions:
   lobby.admin.setspawn:
     description: Definir le spawn du lobby
     default: op
+  lobby.command.servers:
+    description: Utiliser /servers
+    default: true

--- a/src/main/resources/server-selector.yml
+++ b/src/main/resources/server-selector.yml
@@ -1,33 +1,3 @@
-# HeneriaLobby
-
-## Fonctionnalités
-- Sélecteur de serveurs via GUI avec item "Terre" dans le slot 0.
-
-## Commandes
-- `/lobby setspawn` : définit le point de spawn du lobby.
-- `/spawn` : téléporte le joueur au spawn du lobby.
-- `/servers` : ouvre le menu de sélection des serveurs.
-
-## Permissions
-- `lobby.admin.setspawn` : permettre de définir le spawn du lobby.
-- `lobby.command.spawn` : permettre l'utilisation de `/spawn`.
-- `lobby.command.servers` : permettre l'utilisation de `/servers`.
-
-## Configuration
-
-### `config.yml`
-```yaml
-server-selector-item:
-  material: PLAYER_HEAD
-  texture-value: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjFkZDRmZTRhNDI5YWJkNjY1ZGZkYjNlMjEzMjFkMjIzNDuhOTE0Y2ZlMjFjZDVlY2Y4ZDk2ZjdjYjhhNTM3In19fQ=="
-  slot: 0
-  name: '&aSélecteur de Jeux'
-  lore:
-    - '&7Cliquez pour choisir votre jeu !'
-```
-
-### `server-selector.yml`
-```yaml
 menu-title: '&6Menu des jeux'
 menu-size: 3
 items:
@@ -89,14 +59,3 @@ items:
       - '&eJoueurs en ligne: &f%bungee_inédit%'
       - '&aCliquez pour rejoindre !'
     action: 'server:inedit'
-```
-
-## Comment compiler
-
-Ce projet utilise Maven. Pour compiler le plugin et exécuter les tests, lancez :
-
-```bash
-mvn clean verify
-```
-
-Le fichier `.jar` généré se trouvera dans le dossier `target`.

--- a/src/test/java/fr/heneria/lobby/selector/ServerSelectorConfigTest.java
+++ b/src/test/java/fr/heneria/lobby/selector/ServerSelectorConfigTest.java
@@ -1,0 +1,28 @@
+package fr.heneria.lobby.selector;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStreamReader;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServerSelectorConfigTest {
+
+    @Test
+    public void testBedwarsConfigurationExists() {
+        FileConfiguration config = load();
+        assertEquals("&6Menu des jeux", config.getString("menu-title"));
+        assertEquals(3, config.getInt("menu-size"));
+        assertNotNull(config.getConfigurationSection("items.bedwars"));
+        assertEquals(13, config.getInt("items.bedwars.slot"));
+        assertEquals("HAY_BLOCK", config.getString("items.bedwars.material"));
+    }
+
+    private FileConfiguration load() {
+        return YamlConfiguration.loadConfiguration(new InputStreamReader(
+                Objects.requireNonNull(getClass().getClassLoader().getResourceAsStream("server-selector.yml"))));
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable server selector item and GUI with placeholder support
- register `/servers` command and give undroppable head item at login
- document server selector configuration and update roadmap/changelog

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bc7de85c8329904497ff6ab6419b