### PR TITLE
fix: replace deprecated durability enchant

### DIFF
--- a/src/main/java/com/heneria/lobby/cosmetics/CosmeticsManager.java
+++ b/src/main/java/com/heneria/lobby/cosmetics/CosmeticsManager.java
@@ -124,7 +124,7 @@ public class CosmeticsManager implements Listener {
                 if (has) {
                     lore.add(ChatColor.GREEN + "Débloqué");
                     lore.add(isEquipped ? ChatColor.YELLOW + "Cliquez pour déséquiper" : ChatColor.YELLOW + "Cliquez pour équiper");
-                    meta.addEnchant(Enchantment.DURABILITY, 1, true);
+                    meta.addEnchant(Enchantment.UNBREAKING, 1, true);
                     meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
                 } else {
                     lore.add(ChatColor.GRAY + c.getRarity());


### PR DESCRIPTION
## Summary
- replace old `Enchantment.DURABILITY` usage with `Enchantment.UNBREAKING`

## Testing
- `mvn clean package -e` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin:pom:3.2.0; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1aa4ea6e08329a767e3e10d94dd68