### PR TITLE
fix(build): Add authlib as a provided dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ items:
 
 ## Comment compiler
 
-Ce projet utilise des dépôts Maven personnalisés (PaperMC, PlaceholderAPI). Pour compiler le plugin et exécuter les tests, lancez :
+Ce projet utilise des dépôts Maven personnalisés (PaperMC, PlaceholderAPI) ainsi que la bibliothèque `com.mojang:authlib` fournie par le serveur. Pour compiler le plugin et exécuter les tests, lancez :
 
 ```bash
 mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.mojang</groupId>
+            <artifactId>authlib</artifactId>
+            <version>8.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.10.2</version>


### PR DESCRIPTION
## Summary
- declare Mojang's Authlib as a provided dependency so compilation succeeds when using ServerSelectorManager
- document Authlib dependency in README compilation instructions

## Testing
- `mvn -q clean verify` *(fails: Could not resolve maven-clean-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c1c3c19c83299670844c6b8a0306