### PR TITLE
Fix NPC deletion command compile error

### DIFF
--- a/src/main/java/com/lobby/commands/NPCCommands.java
+++ b/src/main/java/com/lobby/commands/NPCCommands.java
@@ -175,14 +175,10 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
         final String name = args[0];
 
         try {
-            final boolean deleted = npcManager.deleteNPC(name);
-            if (deleted) {
-                MessageUtils.sendPrefixedMessage(sender, "&aPNJ '&6" + name + "&a' supprimé avec succès !");
-            } else {
-                MessageUtils.sendPrefixedMessage(sender, "&cPNJ '&6" + name + "&c' introuvable !");
-            }
-        } catch (final IllegalArgumentException exception) {
-            MessageUtils.sendPrefixedMessage(sender, "&c" + exception.getMessage());
+            npcManager.deleteNPC(name);
+            MessageUtils.sendPrefixedMessage(sender, "&aPNJ '&6" + name + "&a' supprimé avec succès !");
+        } catch (final IllegalArgumentException ignored) {
+            MessageUtils.sendPrefixedMessage(sender, "&cPNJ '&6" + name + "&c' introuvable !");
         } catch (final Exception exception) {
             MessageUtils.sendPrefixedMessage(sender, "&cErreur lors de la suppression du PNJ !");
             if (plugin != null) {


### PR DESCRIPTION
## Summary
- fix the NPC deletion admin command to call the manager without expecting a boolean result

## Testing
- `mvn -q -DskipTests package` *(fails: network unreachable while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cc50be56cc83298e5b90c7b6d0aee1