### PR TITLE
CORE-01: initialise lobby plugin with database

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Build with Maven
+        run: mvn -B package

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.iml
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0 - Initial Setup
+- Initial project structure.
+- Database connection and player data management.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # HeneriaLobby
+
+Core lobby plugin for the Heneria network. It connects to a shared MySQL/MariaDB database
+and exposes a small API for other modules to access player information.
+
+## Building
+
+The project uses Maven. To compile the plugin run:
+
+```bash
+mvn package
+```
+
+The compiled jar will be located in the `target` directory.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,6 @@
+# Roadmap
+
+- [ ] Economy system
+- [ ] Friends system
+- [ ] Cosmetics system
+- [ ] Additional lobby features

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.heneria</groupId>
+    <artifactId>heneria-lobby</artifactId>
+    <version>0.1.0</version>
+    <packaging>jar</packaging>
+
+    <name>HeneriaLobby</name>
+    <description>Core lobby plugin for the Heneria network</description>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc-repo</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.3.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/main/java/com/heneria/lobby/HeneriaLobbyPlugin.java
+++ b/src/main/java/com/heneria/lobby/HeneriaLobbyPlugin.java
@@ -1,0 +1,43 @@
+package com.heneria.lobby;
+
+import com.heneria.lobby.database.DatabaseManager;
+import com.heneria.lobby.listeners.PlayerListener;
+import com.heneria.lobby.player.PlayerDataManager;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.sql.SQLException;
+
+public class HeneriaLobbyPlugin extends JavaPlugin {
+
+    private DatabaseManager databaseManager;
+    private PlayerDataManager playerDataManager;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+
+        databaseManager = new DatabaseManager(this);
+        try {
+            databaseManager.init();
+            getLogger().info("Connected to the database successfully.");
+        } catch (SQLException e) {
+            getLogger().severe("Database connection failed: " + e.getMessage());
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        playerDataManager = new PlayerDataManager(this, databaseManager);
+        getServer().getPluginManager().registerEvents(new PlayerListener(playerDataManager), this);
+    }
+
+    @Override
+    public void onDisable() {
+        if (databaseManager != null) {
+            databaseManager.shutdown();
+        }
+    }
+
+    public PlayerDataManager getPlayerDataManager() {
+        return playerDataManager;
+    }
+}

--- a/src/main/java/com/heneria/lobby/database/DatabaseManager.java
+++ b/src/main/java/com/heneria/lobby/database/DatabaseManager.java
@@ -1,0 +1,68 @@
+package com.heneria.lobby.database;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Handles the connection pool to the MySQL/MariaDB database.
+ */
+public class DatabaseManager {
+
+    private final JavaPlugin plugin;
+    private HikariDataSource dataSource;
+
+    public DatabaseManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Initializes the connection pool and ensures required tables exist.
+     */
+    public void init() throws SQLException {
+        FileConfiguration config = plugin.getConfig();
+
+        HikariConfig hikariConfig = new HikariConfig();
+        String jdbcUrl = "jdbc:mysql://" + config.getString("database.host") + ":" +
+                config.getInt("database.port") + "/" + config.getString("database.name");
+        hikariConfig.setJdbcUrl(jdbcUrl);
+        hikariConfig.setUsername(config.getString("database.user"));
+        hikariConfig.setPassword(config.getString("database.password"));
+        hikariConfig.setMaximumPoolSize(10);
+        hikariConfig.setPoolName("HeneriaLobbyPool");
+
+        this.dataSource = new HikariDataSource(hikariConfig);
+
+        createTables();
+    }
+
+    private void createTables() throws SQLException {
+        try (Connection connection = getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate(
+                    "CREATE TABLE IF NOT EXISTS players (" +
+                            "uuid VARCHAR(36) PRIMARY KEY," +
+                            "username VARCHAR(16)," +
+                            "coins BIGINT DEFAULT 0," +
+                            "first_join TIMESTAMP," +
+                            "last_seen TIMESTAMP" +
+                            ")"
+            );
+        }
+    }
+
+    public Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+
+    public void shutdown() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+    }
+}

--- a/src/main/java/com/heneria/lobby/listeners/PlayerListener.java
+++ b/src/main/java/com/heneria/lobby/listeners/PlayerListener.java
@@ -1,0 +1,26 @@
+package com.heneria.lobby.listeners;
+
+import com.heneria.lobby.player.PlayerDataManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class PlayerListener implements Listener {
+
+    private final PlayerDataManager dataManager;
+
+    public PlayerListener(PlayerDataManager dataManager) {
+        this.dataManager = dataManager;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        dataManager.load(event.getPlayer().getUniqueId(), event.getPlayer().getName());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        dataManager.save(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/com/heneria/lobby/player/PlayerData.java
+++ b/src/main/java/com/heneria/lobby/player/PlayerData.java
@@ -1,0 +1,59 @@
+package com.heneria.lobby.player;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Represents persistent data for a player.
+ */
+public class PlayerData {
+    private final UUID uuid;
+    private String username;
+    private long coins;
+    private Instant firstJoin;
+    private Instant lastSeen;
+
+    public PlayerData(UUID uuid, String username, long coins, Instant firstJoin, Instant lastSeen) {
+        this.uuid = uuid;
+        this.username = username;
+        this.coins = coins;
+        this.firstJoin = firstJoin;
+        this.lastSeen = lastSeen;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public long getCoins() {
+        return coins;
+    }
+
+    public void setCoins(long coins) {
+        this.coins = coins;
+    }
+
+    public Instant getFirstJoin() {
+        return firstJoin;
+    }
+
+    public void setFirstJoin(Instant firstJoin) {
+        this.firstJoin = firstJoin;
+    }
+
+    public Instant getLastSeen() {
+        return lastSeen;
+    }
+
+    public void setLastSeen(Instant lastSeen) {
+        this.lastSeen = lastSeen;
+    }
+}

--- a/src/main/java/com/heneria/lobby/player/PlayerDataManager.java
+++ b/src/main/java/com/heneria/lobby/player/PlayerDataManager.java
@@ -1,0 +1,128 @@
+package com.heneria.lobby.player;
+
+import com.heneria.lobby.database.DatabaseManager;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Provides an interface for retrieving and storing player data without exposing
+ * raw database operations.
+ */
+public class PlayerDataManager {
+
+    private final JavaPlugin plugin;
+    private final DatabaseManager databaseManager;
+    private final Map<UUID, PlayerData> cache = new ConcurrentHashMap<>();
+
+    public PlayerDataManager(JavaPlugin plugin, DatabaseManager databaseManager) {
+        this.plugin = plugin;
+        this.databaseManager = databaseManager;
+    }
+
+    public PlayerData getPlayerData(UUID uuid) {
+        return cache.get(uuid);
+    }
+
+    public PlayerData load(UUID uuid, String username) {
+        PlayerData data = cache.get(uuid);
+        if (data != null) {
+            return data;
+        }
+
+        try (Connection connection = databaseManager.getConnection()) {
+            try (PreparedStatement ps = connection.prepareStatement("SELECT * FROM players WHERE uuid=?")) {
+                ps.setString(1, uuid.toString());
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        data = new PlayerData(
+                                uuid,
+                                rs.getString("username"),
+                                rs.getLong("coins"),
+                                rs.getTimestamp("first_join") != null ? rs.getTimestamp("first_join").toInstant() : Instant.now(),
+                                rs.getTimestamp("last_seen") != null ? rs.getTimestamp("last_seen").toInstant() : Instant.now()
+                        );
+                        updateUsernameAndSeen(uuid, username, data.getLastSeen());
+                    } else {
+                        Instant now = Instant.now();
+                        data = new PlayerData(uuid, username, 0L, now, now);
+                        insert(data);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().severe("Failed to load player data for " + username + ": " + e.getMessage());
+        }
+
+        cache.put(uuid, data);
+        return data;
+    }
+
+    public void save(UUID uuid) {
+        PlayerData data = cache.get(uuid);
+        if (data == null) {
+            return;
+        }
+        data.setLastSeen(Instant.now());
+        update(data);
+        cache.remove(uuid);
+    }
+
+    public void setCoins(UUID uuid, long coins) {
+        PlayerData data = cache.computeIfPresent(uuid, (u, d) -> {
+            d.setCoins(coins);
+            return d;
+        });
+        if (data != null) {
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> update(data));
+        }
+    }
+
+    private void insert(PlayerData data) throws SQLException {
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement ps = connection.prepareStatement(
+                     "INSERT INTO players (uuid, username, coins, first_join, last_seen) VALUES (?, ?, ?, ?, ?)")) {
+            ps.setString(1, data.getUuid().toString());
+            ps.setString(2, data.getUsername());
+            ps.setLong(3, data.getCoins());
+            ps.setTimestamp(4, Timestamp.from(data.getFirstJoin()));
+            ps.setTimestamp(5, Timestamp.from(data.getLastSeen()));
+            ps.executeUpdate();
+        }
+    }
+
+    private void update(PlayerData data) {
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement ps = connection.prepareStatement(
+                     "UPDATE players SET username=?, coins=?, first_join=?, last_seen=? WHERE uuid=?")) {
+            ps.setString(1, data.getUsername());
+            ps.setLong(2, data.getCoins());
+            ps.setTimestamp(3, Timestamp.from(data.getFirstJoin()));
+            ps.setTimestamp(4, Timestamp.from(data.getLastSeen()));
+            ps.setString(5, data.getUuid().toString());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            plugin.getLogger().severe("Failed to update data for " + data.getUsername() + ": " + e.getMessage());
+        }
+    }
+
+    private void updateUsernameAndSeen(UUID uuid, String username, Instant lastSeen) throws SQLException {
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement ps = connection.prepareStatement(
+                     "UPDATE players SET username=?, last_seen=? WHERE uuid=?")) {
+            ps.setString(1, username);
+            ps.setTimestamp(2, Timestamp.from(lastSeen));
+            ps.setString(3, uuid.toString());
+            ps.executeUpdate();
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,6 @@
+database:
+  host: "localhost"
+  port: 3306
+  name: "heneria"
+  user: "root"
+  password: "password"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,4 @@
+name: HeneriaLobby
+version: 0.1.0
+main: com.heneria.lobby.HeneriaLobbyPlugin
+api-version: "1.21"


### PR DESCRIPTION
## Summary
- scaffold Maven Paper 1.21 plugin with MySQL connection and player data API
- add config, changelog, roadmap, and CI workflow

## Testing
- `mvn -q package` *(fails: Could not transfer artifacts from Maven Central, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0637542308329ab1dff5f9bcaed50