### PR TITLE
feat: add in-game activity admin commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1 - Interface de configuration en jeu
+- Ajout de la commande `/lobbyadmin` pour configurer le parkour et le mini-foot.
+- Sauvegarde immédiate des modifications dans `activities.yml`.
+
 ## 0.5.0 - Implémentation des activités du lobby
 - Ajout du parkour chronométré avec checkpoints et classement holographique.
 - Mini-jeu de mini-foot avec slime et détection de buts.

--- a/README.md
+++ b/README.md
@@ -79,3 +79,19 @@ affichés aux joueurs.
 
 Les exemples fournis dans `activities.yml` peuvent servir de base et être
 adaptés aux besoins de votre lobby.
+
+## Administration en Jeu
+
+Les administrateurs peuvent configurer les activités directement en jeu via
+la commande `/lobbyadmin` (alias `/la`) :
+
+- `/lobbyadmin parkour setspawn` – définit le point de départ du parkour.
+- `/lobbyadmin parkour setend` – définit la plaque d'arrivée.
+- `/lobbyadmin parkour addcheckpoint` – ajoute un checkpoint.
+- `/lobbyadmin parkour removecheckpoint <numéro>` – supprime un checkpoint.
+- `/lobbyadmin parkour listcheckpoints` – affiche les checkpoints.
+- `/lobbyadmin minifoot setspawn` – définit le point de réapparition du slime.
+- `/lobbyadmin minifoot setgoal1` – définit la première cage de but.
+- `/lobbyadmin minifoot setgoal2` – définit la deuxième cage de but.
+
+Chaque modification est immédiatement enregistrée dans `activities.yml`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,3 +6,4 @@
 - [x] Navigation (Terminé)
 - [ ] Cosmetics system
 - [x] Activités du Lobby (Terminé)
+  - [x] Configuration en Jeu

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.heneria</groupId>
     <artifactId>heneria-lobby</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
     <packaging>jar</packaging>
 
     <name>HeneriaLobby</name>

--- a/src/main/java/com/heneria/lobby/HeneriaLobbyPlugin.java
+++ b/src/main/java/com/heneria/lobby/HeneriaLobbyPlugin.java
@@ -2,6 +2,7 @@ package com.heneria.lobby;
 
 import com.heneria.lobby.commands.FriendsCommand;
 import com.heneria.lobby.commands.LobbyAdminCommand;
+import com.heneria.lobby.config.ConfigManager;
 import com.heneria.lobby.commands.MsgCommand;
 import com.heneria.lobby.commands.OpenMenuCommand;
 import com.heneria.lobby.database.DatabaseManager;
@@ -43,6 +44,7 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
     private GUIManager guiManager;
     private ServerInfoManager serverInfoManager;
     private ParkourManager parkourManager;
+    private ConfigManager activitiesConfigManager;
 
     @Override
     public void onEnable() {
@@ -50,7 +52,8 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
         saveResource("messages.yml", false);
         saveResource("activities.yml", false);
         messages = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "messages.yml"));
-        FileConfiguration activitiesConfig = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "activities.yml"));
+        activitiesConfigManager = new ConfigManager(this);
+        FileConfiguration activitiesConfig = activitiesConfigManager.getConfig();
 
         databaseManager = new DatabaseManager(this);
         if (!databaseManager.init()) {
@@ -78,7 +81,7 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new MenuListener(this, guiManager), this);
         getServer().getPluginManager().registerEvents(new ParkourListener(parkourManager), this);
         getServer().getPluginManager().registerEvents(new ArcheryListener(activitiesConfig), this);
-        getCommand("lobbyadmin").setExecutor(new LobbyAdminCommand(databaseManager));
+        getCommand("lobbyadmin").setExecutor(new LobbyAdminCommand(databaseManager, activitiesConfigManager));
         getCommand("friends").setExecutor(new FriendsCommand(this, friendManager));
         MsgCommand msgCommand = new MsgCommand(this, messageManager);
         getCommand("msg").setExecutor(msgCommand);

--- a/src/main/java/com/heneria/lobby/commands/LobbyAdminCommand.java
+++ b/src/main/java/com/heneria/lobby/commands/LobbyAdminCommand.java
@@ -1,34 +1,151 @@
 package com.heneria.lobby.commands;
 
+import com.heneria.lobby.config.ConfigManager;
 import com.heneria.lobby.database.DatabaseManager;
+import com.heneria.lobby.util.AdminMessage;
+import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
 import java.sql.Connection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
- * Administrative command for various lobby diagnostics.
+ * Administrative command for configuring lobby activities.
  */
 public class LobbyAdminCommand implements CommandExecutor {
 
     private final DatabaseManager databaseManager;
-    public LobbyAdminCommand(DatabaseManager databaseManager) {
+    private final ConfigManager configManager;
+    private final Map<UUID, Location> goalASelections = new HashMap<>();
+    private final Map<UUID, Location> goalBSelections = new HashMap<>();
+
+    public LobbyAdminCommand(DatabaseManager databaseManager, ConfigManager configManager) {
         this.databaseManager = databaseManager;
+        this.configManager = configManager;
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            AdminMessage.info(sender, "Modules disponibles : parkour, minifoot");
+            return true;
+        }
+
+        // legacy testdb command
         if (args.length == 1 && args[0].equalsIgnoreCase("testdb")) {
-            sender.sendMessage("§7[HeneriaLobby] Testing database connection...");
+            AdminMessage.info(sender, "Vérification de la base de données...");
             try (Connection ignored = databaseManager.getConnection()) {
-                sender.sendMessage("§aConnexion à la base de données réussie !");
+                AdminMessage.success(sender, "Connexion à la base de données réussie.");
             } catch (Exception e) {
-                sender.sendMessage("§cÉchec de la connexion à la base de données : " + e.getMessage());
+                AdminMessage.error(sender, "Échec de la connexion : " + e.getMessage());
             }
             return true;
         }
-        sender.sendMessage("§cUsage: /" + label + " testdb");
+
+        String module = args[0].toLowerCase();
+        if (module.equals("parkour")) {
+            if (!(sender instanceof Player player)) {
+                AdminMessage.error(sender, "Cette commande doit être exécutée en jeu.");
+                return true;
+            }
+            if (args.length < 2) {
+                AdminMessage.info(sender, "Sous-commandes : setspawn, setend, addcheckpoint, removecheckpoint <#>, listcheckpoints");
+                return true;
+            }
+            String sub = args[1].toLowerCase();
+            switch (sub) {
+                case "setspawn" -> {
+                    configManager.setParkourSpawn(player.getLocation());
+                    AdminMessage.success(sender, "Le point de spawn du parkour a été défini à votre position.");
+                }
+                case "setend" -> {
+                    configManager.setParkourEnd(player.getLocation());
+                    AdminMessage.success(sender, "La plaque d'arrivée du parkour a été définie à votre position.");
+                }
+                case "addcheckpoint" -> {
+                    int index = configManager.addCheckpoint(player.getLocation());
+                    AdminMessage.success(sender, "Checkpoint #" + index + " ajouté à votre position.");
+                }
+                case "removecheckpoint" -> {
+                    if (args.length < 3) {
+                        AdminMessage.error(sender, "Usage: /" + label + " parkour removecheckpoint <numéro>");
+                        return true;
+                    }
+                    try {
+                        int id = Integer.parseInt(args[2]);
+                        if (configManager.removeCheckpoint(id)) {
+                            AdminMessage.success(sender, "Le checkpoint #" + id + " a été supprimé.");
+                        } else {
+                            AdminMessage.error(sender, "Le checkpoint #" + id + " n'existe pas.");
+                        }
+                    } catch (NumberFormatException e) {
+                        AdminMessage.error(sender, "Numéro de checkpoint invalide.");
+                    }
+                }
+                case "listcheckpoints" -> {
+                    List<String> cps = configManager.getCheckpoints();
+                    if (cps.isEmpty()) {
+                        AdminMessage.info(sender, "Aucun checkpoint défini.");
+                    } else {
+                        StringBuilder sb = new StringBuilder();
+                        for (int i = 0; i < cps.size(); i++) {
+                            String[] p = cps.get(i).split(",");
+                            sb.append("[#").append(i + 1).append(": ")
+                                    .append(p[1]).append(", ")
+                                    .append(p[2]).append(", ")
+                                    .append(p[3]).append("]");
+                            if (i + 1 < cps.size()) sb.append(", ");
+                        }
+                        AdminMessage.info(sender, "Liste des checkpoints : " + sb);
+                    }
+                }
+                default -> AdminMessage.error(sender, "Sous-commande inconnue pour le parkour.");
+            }
+            return true;
+        }
+
+        if (module.equals("minifoot")) {
+            if (!(sender instanceof Player player)) {
+                AdminMessage.error(sender, "Cette commande doit être exécutée en jeu.");
+                return true;
+            }
+            if (args.length < 2) {
+                AdminMessage.info(sender, "Sous-commandes : setspawn, setgoal1, setgoal2");
+                return true;
+            }
+            String sub = args[1].toLowerCase();
+            switch (sub) {
+                case "setspawn" -> {
+                    configManager.setMiniFootSpawn(player.getLocation());
+                    AdminMessage.success(sender, "Le spawn du ballon a été défini à votre position.");
+                }
+                case "setgoal1" -> handleGoalSelection(player, goalASelections, "a");
+                case "setgoal2" -> handleGoalSelection(player, goalBSelections, "b");
+                default -> AdminMessage.error(sender, "Sous-commande inconnue pour le mini-foot.");
+            }
+            return true;
+        }
+
+        AdminMessage.error(sender, "Module inconnu : " + args[0]);
         return true;
+    }
+
+    private void handleGoalSelection(Player player, Map<UUID, Location> map, String which) {
+        UUID id = player.getUniqueId();
+        if (!map.containsKey(id)) {
+            map.put(id, player.getLocation());
+            AdminMessage.info(player, "Premier point défini, exécutez à nouveau la commande à l'autre coin.");
+        } else {
+            Location first = map.remove(id);
+            configManager.setMiniFootGoal(which, first, player.getLocation());
+            AdminMessage.success(player, "La cage de but " + (which.equals("a") ? "1" : "2") + " a été définie.");
+        }
     }
 }
 

--- a/src/main/java/com/heneria/lobby/config/ConfigManager.java
+++ b/src/main/java/com/heneria/lobby/config/ConfigManager.java
@@ -1,0 +1,90 @@
+package com.heneria.lobby.config;
+
+import org.bukkit.Location;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Handles reading and writing of the activities configuration file.
+ */
+public class ConfigManager {
+
+    private final File file;
+    private final FileConfiguration config;
+
+    public ConfigManager(JavaPlugin plugin) {
+        this.file = new File(plugin.getDataFolder(), "activities.yml");
+        this.config = YamlConfiguration.loadConfiguration(file);
+    }
+
+    public FileConfiguration getConfig() {
+        return config;
+    }
+
+    private String serialize(Location loc) {
+        return loc.getWorld().getName() + "," +
+                loc.getBlockX() + "," +
+                loc.getBlockY() + "," +
+                loc.getBlockZ();
+    }
+
+    private void save() {
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // Parkour
+    public void setParkourSpawn(Location loc) {
+        config.set("parkour.start", serialize(loc));
+        save();
+    }
+
+    public void setParkourEnd(Location loc) {
+        config.set("parkour.finish", serialize(loc));
+        save();
+    }
+
+    public int addCheckpoint(Location loc) {
+        List<String> list = config.getStringList("parkour.checkpoints");
+        list.add(serialize(loc));
+        config.set("parkour.checkpoints", list);
+        save();
+        return list.size();
+    }
+
+    public boolean removeCheckpoint(int index) {
+        List<String> list = config.getStringList("parkour.checkpoints");
+        if (index < 1 || index > list.size()) {
+            return false;
+        }
+        list.remove(index - 1);
+        config.set("parkour.checkpoints", list);
+        save();
+        return true;
+    }
+
+    public List<String> getCheckpoints() {
+        return config.getStringList("parkour.checkpoints");
+    }
+
+    // Mini-foot
+    public void setMiniFootSpawn(Location loc) {
+        config.set("mini-foot.slime-spawn", serialize(loc));
+        save();
+    }
+
+    public void setMiniFootGoal(String which, Location min, Location max) {
+        config.set("mini-foot.goal-" + which + ".min", serialize(min));
+        config.set("mini-foot.goal-" + which + ".max", serialize(max));
+        save();
+    }
+}
+

--- a/src/main/java/com/heneria/lobby/util/AdminMessage.java
+++ b/src/main/java/com/heneria/lobby/util/AdminMessage.java
@@ -1,0 +1,27 @@
+package com.heneria.lobby.util;
+
+import org.bukkit.command.CommandSender;
+
+/**
+ * Utility for sending formatted admin command messages.
+ */
+public final class AdminMessage {
+
+    private static final String PREFIX = "§f[LobbyAdmin] §7";
+
+    private AdminMessage() {
+    }
+
+    public static void success(CommandSender sender, String msg) {
+        sender.sendMessage("§a✔ " + PREFIX + msg);
+    }
+
+    public static void error(CommandSender sender, String msg) {
+        sender.sendMessage("§c✖ " + PREFIX + msg);
+    }
+
+    public static void info(CommandSender sender, String msg) {
+        sender.sendMessage("§3ℹ " + PREFIX + msg);
+    }
+}
+

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,15 +1,16 @@
 name: HeneriaLobby
-version: 0.5.0
+version: 0.5.1
 main: com.heneria.lobby.HeneriaLobbyPlugin
 api-version: "1.21"
 softdepend:
   - LuckPerms
 commands:
-  lobbyadmin:
-    description: Administrative utilities for HeneriaLobby
-    usage: "/lobbyadmin testdb"
-    permission: henerialobby.admin
-    permission-message: "§cVous n'avez pas la permission."
+    lobbyadmin:
+      description: Administrative utilities for HeneriaLobby
+      usage: "/lobbyadmin"
+      aliases: [la]
+      permission: henerialobby.admin
+      permission-message: "§cVous n'avez pas la permission."
   friends:
     description: Manage your friends
     usage: "/friends <add|remove|accept|deny|list> [player]"


### PR DESCRIPTION
## Summary
- add `/lobbyadmin` (alias `/la`) to configure parkour and mini-foot activities in-game
- persist activity changes through new `ConfigManager` and provide formatted admin feedback
- document administration commands and bump version to 0.5.1

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c08c48774c83299c87491d8177fc37