### PR TITLE
Fix cosmetic menu title check

### DIFF
--- a/src/main/java/com/heneria/lobby/cosmetics/CosmeticsManager.java
+++ b/src/main/java/com/heneria/lobby/cosmetics/CosmeticsManager.java
@@ -223,7 +223,7 @@ public class CosmeticsManager implements Listener {
 
     public boolean isCosmeticMenu(String title) {
         for (String category : cosmetics.keySet()) {
-            if (ChatColor.GOLD + "" + ChatColor.BOLD + capitalize(category)).equals(title)) {
+            if ((ChatColor.GOLD + "" + ChatColor.BOLD + capitalize(category)).equals(title)) {
                 return true;
             }
         }


### PR DESCRIPTION
## Summary
- fix syntax error in `CosmeticsManager.isCosmeticMenu`

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b68f2ce88329ac8a4f43572cb047