### PR TITLE
fix: correct LibsDisguises dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.github.libraryaddict</groupId>
             <artifactId>LibsDisguises</artifactId>
-            <version>10.0.31</version>
+            <version>10.0.33</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- update LibsDisguises dependency to 10.0.33

## Testing
- `mvn -q clean package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin:pom:3.2.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e055b78c832986256312125ff36e