### PR TITLE
Modernize NPC sound resolution

### DIFF
--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -5,6 +5,8 @@ import com.lobby.utils.LogUtils;
 import com.lobby.utils.MessageUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
@@ -44,10 +46,10 @@ public class ActionProcessor {
         }
         if (startsWithIgnoreCase(trimmed, "[SOUND]")) {
             final String soundName = processed.substring(7).trim();
-            try {
-                final Sound sound = Sound.valueOf(soundName.toUpperCase(Locale.ROOT));
+            final Sound sound = resolveSound(soundName);
+            if (sound != null) {
                 player.playSound(player.getLocation(), sound, 1.0f, 1.0f);
-            } catch (final IllegalArgumentException exception) {
+            } else {
                 LogUtils.warning(plugin, "Unknown sound in NPC action: " + soundName);
             }
             return;
@@ -128,5 +130,57 @@ public class ActionProcessor {
 
     private boolean startsWithIgnoreCase(final String text, final String prefix) {
         return text.regionMatches(true, 0, prefix, 0, prefix.length());
+    }
+
+    private Sound resolveSound(final String soundName) {
+        if (soundName == null || soundName.isBlank()) {
+            return null;
+        }
+        final String trimmed = soundName.trim();
+        final String lower = trimmed.toLowerCase(Locale.ROOT);
+
+        final Sound namespacedMatch = lookupSound(lower);
+        if (namespacedMatch != null) {
+            return namespacedMatch;
+        }
+
+        if (lower.startsWith("minecraft:")) {
+            final Sound minecraftMatch = lookupSound(lower.substring("minecraft:".length()));
+            if (minecraftMatch != null) {
+                return minecraftMatch;
+            }
+        }
+
+        if (!lower.contains(".")) {
+            final String dotted = lower.replace('_', '.');
+            final Sound dottedMatch = lookupSound(dotted);
+            if (dottedMatch != null) {
+                return dottedMatch;
+            }
+        }
+
+        try {
+            return Sound.valueOf(trimmed.toUpperCase(Locale.ROOT));
+        } catch (final IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private Sound lookupSound(final String key) {
+        try {
+            final NamespacedKey directKey = NamespacedKey.fromString(key);
+            if (directKey != null) {
+                final Sound sound = Registry.SOUNDS.get(directKey);
+                if (sound != null) {
+                    return sound;
+                }
+            }
+            if (key.indexOf(':') >= 0) {
+                return null;
+            }
+            return Registry.SOUNDS.get(NamespacedKey.minecraft(key));
+        } catch (final IllegalArgumentException ignored) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace direct `Sound.valueOf` usage with registry-based lookups to remain compatible with modern Paper
- add normalization helpers to resolve both namespaced and legacy sound identifiers when triggering NPC actions

## Testing
- `mvn -q -DskipTests package` *(fails: network unreachable while downloading Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68cc61f353008329adb1d425aba08c53