### PR TITLE
docs: document cosmetics submenus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0 - Sous-menus de boutique et logique d'achat/équipement
+- Ajout des sous-menus paginés pour chaque catégorie de cosmétiques.
+- Possibilité d'acheter et d'équiper les cosmétiques directement depuis l'interface.
+
 ## 0.7.2 - Refonte visuelle du menu cosmétique principal
 - Menu de boutique cosmétique étendu à 45 slots avec bordures décoratives.
 - Configuration des items entièrement personnalisable (matériaux, noms, lores).

--- a/README.md
+++ b/README.md
@@ -83,6 +83,23 @@ Actions disponibles :
 - `run_command:<commande>` – exécute une commande en tant que joueur.
 - `close` – ferme simplement l'inventaire.
 
+## Boutique de Cosmétiques
+
+Le menu principal de la boutique regroupe plusieurs catégories
+(Particules, Chapeaux, etc.). Cliquer sur une catégorie ouvre un
+sous-menu paginé listant les cosmétiques définis dans `cosmetics.yml`.
+
+Chaque item s'adapte à l'état du joueur :
+
+- **Non possédé** – affiche la rareté, le prix en Coins et invite à
+  acheter.
+- **Débloqué** – l'item est enchanté, indique le statut "Débloqué" et
+  permet de l'équiper ou de le déséquiper.
+
+Le bouton **Mes Cosmétiques** ouvre l'inventaire personnel du joueur.
+Seuls les cosmétiques possédés y apparaissent, triés par catégorie et
+équipables d'un simple clic.
+
 ## Configuration des Activités
 
 Le fichier `activities.yml` centralise la configuration des mini-jeux du lobby.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,7 @@
 - [x] Friends system
 - [x] Visual interface
 - [x] Navigation (Terminé)
-- [ ] Cosmetics system
+ - [ ] Cosmetics system
+   - [x] Sous-Menus et Logique (Terminé)
 - [x] Activités du Lobby (Terminé)
   - [x] Configuration en Jeu


### PR DESCRIPTION
## Summary
- document cosmetics shop submenus and player inventory in README
- add changelog entry for 0.8.0 submenus and purchase logic
- update roadmap with completed cosmetics subtask

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a6d989b483298e3a6bbcce3ed032