### PR TITLE
fix: use correct TextDisplay shadow method

### DIFF
--- a/src/main/java/com/heneria/lobby/cosmetics/CosmeticsManager.java
+++ b/src/main/java/com/heneria/lobby/cosmetics/CosmeticsManager.java
@@ -602,7 +602,7 @@ public class CosmeticsManager implements Listener {
         hideTitle(player);
         TextDisplay display = player.getWorld().spawn(player.getLocation(), TextDisplay.class);
         display.text(LegacyComponentSerializer.legacySection().deserialize(color(cosmetic.getText())));
-        display.setShadow(true);
+        display.setShadowed(true);
         player.addPassenger(display);
         titleEntities.put(uuid, display);
     }


### PR DESCRIPTION
## Summary
- fix compile error by using the proper `TextDisplay#setShadowed` method when spawning title displays

## Testing
- `mvn -q clean package` *(fails: PluginResolutionException; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c4fea69c832981a0993c1ce1c795