### PR TITLE
fix: correct plugin.yml indentation

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,12 +5,12 @@ api-version: "1.21"
 softdepend:
   - LuckPerms
 commands:
-    lobbyadmin:
-      description: Administrative utilities for HeneriaLobby
-      usage: "/lobbyadmin"
-      aliases: [la]
-      permission: henerialobby.admin
-      permission-message: "§cVous n'avez pas la permission."
+  lobbyadmin:
+    description: Administrative utilities for HeneriaLobby
+    usage: "/lobbyadmin"
+    aliases: [la]
+    permission: henerialobby.admin
+    permission-message: "§cVous n'avez pas la permission."
   friends:
     description: Manage your friends
     usage: "/friends <add|remove|accept|deny|list> [player]"


### PR DESCRIPTION
## Summary
- fix invalid indentation in `plugin.yml`
- ensure commands section uses consistent spacing

## Testing
- `python - <<'PY'\nimport yaml, sys\nwith open('src/main/resources/plugin.yml') as f:\n    data = yaml.safe_load(f)\nprint('YAML parsed successfully. Keys:', list(data.keys()))\nPY`
- `mvn -q --batch-mode clean package` *(fails: Plugin org.apache.maven.plugins:maven-clean-plugin:3.2.0... Could not transfer artifact... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c08fa2ae7c83299eb6c6a9e534438b