### PR TITLE
feat: add configurable navigation menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.0 - Navigation menus
+- Added configurable GUI navigation system with dynamic server selector.
+- Players receive a permanent item to open the main menu.
+- New `/menu` command to access navigation.
+
 ## 0.3.0 - Visual interface
 - Added configurable scoreboard, tablist and chat formatting.
 - Integrated LuckPerms for rank prefixes in tablist and chat.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,17 @@ Placeholders disponibles :
 - `{player}` – nom du joueur expéditeur.
 - `{message}` – message envoyé.
 - `{ping}` – ping du joueur pour le format de la tablist.
+
+## Configuration des Menus
+
+Le fichier `menus.yml` contrôle l'ensemble de la navigation par GUI. Il permet de définir:
+
+- L'objet de navigation (matériau, nom, description et emplacement).
+- Chaque menu avec son titre et sa taille.
+- Les items contenus dans un menu avec leur matériau, slot, nom, lore et action au clic.
+
+Actions disponibles:
+
+- `open_menu:<nom>` – ouvre un autre menu configuré.
+- `connect_server:<serveur>` – envoie le joueur sur le serveur spécifié via Plugin Messages.
+- `run_command:<commande>` – exécute une commande en tant que joueur.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,5 +3,6 @@
 - [ ] Economy system
 - [x] Friends system
 - [x] Visual interface
+- [x] Navigation
 - [ ] Cosmetics system
 - [ ] Additional lobby features

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.heneria</groupId>
     <artifactId>heneria-lobby</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0</version>
     <packaging>jar</packaging>
 
     <name>HeneriaLobby</name>

--- a/src/main/java/com/heneria/lobby/HeneriaLobbyPlugin.java
+++ b/src/main/java/com/heneria/lobby/HeneriaLobbyPlugin.java
@@ -3,14 +3,19 @@ package com.heneria.lobby;
 import com.heneria.lobby.commands.FriendsCommand;
 import com.heneria.lobby.commands.LobbyAdminCommand;
 import com.heneria.lobby.commands.MsgCommand;
+import com.heneria.lobby.commands.MenuCommand;
 import com.heneria.lobby.database.DatabaseManager;
 import com.heneria.lobby.listeners.PlayerListener;
 import com.heneria.lobby.listeners.ChatListener;
+import com.heneria.lobby.listeners.NavigationItemListener;
+import com.heneria.lobby.listeners.MenuListener;
 import com.heneria.lobby.player.PlayerDataManager;
 import com.heneria.lobby.friends.FriendManager;
 import com.heneria.lobby.friends.PrivateMessageManager;
 import com.heneria.lobby.ui.ScoreboardManager;
 import com.heneria.lobby.ui.TablistManager;
+import com.heneria.lobby.menu.GUIManager;
+import com.heneria.lobby.menu.ServerInfoManager;
 import net.luckperms.api.LuckPerms;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -30,6 +35,8 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
     private ScoreboardManager scoreboardManager;
     private TablistManager tablistManager;
     private LuckPerms luckPerms;
+    private GUIManager guiManager;
+    private ServerInfoManager serverInfoManager;
 
     @Override
     public void onEnable() {
@@ -52,17 +59,24 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
         luckPerms = provider != null ? provider.getProvider() : null;
         scoreboardManager = new ScoreboardManager(this);
         tablistManager = new TablistManager(this, luckPerms);
+        serverInfoManager = new ServerInfoManager(this);
+        guiManager = new GUIManager(this, serverInfoManager);
 
         getServer().getPluginManager().registerEvents(new PlayerListener(this, playerDataManager, friendManager, messageManager, scoreboardManager, tablistManager), this);
         getServer().getPluginManager().registerEvents(new ChatListener(this, tablistManager), this);
+        getServer().getPluginManager().registerEvents(new NavigationItemListener(guiManager), this);
+        getServer().getPluginManager().registerEvents(new MenuListener(this, guiManager), this);
         getCommand("lobbyadmin").setExecutor(new LobbyAdminCommand(databaseManager));
         getCommand("friends").setExecutor(new FriendsCommand(this, friendManager));
+        getCommand("menu").setExecutor(new MenuCommand(guiManager));
         MsgCommand msgCommand = new MsgCommand(this, messageManager);
         getCommand("msg").setExecutor(msgCommand);
         getCommand("r").setExecutor(msgCommand);
 
         getServer().getMessenger().registerOutgoingPluginChannel(this, "heneria:friends");
         getServer().getMessenger().registerOutgoingPluginChannel(this, "heneria:msg");
+        getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
+        getServer().getMessenger().registerIncomingPluginChannel(this, "BungeeCord", serverInfoManager);
     }
 
     @Override
@@ -78,5 +92,13 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
 
     public FileConfiguration getMessages() {
         return messages;
+    }
+
+    public GUIManager getGuiManager() {
+        return guiManager;
+    }
+
+    public ServerInfoManager getServerInfoManager() {
+        return serverInfoManager;
     }
 }

--- a/src/main/java/com/heneria/lobby/commands/MenuCommand.java
+++ b/src/main/java/com/heneria/lobby/commands/MenuCommand.java
@@ -1,0 +1,28 @@
+package com.heneria.lobby.commands;
+
+import com.heneria.lobby.menu.GUIManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Command to open the main navigation menu.
+ */
+public class MenuCommand implements CommandExecutor {
+
+    private final GUIManager guiManager;
+
+    public MenuCommand(GUIManager guiManager) {
+        this.guiManager = guiManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (sender instanceof Player player) {
+            guiManager.openMenu(player, "main");
+        }
+        return true;
+    }
+}
+

--- a/src/main/java/com/heneria/lobby/listeners/MenuListener.java
+++ b/src/main/java/com/heneria/lobby/listeners/MenuListener.java
@@ -1,0 +1,59 @@
+package com.heneria.lobby.listeners;
+
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import com.heneria.lobby.HeneriaLobbyPlugin;
+import com.heneria.lobby.menu.GUIManager;
+import com.heneria.lobby.menu.Menu;
+import com.heneria.lobby.menu.MenuItem;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+/**
+ * Handles clicks within configured menus.
+ */
+public class MenuListener implements Listener {
+
+    private final GUIManager guiManager;
+    private final HeneriaLobbyPlugin plugin;
+
+    public MenuListener(HeneriaLobbyPlugin plugin, GUIManager guiManager) {
+        this.plugin = plugin;
+        this.guiManager = guiManager;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        Menu menu = guiManager.getMenuByTitle(event.getView().getTitle());
+        if (menu == null) {
+            return;
+        }
+        event.setCancelled(true);
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        MenuItem item = menu.getItems().get(event.getRawSlot());
+        if (item == null) {
+            return;
+        }
+        String action = item.getAction();
+        if (action.startsWith("open_menu:")) {
+            String name = action.split(":", 2)[1];
+            guiManager.openMenu(player, name);
+        } else if (action.startsWith("run_command:")) {
+            String cmd = action.split(":", 2)[1];
+            player.closeInventory();
+            player.performCommand(cmd);
+        } else if (action.startsWith("connect_server:")) {
+            String server = action.split(":", 2)[1];
+            ByteArrayDataOutput out = ByteStreams.newDataOutput();
+            out.writeUTF("Connect");
+            out.writeUTF(server);
+            player.closeInventory();
+            player.sendPluginMessage(plugin, "BungeeCord", out.toByteArray());
+        }
+    }
+}
+

--- a/src/main/java/com/heneria/lobby/listeners/NavigationItemListener.java
+++ b/src/main/java/com/heneria/lobby/listeners/NavigationItemListener.java
@@ -1,0 +1,54 @@
+package com.heneria.lobby.listeners;
+
+import com.heneria.lobby.menu.GUIManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+/**
+ * Gives players a permanent navigation item to open the main menu.
+ */
+public class NavigationItemListener implements Listener {
+
+    private final GUIManager guiManager;
+
+    public NavigationItemListener(GUIManager guiManager) {
+        this.guiManager = guiManager;
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        player.getInventory().setItem(guiManager.getNavigationSlot(), guiManager.getNavigationItem());
+    }
+
+    @EventHandler
+    public void onDrop(PlayerDropItemEvent event) {
+        if (event.getItemDrop().getItemStack().isSimilar(guiManager.getNavigationItem())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (event.getCurrentItem() != null && event.getCurrentItem().isSimilar(guiManager.getNavigationItem())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        if (event.getItem() != null && event.getItem().isSimilar(guiManager.getNavigationItem())) {
+            if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+                event.setCancelled(true);
+                guiManager.openMenu(event.getPlayer(), "main");
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/heneria/lobby/menu/GUIManager.java
+++ b/src/main/java/com/heneria/lobby/menu/GUIManager.java
@@ -1,0 +1,147 @@
+package com.heneria.lobby.menu;
+
+import com.heneria.lobby.HeneriaLobbyPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Loads menus from configuration and builds inventories dynamically.
+ */
+public class GUIManager {
+
+    private final HeneriaLobbyPlugin plugin;
+    private final ServerInfoManager serverInfoManager;
+    private FileConfiguration config;
+    private final Map<String, Menu> menus = new HashMap<>();
+    private ItemStack navigationItem;
+    private int navigationSlot;
+
+    public GUIManager(HeneriaLobbyPlugin plugin, ServerInfoManager serverInfoManager) {
+        this.plugin = plugin;
+        this.serverInfoManager = serverInfoManager;
+        loadConfig();
+    }
+
+    public void loadConfig() {
+        plugin.saveResource("menus.yml", false);
+        File file = new File(plugin.getDataFolder(), "menus.yml");
+        this.config = YamlConfiguration.loadConfiguration(file);
+        menus.clear();
+        ConfigurationSection menusSec = config.getConfigurationSection("menus");
+        if (menusSec != null) {
+            for (String key : menusSec.getKeys(false)) {
+                ConfigurationSection sec = menusSec.getConfigurationSection(key);
+                String title = color(sec.getString("title", key));
+                int size = sec.getInt("size", 27);
+                Map<Integer, MenuItem> items = new HashMap<>();
+                ConfigurationSection itemsSec = sec.getConfigurationSection("items");
+                if (itemsSec != null) {
+                    for (String itemKey : itemsSec.getKeys(false)) {
+                        ConfigurationSection itemSec = itemsSec.getConfigurationSection(itemKey);
+                        int slot = itemSec.getInt("slot");
+                        ItemStack stack = buildItem(itemSec);
+                        String action = itemSec.getString("action", "");
+                        items.put(slot, new MenuItem(stack, action));
+                    }
+                }
+                Menu menu = new Menu(key, title, size, items);
+                menus.put(key, menu);
+            }
+        }
+        ConfigurationSection navSec = config.getConfigurationSection("navigation-item");
+        if (navSec != null) {
+            navigationItem = buildItem(navSec);
+            navigationSlot = navSec.getInt("slot", 8);
+        }
+    }
+
+    private ItemStack buildItem(ConfigurationSection sec) {
+        Material mat = Material.matchMaterial(sec.getString("material", "STONE"));
+        if (mat == null) {
+            mat = Material.STONE;
+        }
+        ItemStack stack = new ItemStack(mat);
+        ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(color(sec.getString("name", "")));
+            List<String> lore = sec.getStringList("lore").stream()
+                    .map(this::color)
+                    .collect(Collectors.toList());
+            meta.setLore(lore);
+            stack.setItemMeta(meta);
+        }
+        return stack;
+    }
+
+    public void openMenu(Player player, String menuName) {
+        Menu menu = menus.get(menuName);
+        if (menu == null) {
+            return;
+        }
+        Inventory inv = Bukkit.createInventory(null, menu.getSize(), menu.getTitle());
+        for (Map.Entry<Integer, MenuItem> entry : menu.getItems().entrySet()) {
+            MenuItem item = entry.getValue();
+            ItemStack stack = item.getItemStack().clone();
+            ItemMeta meta = stack.getItemMeta();
+            String action = item.getAction();
+            if (action.startsWith("connect_server:")) {
+                String server = action.split(":", 2)[1];
+                serverInfoManager.requestPlayerCount(player, server);
+                int count = serverInfoManager.getPlayerCount(server);
+                if (meta != null && meta.hasLore()) {
+                    List<String> lore = meta.getLore().stream()
+                            .map(l -> l.replace("%players%", count >= 0 ? String.valueOf(count) : "N/A"))
+                            .collect(Collectors.toList());
+                    meta.setLore(lore);
+                }
+            }
+            if (meta != null && meta.hasLore()) {
+                List<String> lore = meta.getLore().stream()
+                        .map(l -> l.replace("%player%", player.getName()))
+                        .collect(Collectors.toList());
+                meta.setLore(lore);
+            }
+            if (meta != null) {
+                stack.setItemMeta(meta);
+            }
+            inv.setItem(entry.getKey(), stack);
+        }
+        player.openInventory(inv);
+    }
+
+    public ItemStack getNavigationItem() {
+        return navigationItem.clone();
+    }
+
+    public int getNavigationSlot() {
+        return navigationSlot;
+    }
+
+    public Menu getMenuByTitle(String title) {
+        for (Menu menu : menus.values()) {
+            if (menu.getTitle().equals(title)) {
+                return menu;
+            }
+        }
+        return null;
+    }
+
+    private String color(String text) {
+        return ChatColor.translateAlternateColorCodes('&', text);
+    }
+}
+

--- a/src/main/java/com/heneria/lobby/menu/Menu.java
+++ b/src/main/java/com/heneria/lobby/menu/Menu.java
@@ -1,0 +1,44 @@
+package com.heneria.lobby.menu;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Map;
+
+/**
+ * Represents a menu configuration with a title, size and items.
+ */
+public class Menu {
+
+    private final String name;
+    private final String title;
+    private final int size;
+    private final Map<Integer, MenuItem> items;
+
+    public Menu(String name, String title, int size, Map<Integer, MenuItem> items) {
+        this.name = name;
+        this.title = title;
+        this.size = size;
+        this.items = items;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public Map<Integer, MenuItem> getItems() {
+        return items;
+    }
+
+    public ItemStack getItem(int slot) {
+        return items.containsKey(slot) ? items.get(slot).getItemStack() : null;
+    }
+}
+

--- a/src/main/java/com/heneria/lobby/menu/MenuItem.java
+++ b/src/main/java/com/heneria/lobby/menu/MenuItem.java
@@ -1,0 +1,26 @@
+package com.heneria.lobby.menu;
+
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Represents a clickable item inside a menu.
+ */
+public class MenuItem {
+
+    private final ItemStack itemStack;
+    private final String action;
+
+    public MenuItem(ItemStack itemStack, String action) {
+        this.itemStack = itemStack;
+        this.action = action;
+    }
+
+    public ItemStack getItemStack() {
+        return itemStack;
+    }
+
+    public String getAction() {
+        return action;
+    }
+}
+

--- a/src/main/java/com/heneria/lobby/menu/ServerInfoManager.java
+++ b/src/main/java/com/heneria/lobby/menu/ServerInfoManager.java
@@ -1,0 +1,52 @@
+package com.heneria.lobby.menu;
+
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import com.heneria.lobby.HeneriaLobbyPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Handles plugin message communication with Velocity/Bungee to retrieve
+ * server information such as player counts.
+ */
+public class ServerInfoManager implements PluginMessageListener {
+
+    private final HeneriaLobbyPlugin plugin;
+    private final Map<String, Integer> playerCounts = new ConcurrentHashMap<>();
+
+    public ServerInfoManager(HeneriaLobbyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void requestPlayerCount(Player player, String server) {
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        out.writeUTF("PlayerCount");
+        out.writeUTF(server);
+        player.sendPluginMessage(plugin, "BungeeCord", out.toByteArray());
+    }
+
+    public int getPlayerCount(String server) {
+        return playerCounts.getOrDefault(server, -1);
+    }
+
+    @Override
+    public void onPluginMessageReceived(String channel, Player player, byte[] message) {
+        if (!"BungeeCord".equals(channel)) {
+            return;
+        }
+        ByteArrayDataInput in = ByteStreams.newDataInput(message);
+        String sub = in.readUTF();
+        if ("PlayerCount".equals(sub)) {
+            String server = in.readUTF();
+            int count = in.readInt();
+            playerCounts.put(server, count);
+        }
+    }
+}
+

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -1,0 +1,61 @@
+navigation-item:
+  material: NETHER_STAR
+  slot: 8
+  name: "&aNavigation"
+  lore:
+    - "&7Ouvrir le menu principal"
+
+menus:
+  main:
+    title: "&6Menu Principal"
+    size: 27
+    items:
+      games:
+        material: COMPASS
+        slot: 11
+        name: "&eSélecteur de Jeux"
+        lore:
+          - "&7Rejoindre un serveur"
+        action: "open_menu:games"
+      profile:
+        material: PLAYER_HEAD
+        slot: 13
+        name: "&aProfil"
+        lore:
+          - "&7Voir vos informations"
+        action: "open_menu:profile"
+      cosmetics:
+        material: ENDER_CHEST
+        slot: 15
+        name: "&dBoutique Cosmétique"
+        lore:
+          - "&7Acheter des cosmétiques"
+        action: "run_command:cosmetics"
+  games:
+    title: "&eSélecteur de Jeux"
+    size: 27
+    items:
+      bedwars:
+        material: RED_BED
+        slot: 11
+        name: "&cBedwars"
+        lore:
+          - "&7%players% joueurs en ligne"
+        action: "connect_server:bedwars"
+  profile:
+    title: "&aProfil"
+    size: 27
+    items:
+      info:
+        material: PLAYER_HEAD
+        slot: 13
+        name: "&eVos Infos"
+        lore:
+          - "&7Pseudo: %player%"
+      friends:
+        material: BOOK
+        slot: 15
+        name: "&bAmis"
+        lore:
+          - "&7Gérer vos amis"
+        action: "run_command:friends"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: HeneriaLobby
-version: 0.3.0
+version: 0.4.0
 main: com.heneria.lobby.HeneriaLobbyPlugin
 api-version: "1.21"
 softdepend:
@@ -19,3 +19,6 @@ commands:
   r:
     description: Reply to the last private message
     usage: "/r <message>"
+  menu:
+    description: Open the main navigation menu
+    usage: "/menu"


### PR DESCRIPTION
## Summary
- implement configurable GUIManager with menu system and server selector
- give players a permanent navigation item and `/menu` command
- document menu configuration and update project metadata

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c07f1ebb28832981c5b5c66833df25