### PR TITLE
Shade HikariCP to fix startup crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.1 - Fix startup crash
+- Shade HikariCP into the plugin jar to ensure database pool classes are available.
+
 ## 0.1.0 - Initial Setup
 - Initial project structure.
 - Database connection and player data management.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.heneria</groupId>
     <artifactId>heneria-lobby</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>jar</packaging>
 
     <name>HeneriaLobby</name>
@@ -43,5 +43,31 @@
             <version>8.3.0</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.zaxxer.hikari</pattern>
+                            <shadedPattern>com.heneria.lobby.lib.hikari</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: HeneriaLobby
-version: 0.1.0
+version: 0.1.1
 main: com.heneria.lobby.HeneriaLobbyPlugin
 api-version: "1.21"


### PR DESCRIPTION
## Summary
- Shade HikariCP into the plugin jar and relocate classes to prevent NoClassDefFoundError on startup
- Bump plugin version to 0.1.1 and update changelog

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c067c4d13083299eaa9addf3832256