### PR TITLE
[BugFix] #2.2 - Erreur de Compilation : Symbole Introuvable (ProfileProperty)

### DIFF
--- a/src/main/java/fr/heneria/lobby/selector/ServerSelectorManager.java
+++ b/src/main/java/fr/heneria/lobby/selector/ServerSelectorManager.java
@@ -23,7 +23,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.profile.PlayerProfile;
-import org.bukkit.profile.ProfileProperty;
+import com.mojang.authlib.properties.Property;
 
 import java.io.File;
 import java.util.*;
@@ -65,7 +65,7 @@ public class ServerSelectorManager implements Listener {
             String texture = itemSec.getString("texture-value");
             if (texture != null && !texture.isEmpty()) {
                 PlayerProfile profile = Bukkit.createProfile(UUID.randomUUID());
-                profile.setProperty(new ProfileProperty("textures", texture));
+                profile.setProperty(new Property("textures", texture));
                 ((SkullMeta) meta).setPlayerProfile(profile);
             }
         }


### PR DESCRIPTION
## Summary
- use Mojang authlib `Property` to apply custom textures to server selector skulls

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true clean verify` *(fails: Plugin org.apache.maven.plugins:maven-clean-plugin:3.2.0 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c0559ed48329a5c834d88c7b69c3