### PR TITLE
fix(build): Correct authlib version to a resolvable artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.mojang</groupId>
             <artifactId>authlib</artifactId>
-            <version>8.0.0</version>
+            <version>6.0.51</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- correct `com.mojang:authlib` dependency to use version 6.0.51

## Testing
- `mvn clean verify` *(fails: Could not resolve plugin org.apache.maven.plugins:maven-clean-plugin:3.2.0 (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_68b9c3fa15408329b399b7fdbaea59fc