### PR TITLE
feat: initialize cosmetic menus with starter content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 0.8.0 - Sous-menus de boutique et logique d'achat/équipement
+## 0.8.0 - Ajout du contenu initial et finalisation des menus cosmétiques
 - Ajout des sous-menus paginés pour chaque catégorie de cosmétiques.
 - Possibilité d'acheter et d'équiper les cosmétiques directement depuis l'interface.
+- Contenu initial des chapeaux, particules et titres.
 
 ## 0.7.2 - Refonte visuelle du menu cosmétique principal
 - Menu de boutique cosmétique étendu à 45 slots avec bordures décoratives.

--- a/src/main/java/com/heneria/lobby/HeneriaLobbyPlugin.java
+++ b/src/main/java/com/heneria/lobby/HeneriaLobbyPlugin.java
@@ -73,7 +73,7 @@ public class HeneriaLobbyPlugin extends JavaPlugin {
         achievementManager = new AchievementManager(this, databaseManager, economyManager);
         friendManager = new FriendManager(this, databaseManager, achievementManager);
         messageManager = new PrivateMessageManager();
-        cosmeticsManager = new CosmeticsManager();
+        cosmeticsManager = new CosmeticsManager(this, economyManager);
 
         RegisteredServiceProvider<LuckPerms> provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
         luckPerms = provider != null ? provider.getProvider() : null;

--- a/src/main/java/com/heneria/lobby/cosmetics/Cosmetic.java
+++ b/src/main/java/com/heneria/lobby/cosmetics/Cosmetic.java
@@ -1,0 +1,62 @@
+package com.heneria.lobby.cosmetics;
+
+import org.bukkit.Material;
+import java.util.List;
+
+/**
+ * Represents a cosmetic item loaded from configuration.
+ */
+public class Cosmetic {
+    private final String id;
+    private final String name;
+    private final List<String> lore;
+    private final Material material;
+    private final String rarity;
+    private final int price;
+    private final String category;
+    private final String text;
+
+    public Cosmetic(String id, String name, List<String> lore, Material material,
+                     String rarity, int price, String category, String text) {
+        this.id = id;
+        this.name = name;
+        this.lore = lore;
+        this.material = material;
+        this.rarity = rarity;
+        this.price = price;
+        this.category = category;
+        this.text = text;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<String> getLore() {
+        return lore;
+    }
+
+    public Material getMaterial() {
+        return material;
+    }
+
+    public String getRarity() {
+        return rarity;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/src/main/java/com/heneria/lobby/cosmetics/CosmeticsManager.java
+++ b/src/main/java/com/heneria/lobby/cosmetics/CosmeticsManager.java
@@ -1,91 +1,262 @@
 package com.heneria.lobby.cosmetics;
 
+import com.heneria.lobby.HeneriaLobbyPlugin;
+import com.heneria.lobby.economy.EconomyManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
+import java.io.File;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
- * Handles equipping and unequipping of player cosmetics.
+ * Manages cosmetic items, their menus and purchase/equip logic.
  */
 public class CosmeticsManager implements Listener {
 
-    /**
-     * List storing cosmetic data for players currently equipped.
-     * The list is synchronized to allow safe access from multiple threads.
-     */
-    private final List<PlayerCosmetic> equippedCosmetics = Collections.synchronizedList(new ArrayList<>());
+    private final HeneriaLobbyPlugin plugin;
+    private final EconomyManager economyManager;
+
+    private final Map<String, List<Cosmetic>> cosmetics = new HashMap<>();
+    private final Map<UUID, Set<String>> owned = new HashMap<>();
+    private final Map<UUID, Map<String, String>> equipped = new HashMap<>();
+    private final Map<UUID, Map<Integer, Cosmetic>> openMenus = new HashMap<>();
+    private final Map<UUID, String> openCategory = new HashMap<>();
+    private final Map<UUID, Integer> openPage = new HashMap<>();
+
+    public CosmeticsManager(HeneriaLobbyPlugin plugin, EconomyManager economyManager) {
+        this.plugin = plugin;
+        this.economyManager = economyManager;
+        loadConfig();
+    }
 
     /**
-     * Equip a cosmetic for a player.
-     *
-     * @param playerId   UUID of the player
-     * @param cosmeticId identifier of the cosmetic
+     * Load cosmetics from configuration file.
      */
-    public void equipCosmetic(UUID playerId, String cosmeticId) {
-        synchronized (equippedCosmetics) {
-            equippedCosmetics.removeIf(data -> data.getPlayerId().equals(playerId));
-            equippedCosmetics.add(new PlayerCosmetic(playerId, cosmeticId));
+    public void loadConfig() {
+        plugin.saveResource("cosmetics.yml", false);
+        File file = new File(plugin.getDataFolder(), "cosmetics.yml");
+        FileConfiguration config = YamlConfiguration.loadConfiguration(file);
+        cosmetics.clear();
+        ConfigurationSection root = config.getConfigurationSection("cosmetics");
+        if (root != null) {
+            for (String category : root.getKeys(false)) {
+                ConfigurationSection catSec = root.getConfigurationSection(category);
+                if (catSec == null) continue;
+                List<Cosmetic> list = new ArrayList<>();
+                for (String id : catSec.getKeys(false)) {
+                    ConfigurationSection cSec = catSec.getConfigurationSection(id);
+                    if (cSec == null) continue;
+                    String name = color(cSec.getString("name", id));
+                    List<String> lore = cSec.getStringList("lore").stream()
+                            .map(this::color)
+                            .collect(Collectors.toList());
+                    Material mat = Material.matchMaterial(cSec.getString("material", "STONE"));
+                    if (mat == null) {
+                        mat = Material.STONE;
+                    }
+                    String rarity = cSec.getString("rarity", "COMMUN");
+                    int price = cSec.getInt("price", 0);
+                    String text = color(cSec.getString("text", ""));
+                    list.add(new Cosmetic(id, name, lore, mat, rarity, price, category, text));
+                }
+                cosmetics.put(category, list);
+            }
         }
     }
 
     /**
-     * Unequip any cosmetic for the specified player.
+     * Open a menu for the specified category.
      *
-     * @param playerId UUID of the player
+     * @return true if a menu was opened
      */
-    public void unequipCosmetic(UUID playerId) {
-        synchronized (equippedCosmetics) {
-            equippedCosmetics.removeIf(data -> data.getPlayerId().equals(playerId));
+    public boolean openCategoryMenu(Player player, String category) {
+        return openCategoryMenu(player, category, 0);
+    }
+
+    private boolean openCategoryMenu(Player player, String category, int page) {
+        List<Cosmetic> list = cosmetics.get(category);
+        if (list == null) {
+            return false;
+        }
+        int perPage = 45;
+        int maxPage = (list.size() + perPage - 1) / perPage;
+        if (maxPage == 0) {
+            maxPage = 1;
+        }
+        if (page < 0) {
+            page = 0;
+        }
+        if (page >= maxPage) {
+            page = maxPage - 1;
+        }
+        Inventory inv = Bukkit.createInventory(null, 54,
+                ChatColor.DARK_PURPLE + capitalize(category) + " " + (page + 1) + "/" + maxPage);
+        Map<Integer, Cosmetic> map = new HashMap<>();
+        int start = page * perPage;
+        for (int i = 0; i < perPage && start + i < list.size(); i++) {
+            Cosmetic c = list.get(start + i);
+            ItemStack item = new ItemStack(c.getMaterial());
+            ItemMeta meta = item.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName(c.getName());
+                List<String> lore = new ArrayList<>(c.getLore());
+                lore.add("");
+                boolean has = owned.getOrDefault(player.getUniqueId(), Collections.emptySet()).contains(c.getId());
+                String equippedId = equipped.getOrDefault(player.getUniqueId(), Collections.emptyMap()).get(category);
+                boolean isEquipped = c.getId().equals(equippedId);
+                if (has) {
+                    lore.add(ChatColor.GREEN + "Débloqué");
+                    lore.add(isEquipped ? ChatColor.YELLOW + "Cliquez pour déséquiper" : ChatColor.YELLOW + "Cliquez pour équiper");
+                    meta.addEnchant(Enchantment.DURABILITY, 1, true);
+                    meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                } else {
+                    lore.add(ChatColor.GRAY + c.getRarity());
+                    lore.add(ChatColor.GOLD + String.valueOf(c.getPrice()) + " Coins");
+                    lore.add(ChatColor.YELLOW + "Cliquez pour acheter");
+                }
+                meta.setLore(lore);
+                item.setItemMeta(meta);
+            }
+            inv.setItem(i, item);
+            map.put(i, c);
+        }
+        // back to shop
+        ItemStack back = new ItemStack(Material.ARROW);
+        ItemMeta backMeta = back.getItemMeta();
+        if (backMeta != null) {
+            backMeta.setDisplayName(ChatColor.RED + "Retour");
+            back.setItemMeta(backMeta);
+        }
+        inv.setItem(49, back);
+        // navigation
+        if (page > 0) {
+            ItemStack prev = new ItemStack(Material.ARROW);
+            ItemMeta pm = prev.getItemMeta();
+            if (pm != null) {
+                pm.setDisplayName(ChatColor.YELLOW + "Page précédente");
+                prev.setItemMeta(pm);
+            }
+            inv.setItem(45, prev);
+        }
+        if (page < maxPage - 1) {
+            ItemStack next = new ItemStack(Material.ARROW);
+            ItemMeta nm = next.getItemMeta();
+            if (nm != null) {
+                nm.setDisplayName(ChatColor.YELLOW + "Page suivante");
+                next.setItemMeta(nm);
+            }
+            inv.setItem(53, next);
+        }
+        openMenus.put(player.getUniqueId(), map);
+        openCategory.put(player.getUniqueId(), category);
+        openPage.put(player.getUniqueId(), page);
+        player.openInventory(inv);
+        return true;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        UUID uuid = player.getUniqueId();
+        Map<Integer, Cosmetic> map = openMenus.get(uuid);
+        if (map == null) {
+            return;
+        }
+        event.setCancelled(true);
+        int slot = event.getRawSlot();
+        String category = openCategory.get(uuid);
+        int page = openPage.getOrDefault(uuid, 0);
+        if (slot < 45) {
+            Cosmetic cosmetic = map.get(slot);
+            if (cosmetic == null) {
+                return;
+            }
+            Set<String> ownedSet = owned.computeIfAbsent(uuid, k -> new HashSet<>());
+            if (!ownedSet.contains(cosmetic.getId())) {
+                long coins = economyManager.getCoins(uuid);
+                if (coins < cosmetic.getPrice()) {
+                    player.sendMessage(ChatColor.RED + "Vous n'avez pas assez de Coins.");
+                    return;
+                }
+                economyManager.addCoins(uuid, -cosmetic.getPrice());
+                ownedSet.add(cosmetic.getId());
+                player.sendMessage(ChatColor.GREEN + "Vous avez acheté " + cosmetic.getName());
+            } else {
+                Map<String, String> eq = equipped.computeIfAbsent(uuid, k -> new HashMap<>());
+                String current = eq.get(category);
+                if (cosmetic.getId().equals(current)) {
+                    eq.remove(category);
+                    if (category.equalsIgnoreCase("hats")) {
+                        player.getInventory().setHelmet(null);
+                    }
+                    player.sendMessage(ChatColor.YELLOW + "Cosmétique retiré.");
+                } else {
+                    eq.put(category, cosmetic.getId());
+                    if (category.equalsIgnoreCase("hats")) {
+                        player.getInventory().setHelmet(new ItemStack(cosmetic.getMaterial()));
+                    }
+                    player.sendMessage(ChatColor.YELLOW + "Cosmétique équipé.");
+                }
+            }
+            openCategoryMenu(player, category, page);
+        } else if (slot == 45) {
+            openCategoryMenu(player, category, page - 1);
+        } else if (slot == 53) {
+            openCategoryMenu(player, category, page + 1);
+        } else if (slot == 49) {
+            player.closeInventory();
+            plugin.getGuiManager().openMenu(player, "shop");
         }
     }
 
-    /**
-     * Handle player joining the server by equipping stored cosmetics.
-     *
-     * @param event join event
-     */
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        UUID uuid = event.getPlayer().getUniqueId();
+        openMenus.remove(uuid);
+        openCategory.remove(uuid);
+        openPage.remove(uuid);
+    }
+
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
-        Player player = event.getPlayer();
-        // In a full implementation, cosmeticId would come from persistent storage.
-        // For now, we simply mark the player as having no specific cosmetic equipped.
-        equipCosmetic(player.getUniqueId(), null);
+        owned.putIfAbsent(event.getPlayer().getUniqueId(), new HashSet<>());
     }
 
-    /**
-     * Handle player leaving the server by unequipping cosmetics.
-     *
-     * @param event quit event
-     */
     @EventHandler
     public void onQuit(PlayerQuitEvent event) {
-        Player player = event.getPlayer();
-        unequipCosmetic(player.getUniqueId());
+        UUID uuid = event.getPlayer().getUniqueId();
+        openMenus.remove(uuid);
+        openCategory.remove(uuid);
+        openPage.remove(uuid);
     }
 
-    /**
-     * Simple data holder for player cosmetics.
-     */
-    private static class PlayerCosmetic {
-        private final UUID playerId;
-        private final String cosmeticId;
+    private String color(String text) {
+        return ChatColor.translateAlternateColorCodes('&', text == null ? "" : text);
+    }
 
-        PlayerCosmetic(UUID playerId, String cosmeticId) {
-            this.playerId = playerId;
-            this.cosmeticId = cosmeticId;
+    private String capitalize(String text) {
+        if (text == null || text.isEmpty()) {
+            return "";
         }
-
-        UUID getPlayerId() {
-            return playerId;
-        }
-
-        String getCosmeticId() {
-            return cosmeticId;
-        }
+        return Character.toUpperCase(text.charAt(0)) + text.substring(1);
     }
 }
-

--- a/src/main/java/com/heneria/lobby/listeners/MenuListener.java
+++ b/src/main/java/com/heneria/lobby/listeners/MenuListener.java
@@ -41,7 +41,9 @@ public class MenuListener implements Listener {
         String action = item.getAction();
         if (action.startsWith("open_menu:")) {
             String name = action.split(":", 2)[1];
-            guiManager.openMenu(player, name);
+            if (!plugin.getCosmeticsManager().openCategoryMenu(player, name)) {
+                guiManager.openMenu(player, name);
+            }
         } else if (action.startsWith("run_command:")) {
             String cmd = action.split(":", 2)[1];
             player.closeInventory();

--- a/src/main/resources/cosmetics.yml
+++ b/src/main/resources/cosmetics.yml
@@ -1,0 +1,58 @@
+cosmetics:
+  hats:
+    hat_tnt:
+      name: "&cChapeau Explosif"
+      lore:
+        - "&7Un classique pour les joueurs... instables."
+      material: TNT
+      rarity: RARE
+      price: 2500
+    hat_glass:
+      name: "&bCasque de Cristal"
+      lore:
+        - "&7Avoir les idées claires n'a jamais été aussi simple."
+      material: GLASS
+      rarity: COMMUN
+      price: 1000
+    hat_miner:
+      name: "&eCasque de Spéléologue"
+      lore:
+        - "&7Pour éclairer vos idées les plus sombres."
+      material: SEA_LANTERN
+      rarity: EPIC
+      price: 5000
+  particles:
+    particle_flame_aura:
+      name: "&6Aura Enflammée"
+      lore:
+        - "&7Entourez-vous d'un halo de feu."
+      material: BLAZE_POWDER
+      rarity: EPIC
+      price: 7500
+    particle_heart_trail:
+      name: "&cTraînée d'Amour"
+      lore:
+        - "&7Laissez une trace de cœurs derrière vous."
+      material: POPPY
+      rarity: RARE
+      price: 4000
+    particle_matrix_helix:
+      name: "&aHélice Matrix"
+      lore:
+        - "&7Êtes-vous l'Élu ?"
+      material: LIME_DYE
+      rarity: LEGENDARY
+      price: 15000
+  titles:
+    title_artisan:
+      name: "&fTitre : L'Artisan"
+      text: "&fL'Artisan"
+      material: CRAFTING_TABLE
+      rarity: COMMUN
+      price: 2000
+    title_ghost:
+      name: "&7Titre : Le Fantôme"
+      text: "&7Le Fantôme"
+      material: COBWEB
+      rarity: EPIC
+      price: 10000


### PR DESCRIPTION
## Summary
- load cosmetics from new `cosmetics.yml`
- add dynamic paginated menus with purchase/equip logic
- document initial cosmetic content

## Testing
- `mvn -q test` *(failed: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a8b13fb0832987d0c7f11483f97e