### PR TITLE
feat: refactor cosmetics menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.2 - Refonte visuelle du menu cosmétique principal
+- Menu de boutique cosmétique étendu à 45 slots avec bordures décoratives.
+- Configuration des items entièrement personnalisable (matériaux, noms, lores).
+- Ajout de l'action `close` et prise en charge de l'attribut `slots` dans `menus.yml`.
+
 ## 0.6.0 - Système de progression
 - Ajout de l'économie de Coins avec gain passif et API interne.
 - Commande `/coins` pour consulter son solde.

--- a/README.md
+++ b/README.md
@@ -72,11 +72,16 @@ Les menus correspondants peuvent aussi être ouverts via les commandes `/games` 
 Le fichier `menus.yml` définit chaque interface : titre, taille et items internes avec
 leur matériau, emplacement, nom, description et action au clic.
 
+Chaque item peut spécifier un `slot` unique ou une liste `slots` pour être placé à
+plusieurs positions. Les descriptions (`lore`) se définissent sur plusieurs lignes
+grâce à une liste YAML et supportent les codes couleur.
+
 Actions disponibles :
 
 - `open_menu:<nom>` – ouvre un autre menu configuré.
 - `connect_server:<serveur>` – envoie le joueur sur le serveur spécifié via Plugin Messages.
 - `run_command:<commande>` – exécute une commande en tant que joueur.
+- `close` – ferme simplement l'inventaire.
 
 ## Configuration des Activités
 

--- a/src/main/java/com/heneria/lobby/listeners/MenuListener.java
+++ b/src/main/java/com/heneria/lobby/listeners/MenuListener.java
@@ -53,6 +53,8 @@ public class MenuListener implements Listener {
             out.writeUTF(server);
             player.closeInventory();
             player.sendPluginMessage(plugin, "BungeeCord", out.toByteArray());
+        } else if (action.equalsIgnoreCase("close")) {
+            player.closeInventory();
         }
     }
 }

--- a/src/main/java/com/heneria/lobby/menu/GUIManager.java
+++ b/src/main/java/com/heneria/lobby/menu/GUIManager.java
@@ -53,10 +53,16 @@ public class GUIManager {
                 if (itemsSec != null) {
                     for (String itemKey : itemsSec.getKeys(false)) {
                         ConfigurationSection itemSec = itemsSec.getConfigurationSection(itemKey);
-                        int slot = itemSec.getInt("slot");
                         ItemStack stack = buildItem(itemSec);
                         String action = itemSec.getString("action", "");
-                        items.put(slot, new MenuItem(stack, action));
+                        if (itemSec.isList("slots")) {
+                            for (int slot : itemSec.getIntegerList("slots")) {
+                                items.put(slot, new MenuItem(stack, action));
+                            }
+                        } else {
+                            int slot = itemSec.getInt("slot");
+                            items.put(slot, new MenuItem(stack, action));
+                        }
                     }
                 }
                 Menu menu = new Menu(key, title, size, items);
@@ -69,10 +75,16 @@ public class GUIManager {
         if (navSec != null) {
             for (String key : navSec.getKeys(false)) {
                 ConfigurationSection itemSec = navSec.getConfigurationSection(key);
-                int slot = itemSec.getInt("slot");
                 ItemStack stack = buildItem(itemSec);
                 String action = itemSec.getString("action", "");
-                navigationItems.put(slot, new MenuItem(stack, action));
+                if (itemSec.isList("slots")) {
+                    for (int slot : itemSec.getIntegerList("slots")) {
+                        navigationItems.put(slot, new MenuItem(stack, action));
+                    }
+                } else {
+                    int slot = itemSec.getInt("slot");
+                    navigationItems.put(slot, new MenuItem(stack, action));
+                }
             }
         }
     }

--- a/src/main/resources/menus.yml
+++ b/src/main/resources/menus.yml
@@ -35,21 +35,113 @@ menus:
           - "&7Gérer vos amis"
         action: "run_command:friends"
   shop:
-    title: "&dBoutique Cosmétique"
-    size: 27
+    title: "&5&lBoutique Cosmétique"
+    size: 45
     items:
+      filler:
+        material: PURPLE_STAINED_GLASS_PANE
+        slots: [0,1,2,3,4,5,6,7,8,9,13,17,27,28,29,31,33,34,35,36,37,38,39,41,42,43,44]
+        name: " "
+        lore: []
       particles:
-        material: BLAZE_POWDER
-        slot: 11
-        name: "&cParticules"
+        material: NETHER_STAR
+        slot: 10
+        name: "&d&lParticules"
         lore:
-          - "&7Effets de particules"
+          - "&7Débloquez des effets visuels"
+          - "&7uniques qui vous suivront"
+          - "&7partout où vous irez."
+          - ""
+          - "&e► Cliquez pour voir"
+        action: "open_menu:particles"
       hats:
-        material: LEATHER_HELMET
-        slot: 15
-        name: "&eChapeaux"
+        material: CARVED_PUMPKIN
+        slot: 11
+        name: "&6&lChapeaux"
         lore:
-          - "&7Accessoires de tête"
+          - "&7Portez des blocs et des"
+          - "&7objets amusants sur"
+          - "&7votre tête !"
+          - ""
+          - "&e► Cliquez pour voir"
+        action: "open_menu:hats"
+      pets:
+        material: BONE
+        slot: 12
+        name: "&f&lFamiliers"
+        lore:
+          - "&7Soyez accompagné par une"
+          - "&7adorable créature durant"
+          - "&7vos aventures dans le lobby."
+          - ""
+          - "&e► Cliquez pour voir"
+        action: "open_menu:pets"
+      titles:
+        material: NAME_TAG
+        slot: 14
+        name: "&b&lTitres"
+        lore:
+          - "&7Affichez un titre prestigieux"
+          - "&7au-dessus de votre tête pour"
+          - "&7montrer votre statut."
+          - ""
+          - "&e► Cliquez pour voir"
+        action: "open_menu:titles"
+      morphs:
+        material: CREEPER_HEAD
+        slot: 15
+        name: "&a&lTransformations"
+        lore:
+          - "&7Prenez l'apparence de"
+          - "&7différentes créatures et"
+          - "&7surprenez les autres joueurs !"
+          - ""
+          - "&e► Cliquez pour voir"
+        action: "open_menu:morphs"
+      gestures:
+        material: FEATHER
+        slot: 16
+        name: "&e&lGestes (Emotes)"
+        lore:
+          - "&7Exprimez-vous avec des"
+          - "&7animations uniques comme"
+          - "&7s'asseoir ou danser."
+          - ""
+          - "&e► Cliquez pour voir"
+        action: "open_menu:gestures"
+      separator:
+        material: BLACK_STAINED_GLASS_PANE
+        slots: [18,19,20,21,22,23,24,25,26]
+        name: " "
+        lore: []
+      unlocked:
+        material: CHEST
+        slot: 30
+        name: "&a&lMes Cosmétiques"
+        lore:
+          - "&7Consultez et gérez tous"
+          - "&7les cosmétiques que"
+          - "&7vous avez débloqués."
+          - ""
+          - "&e► Cliquez pour ouvrir"
+        action: "open_menu:unlocked"
+      crate:
+        material: TRIPWIRE_HOOK
+        slot: 32
+        name: "&6&lOuvrir une Caisse"
+        lore:
+          - "&7Utilisez une clé de caisse"
+          - "&7pour obtenir un cosmétique"
+          - "&7aléatoire !"
+          - ""
+          - "&c(Bientôt disponible)"
+      back:
+        material: BARRIER
+        slot: 40
+        name: "&c&lRetour"
+        lore:
+          - "&7Ferme le menu actuel."
+        action: "close"
   activities:
     title: "&bActivités du Lobby"
     size: 27


### PR DESCRIPTION
## Summary
- rebuild cosmetic shop menu with 45 slots, category icons and decorative fillers
- allow YAML menus to specify multiple slots and add `close` action
- document multi-slot items and new action

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a43227f4832997769dd6fbfb0186