### PR TITLE
Add NPC armor color command and persistence

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -139,5 +139,9 @@ public final class LobbyPlugin extends JavaPlugin {
             getCommand("lobbyadmin").setExecutor(npcCommands);
             getCommand("lobbyadmin").setTabCompleter(npcCommands);
         }
+        if (getCommand("npc") != null) {
+            getCommand("npc").setExecutor(npcCommands);
+            getCommand("npc").setTabCompleter(npcCommands);
+        }
     }
 }

--- a/src/main/java/com/lobby/commands/NPCCommands.java
+++ b/src/main/java/com/lobby/commands/NPCCommands.java
@@ -40,7 +40,8 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
 
     @Override
     public boolean onCommand(final CommandSender sender, final Command command, final String label, final String[] args) {
-        if (!command.getName().equalsIgnoreCase("lobbyadmin")) {
+        final String commandName = command.getName().toLowerCase(Locale.ROOT);
+        if (!commandName.equals("lobbyadmin") && !commandName.equals("npc")) {
             return false;
         }
 
@@ -49,11 +50,14 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
             return true;
         }
 
+        if (commandName.equals("npc")) {
+            return handleNpcCommand(sender, args);
+        }
+
         if (args.length < 1 || !args[0].equalsIgnoreCase("npc")) {
             sendUsage(sender);
             return true;
         }
-
         final String[] npcArgs = Arrays.copyOfRange(args, 1, args.length);
         handleNpcCommand(sender, npcArgs);
         return true;
@@ -61,8 +65,13 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
 
     @Override
     public List<String> onTabComplete(final CommandSender sender, final Command command, final String alias, final String[] args) {
-        if (!command.getName().equalsIgnoreCase("lobbyadmin")) {
+        final String commandName = command.getName().toLowerCase(Locale.ROOT);
+        if (!commandName.equals("lobbyadmin") && !commandName.equals("npc")) {
             return Collections.emptyList();
+        }
+
+        if (commandName.equals("npc")) {
+            return tabComplete(sender, args);
         }
 
         if (args.length == 1) {
@@ -91,19 +100,23 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
         }
 
         if (args.length == 1) {
-            return filterSuggestions(List.of("create", "delete", "list", "info", "addaction", "equip"), args[0]);
+            return filterSuggestions(List.of("create", "delete", "list", "info", "addaction", "equip", "setcolor"), args[0]);
         }
 
         if (args.length == 2) {
             final String subCommand = args[0].toLowerCase(Locale.ROOT);
             if (subCommand.equals("delete") || subCommand.equals("info") || subCommand.equals("addaction")
-                    || subCommand.equals("equip")) {
+                    || subCommand.equals("equip") || subCommand.equals("setcolor")) {
                 return filterSuggestions(new ArrayList<>(npcManager.getNPCNames()), args[1]);
             }
         }
 
         if (args.length == 3 && args[0].equalsIgnoreCase("addaction")) {
             return filterSuggestions(List.of("[MESSAGE] ", "[SOUND] ", "[COMMAND] ", "[COINS_ADD] ", "[TOKENS_ADD] "), args[2]);
+        }
+
+        if (args.length == 3 && args[0].equalsIgnoreCase("setcolor")) {
+            return filterSuggestions(List.of("#FF0000", "#00FF00", "#0000FF"), args[2]);
         }
 
         return Collections.emptyList();
@@ -125,6 +138,7 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
             case "info" -> handleInfo(sender, parameters);
             case "addaction" -> handleAddAction(sender, parameters);
             case "equip" -> handleEquip(sender, parameters);
+            case "setcolor" -> handleSetColor(sender, parameters);
             default -> sendUsage(sender);
         }
         return true;
@@ -328,6 +342,44 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
         MessageUtils.sendPrefixedMessage(player, "&aPNJ '&6" + name + "&a' équipé avec l'item !");
     }
 
+    private void handleSetColor(final CommandSender sender, final String[] args) {
+        if (!sender.hasPermission("lobby.admin.npc")) {
+            MessageUtils.sendPrefixedMessage(sender, "&cVous n'avez pas la permission !");
+            return;
+        }
+
+        if (args.length != 2) {
+            MessageUtils.sendPrefixedMessage(sender, "&cUsage: /npc setcolor <nom> <#RRGGBB>");
+            return;
+        }
+
+        final String name = args[0];
+        final String hexColor = args[1];
+
+        if (!npcManager.isValidArmorColor(hexColor)) {
+            MessageUtils.sendPrefixedMessage(sender, "&cFormat de couleur invalide (ex: #RRGGBB)");
+            return;
+        }
+
+        final NPC npc = npcManager.getNPC(name);
+        if (npc == null) {
+            MessageUtils.sendPrefixedMessage(sender, "&cPNJ introuvable");
+            return;
+        }
+
+        try {
+            npcManager.updateNPCArmorColor(name, hexColor);
+            MessageUtils.sendPrefixedMessage(sender, "&aCouleur du PNJ '&6" + name + "&a' mise à jour !");
+        } catch (final IllegalArgumentException exception) {
+            MessageUtils.sendPrefixedMessage(sender, "&cFormat de couleur invalide (ex: #RRGGBB)");
+        } catch (final Exception exception) {
+            MessageUtils.sendPrefixedMessage(sender, "&cImpossible de mettre à jour la couleur de ce PNJ.");
+            if (plugin != null) {
+                plugin.getLogger().severe("Error updating NPC color: " + exception.getMessage());
+            }
+        }
+    }
+
     private void sendUsage(final CommandSender sender) {
         MessageUtils.sendPrefixedMessage(sender, "&cCommande inconnue ! Utilisez:");
         MessageUtils.sendPrefixedMessage(sender, "&e/ladmin npc create <nom> <nom_affiché> [tête]");
@@ -336,6 +388,7 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
         MessageUtils.sendPrefixedMessage(sender, "&e/ladmin npc info <nom>");
         MessageUtils.sendPrefixedMessage(sender, "&e/ladmin npc addaction <nom> <action>");
         MessageUtils.sendPrefixedMessage(sender, "&e/ladmin npc equip <nom>");
+        MessageUtils.sendPrefixedMessage(sender, "&e/npc setcolor <nom> <#RRGGBB>");
     }
 
     private List<String> filterSuggestions(final List<String> options, final String prefix) {

--- a/src/main/java/com/lobby/core/DatabaseManager.java
+++ b/src/main/java/com/lobby/core/DatabaseManager.java
@@ -225,6 +225,7 @@ public class DatabaseManager {
                         yaw REAL DEFAULT 0,
                         pitch REAL DEFAULT 0,
                         head_texture TEXT,
+                        armor_color TEXT,
                         actions TEXT,
                         visible INTEGER DEFAULT 1,
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -233,6 +234,7 @@ public class DatabaseManager {
 
             executeSQL(sqliteCreate);
             plugin.getLogger().fine("Created npcs table for SQLite");
+            addColumnIfNotExists("npcs", "armor_color", "TEXT");
             createNPCIndexes();
             return;
         }
@@ -256,6 +258,7 @@ public class DatabaseManager {
                     yaw FLOAT DEFAULT 0,
                     pitch FLOAT DEFAULT 0,
                     head_texture TEXT,
+                    armor_color VARCHAR(7),
                     actions TEXT,
                     visible BOOLEAN DEFAULT TRUE,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -267,6 +270,7 @@ public class DatabaseManager {
 
         executeSQL(createTable);
         LogUtils.info(plugin, "Created npcs table with proper AUTO_INCREMENT");
+        addColumnIfNotExists("npcs", "armor_color", "VARCHAR(7)");
     }
 
     private void addColumnIfMissing(final String table, final String columnName, final String definition) throws SQLException {

--- a/src/main/java/com/lobby/data/NPCData.java
+++ b/src/main/java/com/lobby/data/NPCData.java
@@ -12,6 +12,7 @@ public record NPCData(
         float yaw,
         float pitch,
         String headTexture,
+        String armorColor,
         List<String> actions,
         boolean visible
 ) {
@@ -21,6 +22,10 @@ public record NPCData(
     }
 
     public NPCData withActions(final List<String> newActions) {
-        return new NPCData(name, displayName, world, x, y, z, yaw, pitch, headTexture, newActions, visible);
+        return new NPCData(name, displayName, world, x, y, z, yaw, pitch, headTexture, armorColor, newActions, visible);
+    }
+
+    public NPCData withArmorColor(final String newColor) {
+        return new NPCData(name, displayName, world, x, y, z, yaw, pitch, headTexture, newColor, actions, visible);
     }
 }

--- a/src/main/java/com/lobby/npcs/NPC.java
+++ b/src/main/java/com/lobby/npcs/NPC.java
@@ -22,23 +22,28 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
 public class NPC {
 
-    private final NPCData data;
+    private NPCData data;
     private final NPCManager manager;
     private ArmorStand armorStand;
     private boolean spawned;
 
     public NPC(final NPCData data, final NPCManager manager) {
-        this.data = data;
+        this.data = Objects.requireNonNull(data, "data");
         this.manager = manager;
     }
 
     public NPCData getData() {
         return data;
+    }
+
+    public void setData(final NPCData data) {
+        this.data = Objects.requireNonNull(data, "data");
     }
 
     public boolean isSpawned() {
@@ -62,6 +67,7 @@ public class NPC {
         setupArmorStand();
         setHeadTexture();
         setDefaultEquipment();
+        applyArmorColor();
         spawned = true;
     }
 
@@ -177,6 +183,14 @@ public class NPC {
         if (equipment.getItemInMainHand() == null || equipment.getItemInMainHand().getType() == Material.AIR) {
             equipment.setItemInMainHand(new ItemStack(Material.STICK));
         }
+    }
+
+    private void applyArmorColor() {
+        if (armorStand == null) {
+            return;
+        }
+
+        manager.applyArmorColor(armorStand, data.armorColor());
     }
 
     private static final Pattern UUID_PATTERN = Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");

--- a/src/main/java/com/lobby/npcs/NPCManager.java
+++ b/src/main/java/com/lobby/npcs/NPCManager.java
@@ -4,8 +4,13 @@ import com.lobby.LobbyPlugin;
 import com.lobby.data.NPCData;
 import com.lobby.utils.LogUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.Color;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.scheduler.BukkitTask;
 
 import java.sql.Connection;
@@ -21,8 +26,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.Locale;
+import java.util.regex.Pattern;
 
 public class NPCManager {
+    private static final Pattern HEX_COLOR_PATTERN = Pattern.compile("^#[0-9a-fA-F]{6}$");
     private final LobbyPlugin plugin;
     private final Map<String, NPC> npcs = new ConcurrentHashMap<>();
     private final Map<UUID, Map<String, Long>> cooldowns = new ConcurrentHashMap<>();
@@ -61,8 +69,14 @@ public class NPCManager {
             int loaded = 0;
             while (rs.next()) {
                 try {
+                    final String name = rs.getString("name");
+                    final String rawColor = rs.getString("armor_color");
+                    final String armorColor = normalizeArmorColor(rawColor);
+                    if (rawColor != null && armorColor == null) {
+                        LogUtils.warning(plugin, "Ignoring invalid armor color '" + rawColor + "' for NPC '" + name + "'");
+                    }
                     final NPCData data = new NPCData(
-                            rs.getString("name"),
+                            name,
                             rs.getString("display_name"),
                             rs.getString("world"),
                             rs.getDouble("x"),
@@ -71,6 +85,7 @@ public class NPCManager {
                             rs.getFloat("yaw"),
                             rs.getFloat("pitch"),
                             rs.getString("head_texture"),
+                            armorColor,
                             parseActions(rs.getString("actions")),
                             rs.getBoolean("visible")
                     );
@@ -103,13 +118,13 @@ public class NPCManager {
                 location.getWorld().getName(),
                 location.getX(), location.getY(), location.getZ(),
                 location.getYaw(), location.getPitch(),
-                headTexture, actions, true
+                headTexture, null, actions, true
         );
 
         try (Connection conn = plugin.getDatabaseManager().getConnection();
              PreparedStatement stmt = conn.prepareStatement("""
-                     INSERT INTO npcs (name, display_name, world, x, y, z, yaw, pitch, head_texture, actions, visible)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     INSERT INTO npcs (name, display_name, world, x, y, z, yaw, pitch, head_texture, armor_color, actions, visible)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                      """)) {
 
             stmt.setString(1, name);
@@ -121,8 +136,9 @@ public class NPCManager {
             stmt.setFloat(7, location.getYaw());
             stmt.setFloat(8, location.getPitch());
             stmt.setString(9, headTexture);
-            stmt.setString(10, actionsToJson(actions));
-            stmt.setBoolean(11, true);
+            stmt.setString(10, data.armorColor());
+            stmt.setString(11, actionsToJson(actions));
+            stmt.setBoolean(12, true);
 
             final int result = stmt.executeUpdate();
             plugin.getLogger().fine("Insert result: " + result + " rows affected");
@@ -184,6 +200,34 @@ public class NPCManager {
         }
     }
 
+    public void updateNPCArmorColor(final String name, final String hexColor) {
+        final NPC npc = npcs.get(name);
+        if (npc == null) {
+            throw new IllegalArgumentException("NPC '" + name + "' not found");
+        }
+
+        final String normalized = normalizeArmorColor(hexColor);
+        if (normalized == null) {
+            throw new IllegalArgumentException("Invalid armor color: " + hexColor);
+        }
+
+        try (Connection conn = plugin.getDatabaseManager().getConnection();
+             PreparedStatement stmt = conn.prepareStatement("UPDATE npcs SET armor_color = ? WHERE name = ?")) {
+            stmt.setString(1, normalized);
+            stmt.setString(2, name);
+            stmt.executeUpdate();
+        } catch (final SQLException exception) {
+            throw new RuntimeException("Failed to update NPC color: " + exception.getMessage(), exception);
+        }
+
+        final ArmorStand armorStand = npc.getArmorStand();
+        if (armorStand != null && !armorStand.isDead()) {
+            applyArmorColor(armorStand, normalized);
+        }
+
+        npc.setData(npc.getData().withArmorColor(normalized));
+    }
+
     private List<String> parseActions(String actionsJson) {
         if (actionsJson == null || actionsJson.trim().isEmpty()) {
             return new ArrayList<>();
@@ -212,6 +256,73 @@ public class NPCManager {
             return "[]";
         }
         return "[\"" + String.join("\",\"", actions) + "\"]";
+    }
+
+    public boolean isValidArmorColor(final String color) {
+        if (color == null) {
+            return false;
+        }
+
+        final String trimmed = color.trim();
+        if (!trimmed.startsWith("#")) {
+            return false;
+        }
+
+        return HEX_COLOR_PATTERN.matcher(trimmed).matches();
+    }
+
+    public boolean applyArmorColor(final ArmorStand armorStand, final String hexColor) {
+        if (armorStand == null) {
+            return false;
+        }
+
+        final String normalized = normalizeArmorColor(hexColor);
+        if (normalized == null) {
+            return false;
+        }
+
+        final var equipment = armorStand.getEquipment();
+        if (equipment == null) {
+            return false;
+        }
+
+        final ItemStack[] armorPieces = equipment.getArmorContents();
+        boolean applied = false;
+
+        try {
+            final java.awt.Color awtColor = java.awt.Color.decode(normalized);
+            final Color bukkitColor = Color.fromRGB(awtColor.getRed(), awtColor.getGreen(), awtColor.getBlue());
+
+            for (int index = 0; index < armorPieces.length; index++) {
+                final ItemStack piece = armorPieces[index];
+                if (piece == null || piece.getType() == Material.AIR) {
+                    continue;
+                }
+
+                if (!piece.getType().name().startsWith("LEATHER_")) {
+                    continue;
+                }
+
+                final var meta = piece.getItemMeta();
+                if (!(meta instanceof LeatherArmorMeta leatherMeta)) {
+                    continue;
+                }
+
+                leatherMeta.setColor(bukkitColor);
+                piece.setItemMeta(leatherMeta);
+                armorPieces[index] = piece;
+                applied = true;
+            }
+
+            if (applied) {
+                equipment.setArmorContents(armorPieces);
+            }
+        } catch (final NumberFormatException exception) {
+            LogUtils.warning(plugin, "Invalid armor color provided: " + hexColor);
+            return false;
+        }
+
+        return applied;
     }
 
     public boolean isOnCooldown(final UUID player, final String npcName) {
@@ -303,6 +414,27 @@ public class NPCManager {
         interactionCooldownMillis = Math.max(0L, config.getLong("npcs.interaction_cooldown_ms", 1000L));
         maxInteractionDistance = Math.max(0D, config.getDouble("npcs.max_interaction_distance", 3.0D));
         lookAtPlayer = config.getBoolean("npcs.look_at_player", false);
+    }
+
+    private String normalizeArmorColor(final String hexColor) {
+        if (hexColor == null) {
+            return null;
+        }
+
+        String trimmed = hexColor.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+
+        if (!trimmed.startsWith("#")) {
+            trimmed = "#" + trimmed;
+        }
+
+        if (!HEX_COLOR_PATTERN.matcher(trimmed).matches()) {
+            return null;
+        }
+
+        return trimmed.toUpperCase(Locale.ROOT);
     }
 
     private String formatLocation(final Location location) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,6 +22,9 @@ commands:
     description: Commandes d'administration du lobby
     permission: lobby.admin
     aliases: [ladmin]
+  npc:
+    description: Gestion des PNJ
+    permission: lobby.admin.npc
 permissions:
   lobby.use:
     default: true


### PR DESCRIPTION
## Summary
- register a dedicated `/npc` command and add a `setcolor` subcommand that validates permissions and input before updating a PNJ's leather armor
- persist each NPC's armor color in the database and reload it on spawn so ArmorStands are tinted immediately after creation
- expose utility logic on the NPC manager to normalize, validate, and apply leather armor colors for both live updates and reloads

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download Maven plugins because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6330345c83299492e136a9ae1e1b