### PR TITLE
[Refactor] #2.6 - Migration vers l'API Paper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,5 @@
 ### ✨ Ajouts
 - Ajout du système de spawn principal (/setspawn, /spawn, téléportation à la connexion).
 - Implémentation du sélecteur de serveurs via GUI, avec item "Terre" (slot 0), design visuel spécifique, et descriptions détaillées des jeux (Bedwars, Zombie, Nexus, Inédit).
+### ♻️ Refactor
+- Migration du projet de Spigot API vers Paper API pour assurer la stabilité du build et la résolution des dépendances internes.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ items:
 
 ## Comment compiler
 
-Ce projet utilise des dépôts Maven personnalisés pour ses dépendances : Spigot, PaperMC, PlaceholderAPI et Mojang Libraries (pour `com.mojang:authlib`). Pour compiler le plugin et exécuter les tests, lancez :
+Ce projet est basé sur l'API Paper et utilise des dépôts Maven personnalisés pour ses dépendances : PaperMC et PlaceholderAPI. Pour compiler le plugin et exécuter les tests, lancez :
 
 ```bash
 mvn clean verify

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,3 +2,4 @@
 
 - [x] Module de Base et Gestion du Spawn (#1)
 - [x] Sélecteur de serveurs via GUI (#2)
+- [x] Migration vers Paper API (#2.6)

--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,6 @@
 
     <repositories>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
             <id>papermc-repo</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
@@ -20,17 +16,12 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
-        <repository>
-            <id>mojang-libraries</id>
-            <name>Mojang Libraries</name>
-            <url>https://libraries.minecraft.net/</url>
-        </repository>
     </repositories>
 
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
             <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
@@ -44,12 +35,6 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.5</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.mojang</groupId>
-            <artifactId>authlib</artifactId>
-            <version>6.0.51</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- Replace Spigot API with Paper API and remove manual Mojang dependencies
- Clean up Maven repositories and dependencies
- Document Paper API usage and update roadmap

## Testing
- `mvn clean verify` *(fails: Could not transfer artifact maven-clean-plugin from central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cb4c73f88329b7a007a6610a92ad