### PR TITLE
feat: add configurable navigation items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## 0.4.0 - Navigation menus
-- Added configurable GUI navigation system with dynamic server selector.
-- Players receive a permanent item to open the main menu.
-- New `/menu` command to access navigation.
+## 0.4.0 - Navigation par objets dédiés
+- Ajout d'objets persistants configurables via `items.yml` pour ouvrir les menus principaux.
+- Nouveau système de menus de premier niveau : jeux, profil, boutique et activités.
+- Commandes `/games`, `/profil`, `/shop` et `/activites` comme raccourcis.
 
 ## 0.3.0 - Visual interface
 - Added configurable scoreboard, tablist and chat formatting.

--- a/README.md
+++ b/README.md
@@ -43,15 +43,25 @@ Placeholders disponibles :
 - `{message}` – message envoyé.
 - `{ping}` – ping du joueur pour le format de la tablist.
 
+## Objets de Navigation Persistants
+
+Le fichier `items.yml` distribue des objets permanents aux joueurs à leur connexion.
+Pour chaque objet, on peut définir :
+
+- `material` – type d'objet placé dans la barre d'inventaire.
+- `slot` – position fixe dans l'inventaire.
+- `name` et `lore` – texte supportant les codes couleur.
+- `action` – généralement `open_menu:<nom>` pour ouvrir un menu spécifique.
+
+Les menus correspondants peuvent aussi être ouverts via les commandes `/games` (`/jeux`),
+`/profil`, `/shop` (`/boutique`) et `/activites`.
+
 ## Configuration des Menus
 
-Le fichier `menus.yml` contrôle l'ensemble de la navigation par GUI. Il permet de définir:
+Le fichier `menus.yml` définit chaque interface : titre, taille et items internes avec
+leur matériau, emplacement, nom, description et action au clic.
 
-- L'objet de navigation (matériau, nom, description et emplacement).
-- Chaque menu avec son titre et sa taille.
-- Les items contenus dans un menu avec leur matériau, slot, nom, lore et action au clic.
-
-Actions disponibles:
+Actions disponibles :
 
 - `open_menu:<nom>` – ouvre un autre menu configuré.
 - `connect_server:<serveur>` – envoie le joueur sur le serveur spécifié via Plugin Messages.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,6 @@
 - [ ] Economy system
 - [x] Friends system
 - [x] Visual interface
-- [x] Navigation
+- [x] Navigation (Terminé)
 - [ ] Cosmetics system
 - [ ] Additional lobby features

--- a/src/main/java/com/heneria/lobby/HeneriaLobbyPlugin.java
+++ b/src/main/java/com/heneria/lobby/HeneriaLobbyPlugin.java
@@ -3,7 +3,7 @@ package com.heneria.lobby;
 import com.heneria.lobby.commands.FriendsCommand;
 import com.heneria.lobby.commands.LobbyAdminCommand;
 import com.heneria.lobby.commands.MsgCommand;
-import com.heneria.lobby.commands.MenuCommand;
+import com.heneria.lobby.commands.OpenMenuCommand;
 import com.heneria.lobby.database.DatabaseManager;
 import com.heneria.lobby.listeners.PlayerListener;
 import com.heneria.lobby.listeners.ChatListener;
@@ -68,10 +68,13 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new MenuListener(this, guiManager), this);
         getCommand("lobbyadmin").setExecutor(new LobbyAdminCommand(databaseManager));
         getCommand("friends").setExecutor(new FriendsCommand(this, friendManager));
-        getCommand("menu").setExecutor(new MenuCommand(guiManager));
         MsgCommand msgCommand = new MsgCommand(this, messageManager);
         getCommand("msg").setExecutor(msgCommand);
         getCommand("r").setExecutor(msgCommand);
+        getCommand("games").setExecutor(new OpenMenuCommand(guiManager, "games"));
+        getCommand("profil").setExecutor(new OpenMenuCommand(guiManager, "profile"));
+        getCommand("shop").setExecutor(new OpenMenuCommand(guiManager, "shop"));
+        getCommand("activites").setExecutor(new OpenMenuCommand(guiManager, "activities"));
 
         getServer().getMessenger().registerOutgoingPluginChannel(this, "heneria:friends");
         getServer().getMessenger().registerOutgoingPluginChannel(this, "heneria:msg");

--- a/src/main/java/com/heneria/lobby/commands/OpenMenuCommand.java
+++ b/src/main/java/com/heneria/lobby/commands/OpenMenuCommand.java
@@ -7,22 +7,23 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 /**
- * Command to open the main navigation menu.
+ * Generic command to open a specific GUI menu.
  */
-public class MenuCommand implements CommandExecutor {
+public class OpenMenuCommand implements CommandExecutor {
 
     private final GUIManager guiManager;
+    private final String menu;
 
-    public MenuCommand(GUIManager guiManager) {
+    public OpenMenuCommand(GUIManager guiManager, String menu) {
         this.guiManager = guiManager;
+        this.menu = menu;
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (sender instanceof Player player) {
-            guiManager.openMenu(player, "main");
+            guiManager.openMenu(player, menu);
         }
         return true;
     }
 }
-

--- a/src/main/java/com/heneria/lobby/listeners/NavigationItemListener.java
+++ b/src/main/java/com/heneria/lobby/listeners/NavigationItemListener.java
@@ -1,6 +1,7 @@
 package com.heneria.lobby.listeners;
 
 import com.heneria.lobby.menu.GUIManager;
+import com.heneria.lobby.menu.MenuItem;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -11,7 +12,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 
 /**
- * Gives players a permanent navigation item to open the main menu.
+ * Handles persistent hotbar navigation items defined in configuration.
  */
 public class NavigationItemListener implements Listener {
 
@@ -24,29 +25,38 @@ public class NavigationItemListener implements Listener {
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        player.getInventory().setItem(guiManager.getNavigationSlot(), guiManager.getNavigationItem());
+        guiManager.getNavigationItems().forEach((slot, item) ->
+                player.getInventory().setItem(slot, item.getItemStack()));
     }
 
     @EventHandler
     public void onDrop(PlayerDropItemEvent event) {
-        if (event.getItemDrop().getItemStack().isSimilar(guiManager.getNavigationItem())) {
+        if (guiManager.isNavigationItem(event.getItemDrop().getItemStack())) {
             event.setCancelled(true);
         }
     }
 
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
-        if (event.getCurrentItem() != null && event.getCurrentItem().isSimilar(guiManager.getNavigationItem())) {
+        if (event.getCurrentItem() != null && guiManager.isNavigationItem(event.getCurrentItem())) {
             event.setCancelled(true);
         }
     }
 
     @EventHandler
     public void onInteract(PlayerInteractEvent event) {
-        if (event.getItem() != null && event.getItem().isSimilar(guiManager.getNavigationItem())) {
+        if (event.getItem() != null && guiManager.isNavigationItem(event.getItem())) {
             if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
                 event.setCancelled(true);
-                guiManager.openMenu(event.getPlayer(), "main");
+                MenuItem item = guiManager.getNavigationItem(event.getItem());
+                String action = item.getAction();
+                if (action.startsWith("open_menu:")) {
+                    String name = action.split(":", 2)[1];
+                    guiManager.openMenu(event.getPlayer(), name);
+                } else if (action.startsWith("run_command:")) {
+                    String cmd = action.split(":", 2)[1];
+                    event.getPlayer().performCommand(cmd);
+                }
             }
         }
     }

--- a/src/main/java/com/heneria/lobby/menu/GUIManager.java
+++ b/src/main/java/com/heneria/lobby/menu/GUIManager.java
@@ -27,8 +27,7 @@ public class GUIManager {
     private final ServerInfoManager serverInfoManager;
     private FileConfiguration config;
     private final Map<String, Menu> menus = new HashMap<>();
-    private ItemStack navigationItem;
-    private int navigationSlot;
+    private final Map<Integer, MenuItem> navigationItems = new HashMap<>();
 
     public GUIManager(HeneriaLobbyPlugin plugin, ServerInfoManager serverInfoManager) {
         this.plugin = plugin;
@@ -38,9 +37,11 @@ public class GUIManager {
 
     public void loadConfig() {
         plugin.saveResource("menus.yml", false);
+        plugin.saveResource("items.yml", false);
         File file = new File(plugin.getDataFolder(), "menus.yml");
         this.config = YamlConfiguration.loadConfiguration(file);
         menus.clear();
+        navigationItems.clear();
         ConfigurationSection menusSec = config.getConfigurationSection("menus");
         if (menusSec != null) {
             for (String key : menusSec.getKeys(false)) {
@@ -62,10 +63,17 @@ public class GUIManager {
                 menus.put(key, menu);
             }
         }
-        ConfigurationSection navSec = config.getConfigurationSection("navigation-item");
+        File itemsFile = new File(plugin.getDataFolder(), "items.yml");
+        FileConfiguration itemsConfig = YamlConfiguration.loadConfiguration(itemsFile);
+        ConfigurationSection navSec = itemsConfig.getConfigurationSection("items");
         if (navSec != null) {
-            navigationItem = buildItem(navSec);
-            navigationSlot = navSec.getInt("slot", 8);
+            for (String key : navSec.getKeys(false)) {
+                ConfigurationSection itemSec = navSec.getConfigurationSection(key);
+                int slot = itemSec.getInt("slot");
+                ItemStack stack = buildItem(itemSec);
+                String action = itemSec.getString("action", "");
+                navigationItems.put(slot, new MenuItem(stack, action));
+            }
         }
     }
 
@@ -123,12 +131,21 @@ public class GUIManager {
         player.openInventory(inv);
     }
 
-    public ItemStack getNavigationItem() {
-        return navigationItem.clone();
+    public Map<Integer, MenuItem> getNavigationItems() {
+        return navigationItems;
     }
 
-    public int getNavigationSlot() {
-        return navigationSlot;
+    public MenuItem getNavigationItem(ItemStack stack) {
+        for (MenuItem item : navigationItems.values()) {
+            if (stack.isSimilar(item.getItemStack())) {
+                return item;
+            }
+        }
+        return null;
+    }
+
+    public boolean isNavigationItem(ItemStack stack) {
+        return getNavigationItem(stack) != null;
     }
 
     public Menu getMenuByTitle(String title) {

--- a/src/main/resources/items.yml
+++ b/src/main/resources/items.yml
@@ -1,0 +1,29 @@
+items:
+  games_selector:
+    material: PURPLE_BANNER
+    slot: 0
+    name: "&dSélecteur de Jeux"
+    lore:
+      - "&7Choisir un jeu"
+    action: "open_menu:games"
+  profile:
+    material: PLAYER_HEAD
+    slot: 1
+    name: "&eProfil"
+    lore:
+      - "&7Voir vos informations"
+    action: "open_menu:profile"
+  shop:
+    material: ENDER_CHEST
+    slot: 4
+    name: "&6Boutique Cosmétique"
+    lore:
+      - "&7Acheter des cosmétiques"
+    action: "open_menu:shop"
+  activities:
+    material: FIREWORK_ROCKET
+    slot: 8
+    name: "&bActivités du Lobby"
+    lore:
+      - "&7Mini-jeux du lobby"
+    action: "open_menu:activities"

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -1,36 +1,4 @@
-navigation-item:
-  material: NETHER_STAR
-  slot: 8
-  name: "&aNavigation"
-  lore:
-    - "&7Ouvrir le menu principal"
-
 menus:
-  main:
-    title: "&6Menu Principal"
-    size: 27
-    items:
-      games:
-        material: COMPASS
-        slot: 11
-        name: "&eSélecteur de Jeux"
-        lore:
-          - "&7Rejoindre un serveur"
-        action: "open_menu:games"
-      profile:
-        material: PLAYER_HEAD
-        slot: 13
-        name: "&aProfil"
-        lore:
-          - "&7Voir vos informations"
-        action: "open_menu:profile"
-      cosmetics:
-        material: ENDER_CHEST
-        slot: 15
-        name: "&dBoutique Cosmétique"
-        lore:
-          - "&7Acheter des cosmétiques"
-        action: "run_command:cosmetics"
   games:
     title: "&eSélecteur de Jeux"
     size: 27
@@ -59,3 +27,37 @@ menus:
         lore:
           - "&7Gérer vos amis"
         action: "run_command:friends"
+  shop:
+    title: "&dBoutique Cosmétique"
+    size: 27
+    items:
+      particles:
+        material: BLAZE_POWDER
+        slot: 11
+        name: "&cParticules"
+        lore:
+          - "&7Effets de particules"
+      hats:
+        material: LEATHER_HELMET
+        slot: 15
+        name: "&eChapeaux"
+        lore:
+          - "&7Accessoires de tête"
+  activities:
+    title: "&bActivités du Lobby"
+    size: 27
+    items:
+      parkour:
+        material: SLIME_BLOCK
+        slot: 11
+        name: "&aParkour"
+        lore:
+          - "&7Se téléporter au parkour"
+        action: "run_command:parkour"
+      archery:
+        material: BOW
+        slot: 15
+        name: "&cTir à l'arc"
+        lore:
+          - "&7Lancer le mini-jeu"
+        action: "run_command:archery"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -19,6 +19,17 @@ commands:
   r:
     description: Reply to the last private message
     usage: "/r <message>"
-  menu:
-    description: Open the main navigation menu
-    usage: "/menu"
+  games:
+    description: Open the games selector
+    aliases: [jeux]
+    usage: "/games"
+  profil:
+    description: Open your profile menu
+    usage: "/profil"
+  shop:
+    description: Open the cosmetics shop
+    aliases: [boutique]
+    usage: "/shop"
+  activites:
+    description: Open the lobby activities menu
+    usage: "/activites"


### PR DESCRIPTION
## Summary
- implement persistent hotbar navigation items configurable via `items.yml`
- register commands `/games`, `/profil`, `/shop`, `/activites`
- document navigation item setup and update changelog/roadmap

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c083bf5b908329a437f258e261381d