### PR TITLE
feat: add lobby protection and ambiance systems

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -12,6 +12,9 @@ import com.lobby.holograms.HologramManager;
 import com.lobby.npcs.NPCInteractionHandler;
 import com.lobby.npcs.NPCManager;
 import com.lobby.events.PlayerJoinLeaveEvent;
+import com.lobby.lobby.LobbyManager;
+import com.lobby.lobby.listeners.LobbyPlayerListener;
+import com.lobby.lobby.listeners.LobbyProtectionListener;
 import com.lobby.utils.LogUtils;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.PluginCommand;
@@ -27,6 +30,7 @@ public final class LobbyPlugin extends JavaPlugin {
     private EconomyManager economyManager;
     private HologramManager hologramManager;
     private NPCManager npcManager;
+    private LobbyManager lobbyManager;
 
     public static LobbyPlugin getInstance() {
         return instance;
@@ -52,10 +56,14 @@ public final class LobbyPlugin extends JavaPlugin {
         hologramManager.initialize();
         npcManager = new NPCManager(this);
         npcManager.initialize();
+        lobbyManager = new LobbyManager(this);
+        lobbyManager.applyWorldSettings();
 
         registerCommands();
 
         getServer().getPluginManager().registerEvents(new PlayerJoinLeaveEvent(this, playerDataManager, economyManager), this);
+        getServer().getPluginManager().registerEvents(new LobbyPlayerListener(lobbyManager), this);
+        getServer().getPluginManager().registerEvents(new LobbyProtectionListener(lobbyManager), this);
         getServer().getPluginManager().registerEvents(new NPCInteractionHandler(npcManager), this);
 
         LogUtils.info(this, "LobbyCore activé !");
@@ -74,6 +82,9 @@ public final class LobbyPlugin extends JavaPlugin {
         }
         if (databaseManager != null) {
             databaseManager.shutdown();
+        }
+        if (lobbyManager != null) {
+            lobbyManager.shutdown();
         }
         instance = null;
     }
@@ -102,6 +113,10 @@ public final class LobbyPlugin extends JavaPlugin {
         return npcManager;
     }
 
+    public LobbyManager getLobbyManager() {
+        return lobbyManager;
+    }
+
     public void reloadLobbyConfig() {
         if (configManager != null) {
             configManager.reloadConfigs();
@@ -118,10 +133,13 @@ public final class LobbyPlugin extends JavaPlugin {
         if (npcManager != null) {
             npcManager.reload();
         }
+        if (lobbyManager != null) {
+            lobbyManager.reload();
+        }
     }
 
     private void registerCommands() {
-        final PlayerCommands playerCommands = new PlayerCommands();
+        final PlayerCommands playerCommands = new PlayerCommands(lobbyManager);
         registerCommand("lobby", playerCommands);
         registerCommand("shop", playerCommands);
         registerCommand("serveurs", playerCommands);
@@ -134,7 +152,7 @@ public final class LobbyPlugin extends JavaPlugin {
         registerCommand("pay", economyCommands);
         registerCommand("top", economyCommands);
 
-        final AdminCommands adminCommands = new AdminCommands(this, economyManager, hologramManager, npcManager);
+        final AdminCommands adminCommands = new AdminCommands(this, economyManager, hologramManager, npcManager, lobbyManager);
         registerCommand("lobbyadmin", adminCommands);
 
         final NPCCommands npcCommands = new NPCCommands(this);

--- a/src/main/java/com/lobby/commands/AdminCommands.java
+++ b/src/main/java/com/lobby/commands/AdminCommands.java
@@ -5,6 +5,7 @@ import com.lobby.data.PlayerData;
 import com.lobby.economy.EconomyManager;
 import com.lobby.holograms.HologramManager;
 import com.lobby.npcs.NPCManager;
+import com.lobby.lobby.LobbyManager;
 import com.lobby.utils.MessageUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -28,13 +29,16 @@ public class AdminCommands implements CommandExecutor, TabExecutor {
     private final EconomyManager economyManager;
     private final HologramCommands hologramCommands;
     private final NPCCommands npcCommands;
+    private final LobbyManager lobbyManager;
 
     public AdminCommands(final LobbyPlugin plugin, final EconomyManager economyManager,
-                         final HologramManager hologramManager, final NPCManager npcManager) {
+                         final HologramManager hologramManager, final NPCManager npcManager,
+                         final LobbyManager lobbyManager) {
         this.plugin = plugin;
         this.economyManager = economyManager;
         this.hologramCommands = new HologramCommands(hologramManager);
         this.npcCommands = new NPCCommands(npcManager);
+        this.lobbyManager = lobbyManager;
     }
 
     @Override
@@ -55,6 +59,14 @@ public class AdminCommands implements CommandExecutor, TabExecutor {
             final String[] npcArgs = Arrays.copyOfRange(args, 1, args.length);
             npcCommands.handle(sender, npcArgs);
             return true;
+        }
+
+        if (subCommand.equals("setlobby")) {
+            return handleSetLobby(sender);
+        }
+
+        if (subCommand.equals("bypass")) {
+            return handleBypass(sender);
         }
 
         if (!sender.hasPermission("lobby.admin.economy")) {
@@ -84,7 +96,7 @@ public class AdminCommands implements CommandExecutor, TabExecutor {
         }
 
         if (args.length == 1) {
-            final List<String> options = List.of("give", "take", "balance", "holo", "hologram", "npc");
+            final List<String> options = List.of("give", "take", "balance", "holo", "hologram", "npc", "setlobby", "bypass");
             final String prefix = args[0].toLowerCase(Locale.ROOT);
             return options.stream().filter(option -> option.startsWith(prefix)).toList();
         }
@@ -116,6 +128,44 @@ public class AdminCommands implements CommandExecutor, TabExecutor {
         }
 
         return Collections.emptyList();
+    }
+
+    private boolean handleSetLobby(final CommandSender sender) {
+        if (!(sender instanceof Player player)) {
+            MessageUtils.sendConfigMessage(sender, "commands.player_only");
+            return true;
+        }
+        if (lobbyManager == null) {
+            MessageUtils.sendConfigMessage(sender, "lobby.teleport_failed");
+            return true;
+        }
+        lobbyManager.saveSpawn(player.getLocation());
+        MessageUtils.sendConfigMessage(sender, "lobby.spawn_set", Map.of(
+                "world", player.getWorld().getName(),
+                "x", String.format(Locale.ROOT, "%.2f", player.getLocation().getX()),
+                "y", String.format(Locale.ROOT, "%.2f", player.getLocation().getY()),
+                "z", String.format(Locale.ROOT, "%.2f", player.getLocation().getZ())
+        ));
+        return true;
+    }
+
+    private boolean handleBypass(final CommandSender sender) {
+        if (!(sender instanceof Player player)) {
+            MessageUtils.sendConfigMessage(sender, "commands.player_only");
+            return true;
+        }
+        if (!player.hasPermission("lobby.admin.bypass")) {
+            MessageUtils.sendPrefixedMessage(player, plugin.getConfigManager().getMessagesConfig().getString("no_permission"));
+            return true;
+        }
+        if (lobbyManager == null) {
+            MessageUtils.sendConfigMessage(player, "lobby.teleport_failed");
+            return true;
+        }
+        final boolean enabled = lobbyManager.toggleBypass(player);
+        final String path = enabled ? "lobby.bypass_enabled" : "lobby.bypass_disabled";
+        MessageUtils.sendConfigMessage(player, path);
+        return true;
     }
 
     private boolean handleGive(final CommandSender sender, final String[] args) {

--- a/src/main/java/com/lobby/commands/PlayerCommands.java
+++ b/src/main/java/com/lobby/commands/PlayerCommands.java
@@ -1,5 +1,6 @@
 package com.lobby.commands;
 
+import com.lobby.lobby.LobbyManager;
 import com.lobby.utils.MessageUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -15,12 +16,17 @@ import java.util.Map;
 public class PlayerCommands implements CommandExecutor, TabExecutor {
 
     private static final Map<String, String> COMMAND_MESSAGES = Map.of(
-            "lobby", "commands.lobby_unavailable",
             "shop", "commands.shop_unavailable",
             "serveurs", "commands.servers_unavailable",
             "profil", "commands.profile_unavailable",
             "discord", "commands.discord_unavailable"
     );
+
+    private final LobbyManager lobbyManager;
+
+    public PlayerCommands(final LobbyManager lobbyManager) {
+        this.lobbyManager = lobbyManager;
+    }
 
     @Override
     public boolean onCommand(final CommandSender sender, final Command command, final String label, final String[] args) {
@@ -30,6 +36,10 @@ public class PlayerCommands implements CommandExecutor, TabExecutor {
         }
 
         final String commandName = command.getName().toLowerCase(Locale.ROOT);
+        if (commandName.equals("lobby")) {
+            handleLobbyCommand((Player) sender);
+            return true;
+        }
         final String messagePath = COMMAND_MESSAGES.getOrDefault(commandName, "commands.unavailable");
         MessageUtils.sendConfigMessage(sender, messagePath, Map.of("command", "/" + label));
         return true;
@@ -38,5 +48,32 @@ public class PlayerCommands implements CommandExecutor, TabExecutor {
     @Override
     public List<String> onTabComplete(final CommandSender sender, final Command command, final String alias, final String[] args) {
         return Collections.emptyList();
+    }
+
+    private void handleLobbyCommand(final Player player) {
+        if (lobbyManager == null) {
+            MessageUtils.sendConfigMessage(player, "lobby.teleport_failed");
+            return;
+        }
+        final boolean hasSpawn = lobbyManager.hasLobbySpawn();
+        final boolean teleported = lobbyManager.teleportToLobby(player);
+        if (!lobbyManager.isBypassing(player)) {
+            lobbyManager.preparePlayer(player);
+        }
+        if (!hasSpawn) {
+            if (player.hasPermission("lobby.admin")) {
+                MessageUtils.sendConfigMessage(player, "lobby.spawn_not_set");
+            } else {
+                MessageUtils.sendConfigMessage(player, "lobby.teleport_failed");
+            }
+            return;
+        }
+        if (teleported) {
+            MessageUtils.sendConfigMessage(player, "lobby.teleport_success");
+        } else if (player.hasPermission("lobby.admin")) {
+            MessageUtils.sendConfigMessage(player, "lobby.spawn_not_set");
+        } else {
+            MessageUtils.sendConfigMessage(player, "lobby.teleport_failed");
+        }
     }
 }

--- a/src/main/java/com/lobby/lobby/LobbyManager.java
+++ b/src/main/java/com/lobby/lobby/LobbyManager.java
@@ -1,0 +1,263 @@
+package com.lobby.lobby;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.utils.MessageUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.GameRule;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.potion.PotionEffect;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class LobbyManager {
+
+    private final LobbyPlugin plugin;
+    private final Set<UUID> bypassPlayers = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private Location lobbySpawn;
+
+    public LobbyManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        loadSpawn();
+    }
+
+    public void reload() {
+        loadSpawn();
+        applyWorldSettings();
+    }
+
+    public void loadSpawn() {
+        final FileConfiguration config = plugin.getConfig();
+        final String worldName = config.getString("lobby.spawn.world");
+        if (worldName == null || worldName.isEmpty()) {
+            lobbySpawn = null;
+            return;
+        }
+
+        final World world = Bukkit.getWorld(worldName);
+        if (world == null) {
+            plugin.getLogger().warning("Lobby spawn world '" + worldName + "' introuvable.");
+            lobbySpawn = null;
+            return;
+        }
+
+        final double x = config.getDouble("lobby.spawn.x");
+        final double y = config.getDouble("lobby.spawn.y");
+        final double z = config.getDouble("lobby.spawn.z");
+        final float yaw = (float) config.getDouble("lobby.spawn.yaw");
+        final float pitch = (float) config.getDouble("lobby.spawn.pitch");
+        lobbySpawn = new Location(world, x, y, z, yaw, pitch);
+    }
+
+    public void saveSpawn(final Location location) {
+        if (location == null || location.getWorld() == null) {
+            return;
+        }
+        lobbySpawn = location.clone();
+        final FileConfiguration config = plugin.getConfig();
+        config.set("lobby.spawn.world", location.getWorld().getName());
+        config.set("lobby.spawn.x", location.getX());
+        config.set("lobby.spawn.y", location.getY());
+        config.set("lobby.spawn.z", location.getZ());
+        config.set("lobby.spawn.yaw", location.getYaw());
+        config.set("lobby.spawn.pitch", location.getPitch());
+        plugin.saveConfig();
+        applyWorldSettings();
+    }
+
+    public Location getLobbySpawn() {
+        if (lobbySpawn != null && lobbySpawn.getWorld() != null) {
+            return lobbySpawn.clone();
+        }
+        final World defaultWorld = Bukkit.getWorlds().isEmpty() ? null : Bukkit.getWorlds().get(0);
+        return defaultWorld != null ? defaultWorld.getSpawnLocation() : null;
+    }
+
+    public boolean hasLobbySpawn() {
+        return lobbySpawn != null && lobbySpawn.getWorld() != null;
+    }
+
+    public boolean isBypassing(final Player player) {
+        return player != null && bypassPlayers.contains(player.getUniqueId());
+    }
+
+    public boolean toggleBypass(final Player player) {
+        if (player == null) {
+            return false;
+        }
+        final UUID uniqueId = player.getUniqueId();
+        if (bypassPlayers.contains(uniqueId)) {
+            bypassPlayers.remove(uniqueId);
+            return false;
+        }
+        bypassPlayers.add(uniqueId);
+        return true;
+    }
+
+    public void removeBypass(final UUID uniqueId) {
+        if (uniqueId != null) {
+            bypassPlayers.remove(uniqueId);
+        }
+    }
+
+    public void applyWorldSettings() {
+        final World world = getLobbyWorld();
+        if (world == null) {
+            return;
+        }
+        final FileConfiguration config = plugin.getConfig();
+        final ConfigurationSection worldSection = config.getConfigurationSection("lobby.world");
+        if (worldSection != null) {
+            if (worldSection.getBoolean("freeze_time", true)) {
+                world.setGameRule(GameRule.DO_DAYLIGHT_CYCLE, false);
+                world.setTime(worldSection.getLong("time", 6000L));
+            } else {
+                world.setGameRule(GameRule.DO_DAYLIGHT_CYCLE, true);
+            }
+
+            if (worldSection.getBoolean("freeze_weather", true)) {
+                world.setGameRule(GameRule.DO_WEATHER_CYCLE, false);
+                world.setStorm(false);
+                world.setThundering(false);
+                world.setWeatherDuration(0);
+                world.setThunderDuration(0);
+            } else {
+                world.setGameRule(GameRule.DO_WEATHER_CYCLE, true);
+            }
+
+            final ConfigurationSection gamerules = worldSection.getConfigurationSection("gamerules");
+            if (gamerules != null) {
+                if (gamerules.contains("do_mob_spawning")) {
+                    world.setGameRule(GameRule.DO_MOB_SPAWNING, gamerules.getBoolean("do_mob_spawning"));
+                }
+                if (gamerules.contains("do_fire_tick")) {
+                    world.setGameRule(GameRule.DO_FIRE_TICK, gamerules.getBoolean("do_fire_tick"));
+                }
+                if (gamerules.contains("keep_inventory")) {
+                    world.setGameRule(GameRule.KEEP_INVENTORY, gamerules.getBoolean("keep_inventory"));
+                }
+                if (gamerules.contains("show_death_messages")) {
+                    world.setGameRule(GameRule.SHOW_DEATH_MESSAGES, gamerules.getBoolean("show_death_messages"));
+                }
+                if (gamerules.contains("random_tick_speed")) {
+                    world.setGameRule(GameRule.RANDOM_TICK_SPEED, gamerules.getInt("random_tick_speed"));
+                }
+            }
+        }
+    }
+
+    public double getVoidTeleportY() {
+        return plugin.getConfig().getDouble("lobby.protection.void_teleport_y", 0.0D);
+    }
+
+    public void preparePlayer(final Player player) {
+        if (player == null) {
+            return;
+        }
+        player.getInventory().clear();
+        player.getInventory().setArmorContents(null);
+        player.getInventory().setExtraContents(new ItemStack[0]);
+        player.getInventory().setItemInOffHand(null);
+        player.setFireTicks(0);
+        player.setFallDistance(0);
+        player.setHealth(player.getMaxHealth());
+        player.setFoodLevel(20);
+        player.setSaturation(20.0F);
+        player.getActivePotionEffects().stream()
+                .map(PotionEffect::getType)
+                .forEach(player::removePotionEffect);
+        giveLobbyItems(player);
+    }
+
+    public void giveLobbyItems(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final FileConfiguration config = plugin.getConfig();
+        if (!config.getBoolean("lobby.inventory.enabled", true)) {
+            return;
+        }
+        final ConfigurationSection itemsSection = config.getConfigurationSection("lobby.inventory.items");
+        if (itemsSection == null) {
+            return;
+        }
+        final PlayerInventory inventory = player.getInventory();
+        for (String key : itemsSection.getKeys(false)) {
+            final ConfigurationSection itemSection = itemsSection.getConfigurationSection(key);
+            if (itemSection == null) {
+                continue;
+            }
+            final String materialName = itemSection.getString("material", "STONE");
+            final Material material = Material.matchMaterial(materialName);
+            if (material == null) {
+                plugin.getLogger().warning("Matériau invalide pour l'item de lobby '" + key + "': " + materialName);
+                continue;
+            }
+            final int amount = Math.max(1, itemSection.getInt("amount", 1));
+            final ItemStack itemStack = new ItemStack(material, amount);
+            final ItemMeta meta = itemStack.getItemMeta();
+            if (meta != null) {
+                if (itemSection.isString("name")) {
+                    meta.setDisplayName(MessageUtils.colorize(itemSection.getString("name")));
+                }
+                if (itemSection.isList("lore")) {
+                    meta.setLore(itemSection.getStringList("lore").stream()
+                            .map(MessageUtils::colorize)
+                            .toList());
+                }
+                itemStack.setItemMeta(meta);
+            }
+            final int slot = itemSection.getInt("slot", -1);
+            if (slot >= 0 && slot < inventory.getSize()) {
+                inventory.setItem(slot, itemStack);
+            } else {
+                inventory.addItem(itemStack);
+            }
+        }
+        final int heldSlot = config.getInt("lobby.inventory.held_slot", inventory.getHeldItemSlot());
+        if (heldSlot >= 0 && heldSlot < 9) {
+            inventory.setHeldItemSlot(heldSlot);
+        }
+        player.updateInventory();
+    }
+
+    public boolean teleportToLobby(final Player player) {
+        final Location spawn = getLobbySpawn();
+        if (player == null || spawn == null) {
+            return false;
+        }
+        final boolean result = player.teleport(spawn);
+        if (result) {
+            player.setFallDistance(0.0F);
+            player.setFireTicks(0);
+        }
+        return result;
+    }
+
+    public boolean isLobbyWorld(final World world) {
+        final World spawnWorld = hasLobbySpawn() ? Objects.requireNonNull(lobbySpawn).getWorld() : getLobbyWorld();
+        return spawnWorld != null && spawnWorld.equals(world);
+    }
+
+    public World getLobbyWorld() {
+        if (lobbySpawn != null && lobbySpawn.getWorld() != null) {
+            return lobbySpawn.getWorld();
+        }
+        return Bukkit.getWorlds().isEmpty() ? null : Bukkit.getWorlds().get(0);
+    }
+
+    public void shutdown() {
+        bypassPlayers.clear();
+    }
+}

--- a/src/main/java/com/lobby/lobby/listeners/LobbyPlayerListener.java
+++ b/src/main/java/com/lobby/lobby/listeners/LobbyPlayerListener.java
@@ -1,0 +1,102 @@
+package com.lobby.lobby.listeners;
+
+import com.lobby.lobby.LobbyManager;
+import com.lobby.utils.MessageUtils;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerKickEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+
+public class LobbyPlayerListener implements Listener {
+
+    private final LobbyManager lobbyManager;
+
+    public LobbyPlayerListener(final LobbyManager lobbyManager) {
+        this.lobbyManager = lobbyManager;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerJoin(final PlayerJoinEvent event) {
+        final Player player = event.getPlayer();
+        final boolean hasSpawn = lobbyManager.hasLobbySpawn();
+        final boolean teleported = lobbyManager.teleportToLobby(player);
+        lobbyManager.preparePlayer(player);
+        if (!hasSpawn && player.hasPermission("lobby.admin")) {
+            MessageUtils.sendConfigMessage(player, "lobby.spawn_not_set");
+        } else if (!teleported) {
+            MessageUtils.sendConfigMessage(player, "lobby.teleport_failed");
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerMove(final PlayerMoveEvent event) {
+        final Location to = event.getTo();
+        if (to == null) {
+            return;
+        }
+        final Player player = event.getPlayer();
+        if (!lobbyManager.isLobbyWorld(player.getWorld())) {
+            return;
+        }
+        if (player.getGameMode() == GameMode.SPECTATOR) {
+            return;
+        }
+        if (to.getY() < lobbyManager.getVoidTeleportY()) {
+            lobbyManager.teleportToLobby(player);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerRespawn(final PlayerRespawnEvent event) {
+        final Location spawn = lobbyManager.getLobbySpawn();
+        if (spawn != null) {
+            event.setRespawnLocation(spawn);
+        }
+        final Player player = event.getPlayer();
+        if (!lobbyManager.isBypassing(player)) {
+            lobbyManager.preparePlayer(player);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerQuit(final PlayerQuitEvent event) {
+        lobbyManager.removeBypass(event.getPlayer().getUniqueId());
+    }
+
+    @EventHandler
+    public void onPlayerKick(final PlayerKickEvent event) {
+        lobbyManager.removeBypass(event.getPlayer().getUniqueId());
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
+    public void onItemDrop(final PlayerDropItemEvent event) {
+        final Player player = event.getPlayer();
+        if (!lobbyManager.isLobbyWorld(player.getWorld())) {
+            return;
+        }
+        if (!lobbyManager.isBypassing(player)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
+    public void onItemPickup(final EntityPickupItemEvent event) {
+        if (event.getEntity() instanceof Player player) {
+            if (!lobbyManager.isLobbyWorld(player.getWorld())) {
+                return;
+            }
+            if (!lobbyManager.isBypassing(player)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+}

--- a/src/main/java/com/lobby/lobby/listeners/LobbyProtectionListener.java
+++ b/src/main/java/com/lobby/lobby/listeners/LobbyProtectionListener.java
@@ -1,0 +1,203 @@
+package com.lobby.lobby.listeners;
+
+import com.lobby.lobby.LobbyManager;
+import org.bukkit.Material;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockBurnEvent;
+import org.bukkit.event.block.BlockFadeEvent;
+import org.bukkit.event.block.BlockFormEvent;
+import org.bukkit.event.block.BlockIgniteEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.BlockSpreadEvent;
+import org.bukkit.event.block.LeavesDecayEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.weather.ThunderChangeEvent;
+import org.bukkit.event.weather.WeatherChangeEvent;
+
+public class LobbyProtectionListener implements Listener {
+
+    private final LobbyManager lobbyManager;
+
+    public LobbyProtectionListener(final LobbyManager lobbyManager) {
+        this.lobbyManager = lobbyManager;
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
+    public void onBlockBreak(final BlockBreakEvent event) {
+        if (!lobbyManager.isLobbyWorld(event.getBlock().getWorld())) {
+            return;
+        }
+        if (!lobbyManager.isBypassing(event.getPlayer())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
+    public void onBlockPlace(final BlockPlaceEvent event) {
+        if (!lobbyManager.isLobbyWorld(event.getBlock().getWorld())) {
+            return;
+        }
+        if (!lobbyManager.isBypassing(event.getPlayer())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
+    public void onPlayerInteract(final PlayerInteractEvent event) {
+        final Player player = event.getPlayer();
+        if (!lobbyManager.isLobbyWorld(player.getWorld())) {
+            return;
+        }
+        if (lobbyManager.isBypassing(player)) {
+            return;
+        }
+        if (event.getClickedBlock() != null || event.getAction() == Action.PHYSICAL) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
+    public void onArmorStandManipulate(final PlayerArmorStandManipulateEvent event) {
+        if (!lobbyManager.isLobbyWorld(event.getRightClicked().getWorld())) {
+            return;
+        }
+        if (!lobbyManager.isBypassing(event.getPlayer())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
+    public void onEntityDamage(final EntityDamageEvent event) {
+        final Entity entity = event.getEntity();
+        if (!lobbyManager.isLobbyWorld(entity.getWorld())) {
+            return;
+        }
+        if (entity instanceof ArmorStand) {
+            event.setCancelled(true);
+            return;
+        }
+        if (entity instanceof Player player) {
+            if (event.getCause() == DamageCause.FALL) {
+                event.setCancelled(true);
+                return;
+            }
+            if (event.getCause() == DamageCause.VOID) {
+                event.setCancelled(true);
+                lobbyManager.teleportToLobby(player);
+            }
+            return;
+        }
+        if (lobbyManager.isLobbyWorld(entity.getWorld())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
+    public void onEntityDamageByEntity(final EntityDamageByEntityEvent event) {
+        final Entity target = event.getEntity();
+        if (!lobbyManager.isLobbyWorld(target.getWorld())) {
+            return;
+        }
+        if (target instanceof ArmorStand) {
+            event.setCancelled(true);
+            return;
+        }
+        if (target instanceof Player && event.getDamager() instanceof Player) {
+            event.setCancelled(true);
+            return;
+        }
+        if (event.getDamager() instanceof Player player) {
+            if (!lobbyManager.isBypassing(player)) {
+                event.setCancelled(true);
+            }
+            return;
+        }
+        if (event.getDamager() instanceof Projectile projectile && projectile.getShooter() instanceof Player shooter) {
+            if (target instanceof Player || !lobbyManager.isBypassing((Player) shooter)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.NORMAL)
+    public void onFoodLevelChange(final FoodLevelChangeEvent event) {
+        if (event.getEntity() instanceof Player player && lobbyManager.isLobbyWorld(player.getWorld())) {
+            event.setCancelled(true);
+            player.setFoodLevel(20);
+            player.setSaturation(20.0F);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onWeatherChange(final WeatherChangeEvent event) {
+        if (event.toWeatherState() && lobbyManager.isLobbyWorld(event.getWorld())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onThunderChange(final ThunderChangeEvent event) {
+        if (event.toThunderState() && lobbyManager.isLobbyWorld(event.getWorld())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockBurn(final BlockBurnEvent event) {
+        if (lobbyManager.isLobbyWorld(event.getBlock().getWorld())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockIgnite(final BlockIgniteEvent event) {
+        if (lobbyManager.isLobbyWorld(event.getBlock().getWorld())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockSpread(final BlockSpreadEvent event) {
+        if (lobbyManager.isLobbyWorld(event.getBlock().getWorld())) {
+            if (event.getSource() != null
+                    && (event.getSource().getType() == Material.FIRE || event.getBlock().getType() == Material.FIRE)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onLeavesDecay(final LeavesDecayEvent event) {
+        if (lobbyManager.isLobbyWorld(event.getBlock().getWorld())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockFade(final BlockFadeEvent event) {
+        if (lobbyManager.isLobbyWorld(event.getBlock().getWorld())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockForm(final BlockFormEvent event) {
+        if (lobbyManager.isLobbyWorld(event.getBlock().getWorld())) {
+            event.setCancelled(true);
+        }
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -41,3 +41,46 @@ npcs:
 
 discord:
   enabled: false
+
+lobby:
+  spawn:
+    world: "world"
+    x: 0.5
+    y: 65.0
+    z: 0.5
+    yaw: 0.0
+    pitch: 0.0
+  world:
+    freeze_time: true
+    time: 6000
+    freeze_weather: true
+    gamerules:
+      do_mob_spawning: false
+      do_fire_tick: false
+      keep_inventory: true
+      show_death_messages: false
+      random_tick_speed: 0
+  protection:
+    void_teleport_y: 0.0
+  inventory:
+    enabled: true
+    held_slot: 4
+    items:
+      navigator:
+        material: COMPASS
+        slot: 0
+        name: "&aSélecteur de serveurs"
+        lore:
+          - "&7Clique pour choisir un serveur"
+      profile:
+        material: CLOCK
+        slot: 4
+        name: "&bProfil joueur"
+        lore:
+          - "&7Consulte tes informations"
+      cosmetics:
+        material: NETHER_STAR
+        slot: 8
+        name: "&dCosmétiques"
+        lore:
+          - "&7Découvre des gadgets uniques"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -96,3 +96,10 @@ npc:
   info_position: "&ePosition: &f{x}, {y}, {z}"
   info_actions_header: "&eActions (&6{count}&e) :"
   info_action_entry: "&7  {index}. &f{action}"
+lobby:
+  teleport_success: "&aTéléportation vers le lobby !"
+  teleport_failed: "&cLe point de spawn du lobby est introuvable."
+  spawn_not_set: "&cLe spawn du lobby n'est pas défini. Utilisez &e/lobbyadmin setlobby&c."
+  spawn_set: "&aSpawn du lobby défini sur &e{world} &7({x}, {y}, {z})"
+  bypass_enabled: "&aMode bypass du lobby activé."
+  bypass_disabled: "&cMode bypass du lobby désactivé."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -61,3 +61,5 @@ permissions:
     default: op
   lobby.admin.npc:
     default: op
+  lobby.admin.bypass:
+    default: op


### PR DESCRIPTION
## Summary
- introduce a LobbyManager to persist the spawn, manage bypass mode and configure the lobby world and inventory
- register comprehensive protection and player listeners to enforce anti-grief rules, ambience controls and spawn handling
- extend commands, config and messages to support /lobby teleports, /lobbyadmin setlobby & bypass, and lobby starter items

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6dbe90c48329a390f49ce009f530