### PR TITLE
feat: add economy and achievements system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.0 - Système de progression
+- Ajout de l'économie de Coins avec gain passif et API interne.
+- Commande `/coins` pour consulter son solde.
+- Système de succès configurable via `achievements.yml` et menu dédié.
+
 ## 0.5.1 - Interface de configuration en jeu
 - Ajout de la commande `/lobbyadmin` pour configurer le parkour et le mini-foot.
 - Sauvegarde immédiate des modifications dans `activities.yml`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ The plugin provides network-wide social features:
 - `/msg <player> <message>` – send a private message.
 - `/r <message>` – reply to the last player who messaged you.
 
+## Système de Progression
+
+Les joueurs accumulent des **Coins** en restant connectés ou en participant aux activités du lobby.
+La commande `/coins` affiche le solde actuel.
+
+Un système de **succès** configurable récompense les accomplissements.
+Le fichier `achievements.yml` permet de définir chaque succès : identifiant, nom,
+description, icônes verrouillé/déverrouillé, condition et récompenses (coins, titre, etc.).
+Les joueurs peuvent consulter leur progression via le menu des succès
+ou la commande `/achievements`.
+
 ## Configuration de l'Interface
 
 Les fichiers de configuration permettent de personnaliser l'apparence du serveur :

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-- [ ] Economy system
+ - [x] Progression & Économie (Terminé)
 - [x] Friends system
 - [x] Visual interface
 - [x] Navigation (Terminé)

--- a/src/main/java/com/heneria/lobby/HeneriaLobbyPlugin.java
+++ b/src/main/java/com/heneria/lobby/HeneriaLobbyPlugin.java
@@ -22,6 +22,8 @@ import com.heneria.lobby.activities.parkour.ParkourCommand;
 import com.heneria.lobby.activities.parkour.ParkourListener;
 import com.heneria.lobby.activities.football.MiniFootManager;
 import com.heneria.lobby.activities.archery.ArcheryListener;
+import com.heneria.lobby.economy.EconomyManager;
+import com.heneria.lobby.achievements.AchievementManager;
 import net.luckperms.api.LuckPerms;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -45,6 +47,8 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
     private ServerInfoManager serverInfoManager;
     private ParkourManager parkourManager;
     private ConfigManager activitiesConfigManager;
+    private EconomyManager economyManager;
+    private AchievementManager achievementManager;
 
     @Override
     public void onEnable() {
@@ -63,7 +67,9 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
         getLogger().info("Connected to the database successfully.");
 
         playerDataManager = new PlayerDataManager(this, databaseManager);
-        friendManager = new FriendManager(this, databaseManager);
+        economyManager = new EconomyManager(this, playerDataManager);
+        achievementManager = new AchievementManager(this, databaseManager, economyManager);
+        friendManager = new FriendManager(this, databaseManager, achievementManager);
         messageManager = new PrivateMessageManager();
 
         RegisteredServiceProvider<LuckPerms> provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
@@ -72,10 +78,10 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
         tablistManager = new TablistManager(this, luckPerms);
         serverInfoManager = new ServerInfoManager(this);
         guiManager = new GUIManager(this, serverInfoManager);
-        parkourManager = new ParkourManager(this, databaseManager, activitiesConfig);
+        parkourManager = new ParkourManager(this, databaseManager, activitiesConfig, achievementManager);
         new MiniFootManager(this, activitiesConfig);
 
-        getServer().getPluginManager().registerEvents(new PlayerListener(this, playerDataManager, friendManager, messageManager, scoreboardManager, tablistManager), this);
+        getServer().getPluginManager().registerEvents(new PlayerListener(this, playerDataManager, friendManager, messageManager, scoreboardManager, tablistManager, achievementManager), this);
         getServer().getPluginManager().registerEvents(new ChatListener(this, tablistManager), this);
         getServer().getPluginManager().registerEvents(new NavigationItemListener(guiManager), this);
         getServer().getPluginManager().registerEvents(new MenuListener(this, guiManager), this);
@@ -91,6 +97,10 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
         getCommand("shop").setExecutor(new OpenMenuCommand(guiManager, "shop"));
         getCommand("activites").setExecutor(new OpenMenuCommand(guiManager, "activities"));
         getCommand("parkour").setExecutor(new ParkourCommand(parkourManager));
+        getCommand("coins").setExecutor(new com.heneria.lobby.commands.CoinsCommand(economyManager));
+        getCommand("achievements").setExecutor(new com.heneria.lobby.commands.AchievementsCommand(achievementManager));
+
+        economyManager.startPassiveRewardTask(20L * 600, 5);
 
         getServer().getMessenger().registerOutgoingPluginChannel(this, "heneria:friends");
         getServer().getMessenger().registerOutgoingPluginChannel(this, "heneria:msg");
@@ -119,5 +129,13 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
 
     public ServerInfoManager getServerInfoManager() {
         return serverInfoManager;
+    }
+
+    public EconomyManager getEconomyManager() {
+        return economyManager;
+    }
+
+    public AchievementManager getAchievementManager() {
+        return achievementManager;
     }
 }

--- a/src/main/java/com/heneria/lobby/achievements/Achievement.java
+++ b/src/main/java/com/heneria/lobby/achievements/Achievement.java
@@ -1,0 +1,73 @@
+package com.heneria.lobby.achievements;
+
+import org.bukkit.Material;
+
+/**
+ * Represents a configurable achievement.
+ */
+public class Achievement {
+
+    public enum ConditionType {
+        PARKOUR_FINISH_TIME,
+        ADD_FRIEND
+    }
+
+    private final String id;
+    private final String name;
+    private final String description;
+    private final Material lockedIcon;
+    private final Material unlockedIcon;
+    private final ConditionType conditionType;
+    private final double value;
+    private final long rewardCoins;
+    private final String rewardTitle;
+
+    public Achievement(String id, String name, String description, Material lockedIcon, Material unlockedIcon,
+                       ConditionType conditionType, double value, long rewardCoins, String rewardTitle) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.lockedIcon = lockedIcon;
+        this.unlockedIcon = unlockedIcon;
+        this.conditionType = conditionType;
+        this.value = value;
+        this.rewardCoins = rewardCoins;
+        this.rewardTitle = rewardTitle;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Material getLockedIcon() {
+        return lockedIcon;
+    }
+
+    public Material getUnlockedIcon() {
+        return unlockedIcon;
+    }
+
+    public ConditionType getConditionType() {
+        return conditionType;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public long getRewardCoins() {
+        return rewardCoins;
+    }
+
+    public String getRewardTitle() {
+        return rewardTitle;
+    }
+}

--- a/src/main/java/com/heneria/lobby/achievements/AchievementManager.java
+++ b/src/main/java/com/heneria/lobby/achievements/AchievementManager.java
@@ -1,0 +1,170 @@
+package com.heneria.lobby.achievements;
+
+import com.heneria.lobby.economy.EconomyManager;
+import com.heneria.lobby.database.DatabaseManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages achievements and player progress.
+ */
+public class AchievementManager {
+
+    private final JavaPlugin plugin;
+    private final DatabaseManager databaseManager;
+    private final EconomyManager economyManager;
+    private final Map<String, Achievement> achievements = new HashMap<>();
+    private final Map<UUID, Map<String, Instant>> unlocked = new ConcurrentHashMap<>();
+
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+            .withZone(ZoneId.systemDefault());
+
+    public AchievementManager(JavaPlugin plugin, DatabaseManager databaseManager, EconomyManager economyManager) {
+        this.plugin = plugin;
+        this.databaseManager = databaseManager;
+        this.economyManager = economyManager;
+        loadConfig();
+    }
+
+    public void loadConfig() {
+        plugin.saveResource("achievements.yml", false);
+        File file = new File(plugin.getDataFolder(), "achievements.yml");
+        FileConfiguration config = YamlConfiguration.loadConfiguration(file);
+        achievements.clear();
+        ConfigurationSection sec = config.getConfigurationSection("achievements");
+        if (sec != null) {
+            for (String id : sec.getKeys(false)) {
+                ConfigurationSection a = sec.getConfigurationSection(id);
+                if (a == null) continue;
+                String name = ChatColor.translateAlternateColorCodes('&', a.getString("name", id));
+                String description = ChatColor.translateAlternateColorCodes('&', a.getString("description", ""));
+                Material locked = Material.matchMaterial(a.getString("icon.locked", "STONE"));
+                Material unlockedMat = Material.matchMaterial(a.getString("icon.unlocked", "DIAMOND"));
+                Achievement.ConditionType type = Achievement.ConditionType.valueOf(a.getString("condition.type", "PARKOUR_FINISH_TIME"));
+                double value = a.getDouble("condition.value", 0);
+                long rewardCoins = a.getLong("rewards.coins", 0);
+                String rewardTitle = a.getString("rewards.title", "");
+                Achievement ach = new Achievement(id, name, description, locked, unlockedMat, type, value, rewardCoins, rewardTitle);
+                achievements.put(id, ach);
+            }
+        }
+    }
+
+    public void loadPlayer(UUID uuid) {
+        Map<String, Instant> map = new HashMap<>();
+        try (Connection c = databaseManager.getConnection();
+             PreparedStatement ps = c.prepareStatement("SELECT achievement_id, unlock_date FROM player_achievements WHERE player_uuid=?")) {
+            ps.setString(1, uuid.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    map.put(rs.getString("achievement_id"), rs.getTimestamp("unlock_date").toInstant());
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().severe("Failed to load achievements for " + uuid + ": " + e.getMessage());
+        }
+        unlocked.put(uuid, map);
+    }
+
+    public boolean hasAchievement(UUID uuid, String id) {
+        return unlocked.getOrDefault(uuid, Collections.emptyMap()).containsKey(id);
+    }
+
+    private void unlock(Player player, Achievement achievement) {
+        UUID uuid = player.getUniqueId();
+        if (hasAchievement(uuid, achievement.getId())) {
+            return;
+        }
+        Instant now = Instant.now();
+        try (Connection c = databaseManager.getConnection();
+             PreparedStatement ps = c.prepareStatement("INSERT INTO player_achievements (player_uuid, achievement_id, unlock_date) VALUES (?,?,?)")) {
+            ps.setString(1, uuid.toString());
+            ps.setString(2, achievement.getId());
+            ps.setTimestamp(3, Timestamp.from(now));
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            plugin.getLogger().severe("Failed to save achievement: " + e.getMessage());
+            return;
+        }
+        unlocked.computeIfAbsent(uuid, k -> new HashMap<>()).put(achievement.getId(), now);
+        if (achievement.getRewardCoins() > 0) {
+            economyManager.addCoins(uuid, achievement.getRewardCoins());
+        }
+        player.sendMessage(ChatColor.GOLD + "Succès débloqué: " + achievement.getName());
+    }
+
+    public void handleParkourFinish(Player player, long timeMillis) {
+        double seconds = timeMillis / 1000.0;
+        for (Achievement a : achievements.values()) {
+            if (a.getConditionType() == Achievement.ConditionType.PARKOUR_FINISH_TIME &&
+                    seconds <= a.getValue()) {
+                unlock(player, a);
+            }
+        }
+    }
+
+    public void handleFriendAdded(Player player, int totalFriends) {
+        for (Achievement a : achievements.values()) {
+            if (a.getConditionType() == Achievement.ConditionType.ADD_FRIEND &&
+                    totalFriends >= a.getValue()) {
+                unlock(player, a);
+            }
+        }
+    }
+
+    public void openMenu(Player player) {
+        int size = ((achievements.size() / 9) + 1) * 9;
+        Inventory inv = Bukkit.createInventory(null, size, ChatColor.DARK_GREEN + "Succès");
+        int slot = 0;
+        Map<String, Instant> unlockedMap = unlocked.getOrDefault(player.getUniqueId(), Collections.emptyMap());
+        for (Achievement a : achievements.values()) {
+            boolean has = unlockedMap.containsKey(a.getId());
+            Material mat = has ? a.getUnlockedIcon() : a.getLockedIcon();
+            ItemStack item = new ItemStack(mat);
+            ItemMeta meta = item.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName((has ? ChatColor.GREEN : ChatColor.GRAY) + a.getName());
+                List<String> lore = new ArrayList<>();
+                lore.add(ChatColor.WHITE + a.getDescription());
+                if (has) {
+                    lore.add(ChatColor.YELLOW + "Débloqué le " + formatter.format(unlockedMap.get(a.getId())));
+                } else {
+                    lore.add(ChatColor.DARK_GRAY + "???");
+                }
+                meta.setLore(lore);
+                if (has) {
+                    meta.addEnchant(org.bukkit.enchantments.Enchantment.ARROW_DAMAGE, 1, true);
+                    meta.addItemFlags(org.bukkit.inventory.ItemFlag.HIDE_ENCHANTS);
+                }
+                item.setItemMeta(meta);
+            }
+            inv.setItem(slot++, item);
+        }
+        player.openInventory(inv);
+    }
+
+    public Map<String, Achievement> getAchievements() {
+        return achievements;
+    }
+}

--- a/src/main/java/com/heneria/lobby/activities/parkour/ParkourManager.java
+++ b/src/main/java/com/heneria/lobby/activities/parkour/ParkourManager.java
@@ -1,6 +1,7 @@
 package com.heneria.lobby.activities.parkour;
 
 import com.heneria.lobby.database.DatabaseManager;
+import com.heneria.lobby.achievements.AchievementManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -22,6 +23,7 @@ public class ParkourManager {
     private final JavaPlugin plugin;
     private final DatabaseManager databaseManager;
     private final FileConfiguration config;
+    private final AchievementManager achievementManager;
     private final Location start;
     private final List<Location> checkpoints;
     private final Location finish;
@@ -32,10 +34,11 @@ public class ParkourManager {
     private final Map<UUID, Location> lastCheckpoint = new HashMap<>();
     private final List<ArmorStand> hologramLines = new ArrayList<>();
 
-    public ParkourManager(JavaPlugin plugin, DatabaseManager databaseManager, FileConfiguration config) {
+    public ParkourManager(JavaPlugin plugin, DatabaseManager databaseManager, FileConfiguration config, AchievementManager achievementManager) {
         this.plugin = plugin;
         this.databaseManager = databaseManager;
         this.config = config;
+        this.achievementManager = achievementManager;
 
         this.start = parseLocation(config.getString("parkour.start"));
         this.finish = parseLocation(config.getString("parkour.finish"));
@@ -107,6 +110,9 @@ public class ParkourManager {
         lastCheckpoint.remove(player.getUniqueId());
         if (newRecord) {
             updateLeaderboard();
+        }
+        if (achievementManager != null) {
+            achievementManager.handleParkourFinish(player, time);
         }
     }
 

--- a/src/main/java/com/heneria/lobby/commands/AchievementsCommand.java
+++ b/src/main/java/com/heneria/lobby/commands/AchievementsCommand.java
@@ -1,0 +1,29 @@
+package com.heneria.lobby.commands;
+
+import com.heneria.lobby.achievements.AchievementManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Opens the achievements menu for the player.
+ */
+public class AchievementsCommand implements CommandExecutor {
+
+    private final AchievementManager achievementManager;
+
+    public AchievementsCommand(AchievementManager achievementManager) {
+        this.achievementManager = achievementManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (sender instanceof Player player) {
+            achievementManager.openMenu(player);
+        } else {
+            sender.sendMessage("Command only available to players.");
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/heneria/lobby/commands/CoinsCommand.java
+++ b/src/main/java/com/heneria/lobby/commands/CoinsCommand.java
@@ -1,0 +1,31 @@
+package com.heneria.lobby.commands;
+
+import com.heneria.lobby.economy.EconomyManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Displays the player's current coin balance.
+ */
+public class CoinsCommand implements CommandExecutor {
+
+    private final EconomyManager economyManager;
+
+    public CoinsCommand(EconomyManager economyManager) {
+        this.economyManager = economyManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Command only available to players.");
+            return true;
+        }
+        long coins = economyManager.getCoins(player.getUniqueId());
+        player.sendMessage(ChatColor.GOLD + "Vous avez " + coins + " coins.");
+        return true;
+    }
+}

--- a/src/main/java/com/heneria/lobby/database/DatabaseManager.java
+++ b/src/main/java/com/heneria/lobby/database/DatabaseManager.java
@@ -90,6 +90,14 @@ public class DatabaseManager {
                             "best_time BIGINT" +
                             ")"
             );
+            statement.executeUpdate(
+                    "CREATE TABLE IF NOT EXISTS player_achievements (" +
+                            "player_uuid VARCHAR(36)," +
+                            "achievement_id VARCHAR(64)," +
+                            "unlock_date TIMESTAMP," +
+                            "PRIMARY KEY (player_uuid, achievement_id)" +
+                            ")"
+            );
         }
     }
 

--- a/src/main/java/com/heneria/lobby/economy/EconomyManager.java
+++ b/src/main/java/com/heneria/lobby/economy/EconomyManager.java
@@ -1,0 +1,47 @@
+package com.heneria.lobby.economy;
+
+import com.heneria.lobby.player.PlayerData;
+import com.heneria.lobby.player.PlayerDataManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.UUID;
+
+/**
+ * Simple economy manager to handle coin balance for players.
+ */
+public class EconomyManager {
+
+    private final JavaPlugin plugin;
+    private final PlayerDataManager dataManager;
+
+    public EconomyManager(JavaPlugin plugin, PlayerDataManager dataManager) {
+        this.plugin = plugin;
+        this.dataManager = dataManager;
+    }
+
+    public long getCoins(UUID uuid) {
+        PlayerData data = dataManager.getPlayerData(uuid);
+        return data != null ? data.getCoins() : 0L;
+    }
+
+    public void addCoins(UUID uuid, long amount) {
+        if (amount == 0) {
+            return;
+        }
+        PlayerData data = dataManager.getPlayerData(uuid);
+        if (data != null) {
+            long newBalance = Math.max(0, data.getCoins() + amount);
+            dataManager.setCoins(uuid, newBalance);
+        }
+    }
+
+    public void startPassiveRewardTask(long intervalTicks, long rewardAmount) {
+        Bukkit.getScheduler().runTaskTimer(plugin, () -> {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                addCoins(player.getUniqueId(), rewardAmount);
+            }
+        }, intervalTicks, intervalTicks);
+    }
+}

--- a/src/main/java/com/heneria/lobby/friends/FriendManager.java
+++ b/src/main/java/com/heneria/lobby/friends/FriendManager.java
@@ -1,6 +1,7 @@
 package com.heneria.lobby.friends;
 
 import com.heneria.lobby.database.DatabaseManager;
+import com.heneria.lobby.achievements.AchievementManager;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -21,11 +22,13 @@ public class FriendManager {
 
     private final JavaPlugin plugin;
     private final DatabaseManager databaseManager;
+    private final AchievementManager achievementManager;
     private final Map<UUID, Set<UUID>> cache = new ConcurrentHashMap<>();
 
-    public FriendManager(JavaPlugin plugin, DatabaseManager databaseManager) {
+    public FriendManager(JavaPlugin plugin, DatabaseManager databaseManager, AchievementManager achievementManager) {
         this.plugin = plugin;
         this.databaseManager = databaseManager;
+        this.achievementManager = achievementManager;
     }
 
     /**
@@ -110,7 +113,7 @@ public class FriendManager {
     public void acceptRequest(UUID player, UUID requester) {
         try (Connection connection = databaseManager.getConnection();
              PreparedStatement ps = connection.prepareStatement(
-                     "UPDATE player_friends SET status='ACCEPTED' WHERE player_uuid=? AND friend_uuid=? AND status='PENDING'")) {
+                    "UPDATE player_friends SET status='ACCEPTED' WHERE player_uuid=? AND friend_uuid=? AND status='PENDING'")) {
             ps.setString(1, requester.toString());
             ps.setString(2, player.toString());
             ps.executeUpdate();
@@ -119,6 +122,16 @@ public class FriendManager {
         }
         reload(player);
         reload(requester);
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (achievementManager != null) {
+                int playerCount = getFriends(player).size();
+                int requesterCount = getFriends(requester).size();
+                org.bukkit.entity.Player p = Bukkit.getPlayer(player);
+                if (p != null) achievementManager.handleFriendAdded(p, playerCount);
+                org.bukkit.entity.Player r = Bukkit.getPlayer(requester);
+                if (r != null) achievementManager.handleFriendAdded(r, requesterCount);
+            }
+        }, 20L);
     }
 
     public void denyRequest(UUID player, UUID requester) {

--- a/src/main/java/com/heneria/lobby/listeners/PlayerListener.java
+++ b/src/main/java/com/heneria/lobby/listeners/PlayerListener.java
@@ -6,6 +6,7 @@ import com.heneria.lobby.HeneriaLobbyPlugin;
 import com.heneria.lobby.friends.FriendManager;
 import com.heneria.lobby.friends.PrivateMessageManager;
 import com.heneria.lobby.player.PlayerDataManager;
+import com.heneria.lobby.achievements.AchievementManager;
 import com.heneria.lobby.ui.ScoreboardManager;
 import com.heneria.lobby.ui.TablistManager;
 import org.bukkit.Bukkit;
@@ -24,14 +25,16 @@ public class PlayerListener implements Listener {
     private final PrivateMessageManager messageManager;
     private final ScoreboardManager scoreboardManager;
     private final TablistManager tablistManager;
+    private final AchievementManager achievementManager;
 
-    public PlayerListener(HeneriaLobbyPlugin plugin, PlayerDataManager dataManager, FriendManager friendManager, PrivateMessageManager messageManager, ScoreboardManager scoreboardManager, TablistManager tablistManager) {
+    public PlayerListener(HeneriaLobbyPlugin plugin, PlayerDataManager dataManager, FriendManager friendManager, PrivateMessageManager messageManager, ScoreboardManager scoreboardManager, TablistManager tablistManager, AchievementManager achievementManager) {
         this.plugin = plugin;
         this.dataManager = dataManager;
         this.friendManager = friendManager;
         this.messageManager = messageManager;
         this.scoreboardManager = scoreboardManager;
         this.tablistManager = tablistManager;
+        this.achievementManager = achievementManager;
     }
 
     @EventHandler
@@ -40,6 +43,7 @@ public class PlayerListener implements Listener {
         event.setJoinMessage(plugin.getMessages().getString("join-message").replace("{player}", player.getName()));
         dataManager.load(player.getUniqueId(), player.getName());
         friendManager.loadFriends(player.getUniqueId());
+        achievementManager.loadPlayer(player.getUniqueId());
         scoreboardManager.show(player);
         tablistManager.update(player);
         for (UUID uuid : friendManager.getFriends(player.getUniqueId())) {

--- a/src/main/resources/achievements.yml
+++ b/src/main/resources/achievements.yml
@@ -1,0 +1,24 @@
+achievements:
+  parkour_beginner:
+    name: "&aDébutant du Parkour"
+    description: "&7Termine le parkour en moins de 2 minutes."
+    icon:
+      locked: COAL_BLOCK
+      unlocked: EMERALD_BLOCK
+    condition:
+      type: PARKOUR_FINISH_TIME
+      value: 120
+    rewards:
+      coins: 500
+      title: "Le Rapide"
+  first_friend:
+    name: "&bPremier Ami"
+    description: "&7Ajoute un ami au réseau."
+    icon:
+      locked: GRAY_DYE
+      unlocked: LIME_DYE
+    condition:
+      type: ADD_FRIEND
+      value: 1
+    rewards:
+      coins: 100

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -14,6 +14,13 @@ menus:
     title: "&aProfil"
     size: 27
     items:
+      achievements:
+        material: NETHER_STAR
+        slot: 11
+        name: "&6Succès"
+        lore:
+          - "&7Voir vos succès"
+        action: "run_command:achievements"
       info:
         material: PLAYER_HEAD
         slot: 13

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: HeneriaLobby
-version: 0.5.1
+version: 0.6.0
 main: com.heneria.lobby.HeneriaLobbyPlugin
 api-version: "1.21"
 softdepend:
@@ -37,3 +37,9 @@ commands:
   parkour:
     description: Parkour commands
     usage: "/parkour <spawn|checkpoint|top>"
+  coins:
+    description: Display your coin balance
+    usage: "/coins"
+  achievements:
+    description: Open your achievements menu
+    usage: "/achievements"


### PR DESCRIPTION
## Summary
- implement coin economy with passive rewards and `/coins` command
- add configurable achievements with database storage and menu
- integrate achievements into parkour and friends systems
- document progression system and update roadmap/changelog

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0924b0bc88329a86107a7188f604e