### PR TITLE
[BugFix] #2.4 - Correction de Dépendance : authlib Introuvable dans les Dépôts

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ items:
 
 ## Comment compiler
 
-Ce projet utilise des dépôts Maven personnalisés (PaperMC, PlaceholderAPI) ainsi que la bibliothèque `com.mojang:authlib` fournie par le serveur. Pour compiler le plugin et exécuter les tests, lancez :
+Ce projet utilise des dépôts Maven personnalisés pour ses dépendances : Spigot, PaperMC, PlaceholderAPI et Mojang Libraries (pour `com.mojang:authlib`). Pour compiler le plugin et exécuter les tests, lancez :
 
 ```bash
 mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,11 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>mojang-libraries</id>
+            <name>Mojang Libraries</name>
+            <url>https://libraries.minecraft.net/</url>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- Add Mojang libraries repository to resolve `com.mojang:authlib`
- Document required Maven repositories in README

## Testing
- `mvn clean verify` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin:pom:3.2.0 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c2c2448c832997b40709bc63698f