### PR TITLE
Add visible NPC armor stands with equipment management

### DIFF
--- a/src/main/java/com/lobby/commands/NPCCommands.java
+++ b/src/main/java/com/lobby/commands/NPCCommands.java
@@ -5,11 +5,14 @@ import com.lobby.npcs.NPC;
 import com.lobby.npcs.NPCManager;
 import com.lobby.utils.MessageUtils;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,12 +91,13 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
         }
 
         if (args.length == 1) {
-            return filterSuggestions(List.of("create", "delete", "list", "info", "addaction"), args[0]);
+            return filterSuggestions(List.of("create", "delete", "list", "info", "addaction", "equip"), args[0]);
         }
 
         if (args.length == 2) {
             final String subCommand = args[0].toLowerCase(Locale.ROOT);
-            if (subCommand.equals("delete") || subCommand.equals("info") || subCommand.equals("addaction")) {
+            if (subCommand.equals("delete") || subCommand.equals("info") || subCommand.equals("addaction")
+                    || subCommand.equals("equip")) {
                 return filterSuggestions(new ArrayList<>(npcManager.getNPCNames()), args[1]);
             }
         }
@@ -120,6 +124,7 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
             case "list" -> handleList(sender);
             case "info" -> handleInfo(sender, parameters);
             case "addaction" -> handleAddAction(sender, parameters);
+            case "equip" -> handleEquip(sender, parameters);
             default -> sendUsage(sender);
         }
         return true;
@@ -280,6 +285,50 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
         }
     }
 
+    private void handleEquip(final CommandSender sender, final String[] args) {
+        if (!(sender instanceof Player player)) {
+            MessageUtils.sendPrefixedMessage(sender, "&cSeuls les joueurs peuvent équiper des PNJ !");
+            return;
+        }
+        if (!sender.hasPermission("lobby.admin.npc")) {
+            MessageUtils.sendPrefixedMessage(sender, "&cVous n'avez pas la permission !");
+            return;
+        }
+        if (args.length == 0) {
+            MessageUtils.sendPrefixedMessage(sender, "&cUsage: /ladmin npc equip <nom>");
+            MessageUtils.sendPrefixedMessage(sender, "&7Tenez l'item à équiper dans votre main principale");
+            return;
+        }
+
+        final String name = args[0];
+        final NPC npc = npcManager.getNPC(name);
+        if (npc == null) {
+            MessageUtils.sendPrefixedMessage(player, "&cPNJ '&6" + name + "&c' introuvable !");
+            return;
+        }
+
+        final ItemStack itemInHand = player.getInventory().getItemInMainHand();
+        if (itemInHand.getType() == Material.AIR) {
+            MessageUtils.sendPrefixedMessage(player, "&cVous devez tenir un item dans votre main !");
+            return;
+        }
+
+        final ArmorStand armorStand = npc.getArmorStand();
+        if (armorStand == null || armorStand.isDead()) {
+            MessageUtils.sendPrefixedMessage(player, "&cLe PNJ n'est pas disponible actuellement.");
+            return;
+        }
+
+        final var equipment = armorStand.getEquipment();
+        if (equipment == null) {
+            MessageUtils.sendPrefixedMessage(player, "&cImpossible d'équiper ce PNJ.");
+            return;
+        }
+
+        equipment.setItemInMainHand(itemInHand.clone());
+        MessageUtils.sendPrefixedMessage(player, "&aPNJ '&6" + name + "&a' équipé avec l'item !");
+    }
+
     private void sendUsage(final CommandSender sender) {
         MessageUtils.sendPrefixedMessage(sender, "&cCommande inconnue ! Utilisez:");
         MessageUtils.sendPrefixedMessage(sender, "&e/ladmin npc create <nom> <nom_affiché> [tête]");
@@ -287,6 +336,7 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
         MessageUtils.sendPrefixedMessage(sender, "&e/ladmin npc list");
         MessageUtils.sendPrefixedMessage(sender, "&e/ladmin npc info <nom>");
         MessageUtils.sendPrefixedMessage(sender, "&e/ladmin npc addaction <nom> <action>");
+        MessageUtils.sendPrefixedMessage(sender, "&e/ladmin npc equip <nom>");
     }
 
     private List<String> filterSuggestions(final List<String> options, final String prefix) {

--- a/src/main/java/com/lobby/npcs/NPC.java
+++ b/src/main/java/com/lobby/npcs/NPC.java
@@ -30,6 +30,7 @@ public class NPC {
     private final NPCData data;
     private final NPCManager manager;
     private ArmorStand armorStand;
+    private ArmorStand nameArmorStand;
     private boolean spawned;
 
     public NPC(final NPCData data, final NPCManager manager) {
@@ -49,33 +50,19 @@ public class NPC {
         if (isSpawned()) {
             return;
         }
+
         final World world = Bukkit.getWorld(data.world());
         if (world == null) {
             LogUtils.warning(manager.getPlugin(), "World not found for NPC '" + data.name() + "': " + data.world());
             return;
         }
+
         final Location location = new Location(world, data.x(), data.y(), data.z(), data.yaw(), data.pitch());
-        armorStand = world.spawn(location, ArmorStand.class, stand -> {
-            stand.setVisible(false);
-            stand.setGravity(false);
-            stand.setCanPickupItems(false);
-            stand.setMarker(true);
-            stand.setInvulnerable(true);
-            stand.setPersistent(true);
-            stand.setRemoveWhenFarAway(false);
-            stand.setCollidable(false);
-            stand.setSilent(true);
-            stand.setBasePlate(false);
-            stand.setArms(false);
-            final String displayName = data.displayName() == null ? data.name() : data.displayName();
-            stand.customName(LegacyComponentSerializer.legacyAmpersand().deserialize(displayName));
-            stand.setCustomNameVisible(true);
-            final NamespacedKey key = manager.getNpcKey();
-            if (key != null) {
-                stand.getPersistentDataContainer().set(key, PersistentDataType.STRING, data.name());
-            }
-        });
+        armorStand = world.spawn(location, ArmorStand.class);
+
+        setupArmorStand();
         setHeadTexture();
+        setDefaultEquipment();
         spawned = true;
     }
 
@@ -83,6 +70,10 @@ public class NPC {
         if (armorStand != null) {
             armorStand.remove();
             armorStand = null;
+        }
+        if (nameArmorStand != null) {
+            nameArmorStand.remove();
+            nameArmorStand = null;
         }
         spawned = false;
     }
@@ -133,6 +124,90 @@ public class NPC {
         final var equipment = armorStand.getEquipment();
         if (equipment != null) {
             equipment.setHelmet(head);
+        }
+    }
+
+    public ArmorStand getArmorStand() {
+        return armorStand;
+    }
+
+    private void setupArmorStand() {
+        if (armorStand == null) {
+            return;
+        }
+
+        armorStand.setVisible(true);
+        armorStand.setGravity(false);
+        armorStand.setCanPickupItems(false);
+        armorStand.setInvulnerable(true);
+        armorStand.setSilent(true);
+        armorStand.setBasePlate(true);
+        armorStand.setArms(true);
+        armorStand.setMarker(false);
+        armorStand.setSmall(false);
+        armorStand.setPersistent(true);
+        armorStand.setRemoveWhenFarAway(false);
+        armorStand.setCollidable(false);
+        final String customName = (data.displayName() == null || data.displayName().isEmpty())
+                ? data.name() : data.displayName();
+        armorStand.customName(LegacyComponentSerializer.legacyAmpersand().deserialize(customName));
+        armorStand.setCustomNameVisible(false);
+
+        final NamespacedKey key = manager.getNpcKey();
+        if (key != null) {
+            armorStand.getPersistentDataContainer().set(key, PersistentDataType.STRING, data.name());
+        }
+
+        if (nameArmorStand != null) {
+            nameArmorStand.remove();
+            nameArmorStand = null;
+        }
+
+        final String displayName = data.displayName();
+        if (displayName != null && !displayName.isEmpty()) {
+            final Location nameLocation = armorStand.getLocation().clone().add(0, 0.5, 0);
+            nameArmorStand = armorStand.getWorld().spawn(nameLocation, ArmorStand.class);
+            nameArmorStand.setVisible(false);
+            nameArmorStand.setGravity(false);
+            nameArmorStand.setCanPickupItems(false);
+            nameArmorStand.setInvulnerable(true);
+            nameArmorStand.setSilent(true);
+            nameArmorStand.setBasePlate(false);
+            nameArmorStand.setArms(false);
+            nameArmorStand.setMarker(true);
+            nameArmorStand.setPersistent(true);
+            nameArmorStand.setRemoveWhenFarAway(false);
+            nameArmorStand.setCollidable(false);
+            nameArmorStand.customName(LegacyComponentSerializer.legacyAmpersand().deserialize(displayName));
+            nameArmorStand.setCustomNameVisible(true);
+
+            if (key != null) {
+                nameArmorStand.getPersistentDataContainer().set(key, PersistentDataType.STRING, data.name());
+            }
+        }
+    }
+
+    private void setDefaultEquipment() {
+        if (armorStand == null) {
+            return;
+        }
+
+        final var equipment = armorStand.getEquipment();
+        if (equipment == null) {
+            return;
+        }
+
+        if (equipment.getChestplate() == null || equipment.getChestplate().getType() == Material.AIR) {
+            equipment.setChestplate(new ItemStack(Material.LEATHER_CHESTPLATE));
+        }
+        if (equipment.getLeggings() == null || equipment.getLeggings().getType() == Material.AIR) {
+            equipment.setLeggings(new ItemStack(Material.LEATHER_LEGGINGS));
+        }
+        if (equipment.getBoots() == null || equipment.getBoots().getType() == Material.AIR) {
+            equipment.setBoots(new ItemStack(Material.LEATHER_BOOTS));
+        }
+        if (equipment.getItemInMainHand() == null || equipment.getItemInMainHand().getType() == Material.AIR) {
+            equipment.setItemInMainHand(new ItemStack(Material.STICK));
         }
     }
 


### PR DESCRIPTION
## Summary
- spawn NPCs with fully visible armor stands, a separate name display, and default outfit
- ensure NPC metadata is stored on both armor stand entities and expose the armor stand via a getter
- add an `/ladmin npc equip` command so admins can copy the held item onto the NPC's main hand

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach repo.maven.apache.org due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5878b57c8329ba20a23d6e26ded5