### PR TITLE
Implement configurable GUI menu system

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -9,6 +9,7 @@ import com.lobby.core.DatabaseManager;
 import com.lobby.core.PlayerDataManager;
 import com.lobby.economy.EconomyManager;
 import com.lobby.holograms.HologramManager;
+import com.lobby.menus.MenuManager;
 import com.lobby.npcs.NPCInteractionHandler;
 import com.lobby.npcs.NPCManager;
 import com.lobby.events.PlayerJoinLeaveEvent;
@@ -31,6 +32,7 @@ public final class LobbyPlugin extends JavaPlugin {
     private HologramManager hologramManager;
     private NPCManager npcManager;
     private LobbyManager lobbyManager;
+    private MenuManager menuManager;
 
     public static LobbyPlugin getInstance() {
         return instance;
@@ -58,6 +60,7 @@ public final class LobbyPlugin extends JavaPlugin {
         npcManager.initialize();
         lobbyManager = new LobbyManager(this);
         lobbyManager.applyWorldSettings();
+        menuManager = new MenuManager(this);
 
         registerCommands();
 
@@ -86,6 +89,9 @@ public final class LobbyPlugin extends JavaPlugin {
         if (lobbyManager != null) {
             lobbyManager.shutdown();
         }
+        if (menuManager != null) {
+            menuManager.closeAll();
+        }
         instance = null;
     }
 
@@ -113,6 +119,10 @@ public final class LobbyPlugin extends JavaPlugin {
         return npcManager;
     }
 
+    public MenuManager getMenuManager() {
+        return menuManager;
+    }
+
     public LobbyManager getLobbyManager() {
         return lobbyManager;
     }
@@ -136,10 +146,13 @@ public final class LobbyPlugin extends JavaPlugin {
         if (lobbyManager != null) {
             lobbyManager.reload();
         }
+        if (menuManager != null) {
+            menuManager.closeAll();
+        }
     }
 
     private void registerCommands() {
-        final PlayerCommands playerCommands = new PlayerCommands(lobbyManager);
+        final PlayerCommands playerCommands = new PlayerCommands(lobbyManager, menuManager);
         registerCommand("lobby", playerCommands);
         registerCommand("shop", playerCommands);
         registerCommand("serveurs", playerCommands);

--- a/src/main/java/com/lobby/commands/PlayerCommands.java
+++ b/src/main/java/com/lobby/commands/PlayerCommands.java
@@ -1,6 +1,7 @@
 package com.lobby.commands;
 
 import com.lobby.lobby.LobbyManager;
+import com.lobby.menus.MenuManager;
 import com.lobby.utils.MessageUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -22,10 +23,18 @@ public class PlayerCommands implements CommandExecutor, TabExecutor {
             "discord", "commands.discord_unavailable"
     );
 
-    private final LobbyManager lobbyManager;
+    private static final Map<String, String> MENU_COMMANDS = Map.of(
+            "shop", "shop_menu",
+            "serveurs", "servers_menu",
+            "profil", "profile_menu"
+    );
 
-    public PlayerCommands(final LobbyManager lobbyManager) {
+    private final LobbyManager lobbyManager;
+    private final MenuManager menuManager;
+
+    public PlayerCommands(final LobbyManager lobbyManager, final MenuManager menuManager) {
         this.lobbyManager = lobbyManager;
+        this.menuManager = menuManager;
     }
 
     @Override
@@ -36,12 +45,22 @@ public class PlayerCommands implements CommandExecutor, TabExecutor {
         }
 
         final String commandName = command.getName().toLowerCase(Locale.ROOT);
+        final Player player = (Player) sender;
         if (commandName.equals("lobby")) {
-            handleLobbyCommand((Player) sender);
+            handleLobbyCommand(player);
+            return true;
+        }
+        if (MENU_COMMANDS.containsKey(commandName)) {
+            final String menuId = MENU_COMMANDS.get(commandName);
+            final boolean opened = menuManager != null && menuManager.openMenu(player, menuId);
+            if (!opened) {
+                final String messagePath = COMMAND_MESSAGES.getOrDefault(commandName, "commands.unavailable");
+                MessageUtils.sendConfigMessage(player, messagePath, Map.of("command", "/" + label));
+            }
             return true;
         }
         final String messagePath = COMMAND_MESSAGES.getOrDefault(commandName, "commands.unavailable");
-        MessageUtils.sendConfigMessage(sender, messagePath, Map.of("command", "/" + label));
+        MessageUtils.sendConfigMessage(player, messagePath, Map.of("command", "/" + label));
         return true;
     }
 

--- a/src/main/java/com/lobby/core/ConfigManager.java
+++ b/src/main/java/com/lobby/core/ConfigManager.java
@@ -14,7 +14,9 @@ public class ConfigManager {
 
     private final LobbyPlugin plugin;
     private FileConfiguration messagesConfig;
+    private FileConfiguration menusConfig;
     private File messagesFile;
+    private File menusFile;
 
     public ConfigManager(final LobbyPlugin plugin) {
         this.plugin = plugin;
@@ -24,11 +26,13 @@ public class ConfigManager {
         plugin.saveDefaultConfig();
         plugin.reloadConfig();
         loadMessages();
+        loadMenus();
     }
 
     public void reloadConfigs() {
         plugin.reloadConfig();
         loadMessages();
+        loadMenus();
     }
 
     public FileConfiguration getMainConfig() {
@@ -40,6 +44,13 @@ public class ConfigManager {
             loadMessages();
         }
         return messagesConfig;
+    }
+
+    public FileConfiguration getMenusConfig() {
+        if (menusConfig == null) {
+            loadMenus();
+        }
+        return menusConfig;
     }
 
     public boolean isDebugEnabled() {
@@ -77,6 +88,44 @@ public class ConfigManager {
             }
         } catch (IOException | InvalidConfigurationException exception) {
             plugin.getLogger().severe("Unable to load default messages.yml: " + exception.getMessage());
+        }
+    }
+
+    private void loadMenus() {
+        if (menusFile == null) {
+            final File configDirectory = new File(plugin.getDataFolder(), "config");
+            if (!configDirectory.exists() && !configDirectory.mkdirs()) {
+                plugin.getLogger().severe("Unable to create config directory for menus.");
+            }
+            menusFile = new File(configDirectory, "menus.yml");
+        }
+
+        if (!plugin.getDataFolder().exists() && !plugin.getDataFolder().mkdirs()) {
+            plugin.getLogger().severe("Unable to create plugin data folder for configuration files.");
+        }
+
+        if (!menusFile.exists()) {
+            plugin.saveResource("config/menus.yml", false);
+        }
+
+        menusConfig = new YamlConfiguration();
+        try {
+            menusConfig.load(menusFile);
+        } catch (IOException | InvalidConfigurationException exception) {
+            plugin.getLogger().severe("Unable to load config/menus.yml: " + exception.getMessage());
+            loadDefaultMenus();
+        }
+    }
+
+    private void loadDefaultMenus() {
+        menusConfig = new YamlConfiguration();
+        try (InputStream inputStream = plugin.getResource("config/menus.yml")) {
+            if (inputStream != null) {
+                Files.copy(inputStream, menusFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                menusConfig.load(menusFile);
+            }
+        } catch (IOException | InvalidConfigurationException exception) {
+            plugin.getLogger().severe("Unable to load default config/menus.yml: " + exception.getMessage());
         }
     }
 }

--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -1,0 +1,203 @@
+package com.lobby.menus;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.npcs.ActionProcessor;
+import com.lobby.utils.LogUtils;
+import com.lobby.utils.MessageUtils;
+import com.lobby.utils.PlaceholderUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class ConfiguredMenu implements Menu {
+
+    private final LobbyPlugin plugin;
+    private final String menuId;
+    private final ConfigurationSection menuSection;
+    private Inventory inventory;
+    private final Map<Integer, List<String>> actionsBySlot = new HashMap<>();
+
+    public ConfiguredMenu(final LobbyPlugin plugin, final String menuId, final ConfigurationSection menuSection) {
+        this.plugin = plugin;
+        this.menuId = menuId;
+        this.menuSection = menuSection;
+    }
+
+    @Override
+    public void open(final Player player) {
+        final String rawTitle = menuSection.getString("title", "Menu");
+        final String title = MessageUtils.colorize(PlaceholderUtils.applyPlaceholders(plugin, rawTitle, player));
+        final int size = normalizeSize(menuSection.getInt("size", 27));
+        inventory = Bukkit.createInventory(null, size, title);
+        actionsBySlot.clear();
+
+        final ConfigurationSection itemsSection = menuSection.getConfigurationSection("items");
+        if (itemsSection != null) {
+            for (String key : itemsSection.getKeys(false)) {
+                final ConfigurationSection itemSection = itemsSection.getConfigurationSection(key);
+                if (itemSection == null) {
+                    continue;
+                }
+                final Optional<Integer> slot = createItem(player, itemSection);
+                slot.ifPresent(index -> storeActions(index, itemSection.getStringList("actions")));
+            }
+        }
+
+        player.openInventory(inventory);
+    }
+
+    @Override
+    public void handleClick(final InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (inventory == null) {
+            return;
+        }
+        final int rawSlot = event.getRawSlot();
+        if (rawSlot < 0 || rawSlot >= inventory.getSize()) {
+            return;
+        }
+        final List<String> actions = actionsBySlot.get(rawSlot);
+        if (actions == null || actions.isEmpty()) {
+            return;
+        }
+        final ActionProcessor actionProcessor = resolveActionProcessor();
+        if (actionProcessor == null) {
+            LogUtils.warning(plugin, "Attempted to execute menu actions but no ActionProcessor is available.");
+            return;
+        }
+        actionProcessor.processActions(actions, player, null);
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    private Optional<Integer> createItem(final Player player, final ConfigurationSection itemSection) {
+        final String materialName = itemSection.getString("material", "STONE");
+        final Material material = Material.matchMaterial(materialName);
+        if (material == null) {
+            LogUtils.warning(plugin, "Invalid material '" + materialName + "' in menu '" + menuId + "'.");
+            return Optional.empty();
+        }
+
+        final int amount = Math.max(1, itemSection.getInt("amount", 1));
+        final ItemStack itemStack = new ItemStack(material, amount);
+        final ItemMeta meta = itemStack.getItemMeta();
+        if (meta != null) {
+            if (itemSection.isString("name")) {
+                final String name = MessageUtils.colorize(PlaceholderUtils.applyPlaceholders(plugin,
+                        itemSection.getString("name"), player));
+                meta.setDisplayName(name);
+            }
+
+            if (itemSection.isList("lore")) {
+                final List<String> lore = PlaceholderUtils.applyPlaceholders(plugin, itemSection.getStringList("lore"), player)
+                        .stream()
+                        .map(MessageUtils::colorize)
+                        .toList();
+                meta.setLore(lore);
+            }
+
+            if (itemSection.contains("custom_model_data")) {
+                meta.setCustomModelData(itemSection.getInt("custom_model_data"));
+            }
+
+            if (itemSection.getBoolean("glow", false)) {
+                meta.addItemFlags(ItemFlag.values());
+                meta.addEnchant(org.bukkit.enchantments.Enchantment.DURABILITY, 1, true);
+            }
+
+            if (meta instanceof SkullMeta skullMeta) {
+                applyHead(itemSection, player, skullMeta);
+            }
+
+            itemStack.setItemMeta(meta);
+        }
+
+        final int slot = itemSection.getInt("slot", -1);
+        final int targetSlot = resolveSlot(slot, itemStack);
+        if (targetSlot < 0) {
+            return Optional.empty();
+        }
+        return Optional.of(targetSlot);
+    }
+
+    private void applyHead(final ConfigurationSection itemSection, final Player player, final SkullMeta skullMeta) {
+        final String head = itemSection.getString("head");
+        if (head == null || head.isEmpty()) {
+            return;
+        }
+        if (player != null && head.equalsIgnoreCase("%player_name%")) {
+            skullMeta.setOwningPlayer(player);
+            return;
+        }
+        final String processed = PlaceholderUtils.applyPlaceholders(plugin, head, player);
+        if (player != null && processed.equalsIgnoreCase(player.getName())) {
+            skullMeta.setOwningPlayer(player);
+            return;
+        }
+        final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(processed);
+        skullMeta.setOwningPlayer(offlinePlayer);
+    }
+
+    private void storeActions(final int slot, final List<String> actions) {
+        if (actions == null || actions.isEmpty()) {
+            return;
+        }
+        final List<String> sanitized = new ArrayList<>();
+        for (String action : actions) {
+            if (action == null || action.isBlank()) {
+                continue;
+            }
+            sanitized.add(action.trim());
+        }
+        if (!sanitized.isEmpty()) {
+            actionsBySlot.put(slot, List.copyOf(sanitized));
+        }
+    }
+
+    private int resolveSlot(final int slot, final ItemStack itemStack) {
+        if (inventory == null) {
+            return -1;
+        }
+        if (slot >= 0 && slot < inventory.getSize()) {
+            inventory.setItem(slot, itemStack);
+            return slot;
+        }
+        final int firstEmpty = inventory.firstEmpty();
+        if (firstEmpty >= 0) {
+            inventory.setItem(firstEmpty, itemStack);
+            return firstEmpty;
+        }
+        return -1;
+    }
+
+    private int normalizeSize(final int requested) {
+        final int clamped = Math.max(9, Math.min(54, requested));
+        final int remainder = clamped % 9;
+        return remainder == 0 ? clamped : clamped + (9 - remainder);
+    }
+
+    private ActionProcessor resolveActionProcessor() {
+        return Optional.ofNullable(plugin.getNpcManager())
+                .map(npcManager -> npcManager.getActionProcessor())
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/lobby/menus/Menu.java
+++ b/src/main/java/com/lobby/menus/Menu.java
@@ -1,0 +1,14 @@
+package com.lobby.menus;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+public interface Menu {
+
+    void open(Player player);
+
+    void handleClick(InventoryClickEvent event);
+
+    Inventory getInventory();
+}

--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -1,0 +1,118 @@
+package com.lobby.menus;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.utils.MessageUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.Inventory;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MenuManager implements Listener {
+
+    private final LobbyPlugin plugin;
+    private final Map<UUID, Menu> openMenus = new ConcurrentHashMap<>();
+
+    public MenuManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    public boolean openMenu(final Player player, final String menuId) {
+        if (player == null || menuId == null || menuId.isBlank()) {
+            return false;
+        }
+        final FileConfiguration menusConfig = plugin.getConfigManager().getMenusConfig();
+        final ConfigurationSection menuSection = menusConfig.getConfigurationSection("menus." + menuId);
+        if (menuSection == null) {
+            MessageUtils.sendConfigMessage(player, "menus.not_found", Map.of("menu", menuId));
+            return false;
+        }
+
+        final Menu menu = new ConfiguredMenu(plugin, menuId, menuSection);
+        openMenus.put(player.getUniqueId(), menu);
+        menu.open(player);
+        if (menu.getInventory() == null) {
+            openMenus.remove(player.getUniqueId());
+            return false;
+        }
+        return true;
+    }
+
+    public Optional<Menu> getOpenMenu(final UUID uuid) {
+        if (uuid == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(openMenus.get(uuid));
+    }
+
+    public void closeAll() {
+        final var uuids = openMenus.keySet().stream().toList();
+        uuids.forEach(uuid -> {
+            final Player player = Bukkit.getPlayer(uuid);
+            if (player != null && player.isOnline()) {
+                player.closeInventory();
+            }
+        });
+        openMenus.clear();
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onInventoryClick(final InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        final Menu menu = openMenus.get(player.getUniqueId());
+        if (menu == null) {
+            return;
+        }
+        event.setCancelled(true);
+        final Inventory topInventory = event.getView().getTopInventory();
+        if (topInventory == null || !topInventory.equals(menu.getInventory())) {
+            return;
+        }
+        menu.handleClick(event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onInventoryDrag(final InventoryDragEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (openMenus.containsKey(player.getUniqueId())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(final InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player player)) {
+            return;
+        }
+        final Menu menu = openMenus.get(player.getUniqueId());
+        if (menu == null) {
+            return;
+        }
+        final Inventory inventory = menu.getInventory();
+        if (inventory == null || inventory.equals(event.getInventory())) {
+            openMenus.remove(player.getUniqueId());
+        }
+    }
+
+    @EventHandler
+    public void onPlayerQuit(final PlayerQuitEvent event) {
+        openMenus.remove(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -1,8 +1,10 @@
 package com.lobby.npcs;
 
 import com.lobby.LobbyPlugin;
+import com.lobby.menus.MenuManager;
 import com.lobby.utils.LogUtils;
 import com.lobby.utils.MessageUtils;
+import com.lobby.utils.PlaceholderUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -54,10 +56,26 @@ public class ActionProcessor {
             }
             return;
         }
+        if (startsWithIgnoreCase(trimmed, "[CLOSE]")) {
+            Bukkit.getScheduler().runTask(plugin, player::closeInventory);
+            return;
+        }
         if (startsWithIgnoreCase(trimmed, "[COMMAND]")) {
             final String command = processed.substring(9).trim();
             if (!command.isEmpty()) {
                 Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
+            }
+            return;
+        }
+        if (startsWithIgnoreCase(trimmed, "[MENU]")) {
+            final String menuId = processed.substring(6).trim();
+            if (!menuId.isEmpty()) {
+                final MenuManager menuManager = plugin.getMenuManager();
+                if (menuManager != null) {
+                    Bukkit.getScheduler().runTask(plugin, () -> menuManager.openMenu(player, menuId));
+                } else {
+                    LogUtils.warning(plugin, "Menu action requested but MenuManager is not available: " + menuId);
+                }
             }
             return;
         }
@@ -119,13 +137,7 @@ public class ActionProcessor {
         if (text == null) {
             return "";
         }
-        final var economyManager = plugin.getEconomyManager();
-        final long coins = economyManager != null ? economyManager.getCoins(player.getUniqueId()) : 0L;
-        final long tokens = economyManager != null ? economyManager.getTokens(player.getUniqueId()) : 0L;
-        return text
-                .replace("%player_name%", player.getName())
-                .replace("%player_coins%", String.valueOf(coins))
-                .replace("%player_tokens%", String.valueOf(tokens));
+        return PlaceholderUtils.applyPlaceholders(plugin, text, player);
     }
 
     private boolean startsWithIgnoreCase(final String text, final String prefix) {

--- a/src/main/java/com/lobby/utils/PlaceholderUtils.java
+++ b/src/main/java/com/lobby/utils/PlaceholderUtils.java
@@ -1,0 +1,110 @@
+package com.lobby.utils;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.data.PlayerData;
+import com.lobby.economy.EconomyManager;
+import com.lobby.holograms.HologramManager;
+import com.lobby.holograms.PlaceholderProcessor;
+import org.bukkit.entity.Player;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public final class PlaceholderUtils {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")
+            .withLocale(Locale.FRENCH);
+
+    private PlaceholderUtils() {
+    }
+
+    public static String applyPlaceholders(final LobbyPlugin plugin, final String text, final Player player) {
+        if (text == null || plugin == null) {
+            return text == null ? "" : text;
+        }
+
+        String processed = text;
+
+        final HologramManager hologramManager = plugin.getHologramManager();
+        if (hologramManager != null) {
+            final PlaceholderProcessor processor = hologramManager.getPlaceholderProcessor();
+            if (processor != null) {
+                processed = processor.process(processed, player);
+            }
+        }
+
+        if (player == null) {
+            return processed;
+        }
+
+        processed = processed.replace("%player_name%", player.getName());
+
+        final EconomyManager economyManager = plugin.getEconomyManager();
+        if (economyManager == null) {
+            return processed;
+        }
+
+        final PlayerData data = economyManager.getPlayerData(player.getUniqueId());
+        if (data == null) {
+            return processed;
+        }
+
+        processed = processed
+                .replace("%player_coins%", String.valueOf(data.coins()))
+                .replace("%player_tokens%", String.valueOf(data.tokens()))
+                .replace("%player_first_join%", formatInstant(data.firstJoin()))
+                .replace("%player_last_join%", formatInstant(data.lastJoin()))
+                .replace("%player_playtime%", formatPlaytime(data.totalPlaytime()));
+
+        return processed;
+    }
+
+    public static List<String> applyPlaceholders(final LobbyPlugin plugin, final List<String> lines, final Player player) {
+        if (lines == null || lines.isEmpty()) {
+            return List.of();
+        }
+        return lines.stream()
+                .filter(Objects::nonNull)
+                .map(line -> applyPlaceholders(plugin, line, player))
+                .toList();
+    }
+
+    private static String formatInstant(final Instant instant) {
+        if (instant == null) {
+            return "N/A";
+        }
+        return DATE_FORMATTER.format(instant.atZone(ZoneId.systemDefault()));
+    }
+
+    private static String formatPlaytime(final long totalSeconds) {
+        if (totalSeconds <= 0L) {
+            return "0s";
+        }
+        final Duration duration = Duration.ofSeconds(totalSeconds);
+        final long days = duration.toDays();
+        final long hours = duration.minusDays(days).toHours();
+        final long minutes = duration.minusDays(days).minusHours(hours).toMinutes();
+        final long seconds = duration.minusDays(days).minusHours(hours).minusMinutes(minutes).toSeconds();
+
+        final StringBuilder builder = new StringBuilder();
+        if (days > 0) {
+            builder.append(days).append('j').append(' ');
+        }
+        if (hours > 0) {
+            builder.append(hours).append('h').append(' ');
+        }
+        if (minutes > 0) {
+            builder.append(minutes).append('m').append(' ');
+        }
+        if (seconds > 0 && builder.length() == 0) {
+            builder.append(seconds).append('s');
+        }
+        final String result = builder.toString().trim();
+        return result.isEmpty() ? "0s" : result;
+    }
+}

--- a/src/main/resources/config/menus.yml
+++ b/src/main/resources/config/menus.yml
@@ -1,0 +1,227 @@
+menus:
+  main_menu:
+    title: "&6Menu Principal"
+    size: 27
+    items:
+      profile:
+        slot: 11
+        material: PLAYER_HEAD
+        head: "%player_name%"
+        name: "&bProfil de %player_name%"
+        lore:
+          - "&7Coins: &6%player_coins%"
+          - "&7Tokens: &d%player_tokens%"
+          - "&7Temps de jeu: &f%player_playtime%"
+          - ""
+          - "&eClique pour consulter ton profil"
+        actions:
+          - "[MENU] profile_menu"
+      shop:
+        slot: 13
+        material: EMERALD
+        name: "&aBoutique"
+        lore:
+          - "&7Découvre des offres exclusives"
+          - "&7Solde disponible: &6%player_coins%"
+        actions:
+          - "[MENU] shop_menu"
+      servers:
+        slot: 15
+        material: COMPASS
+        name: "&eSélecteur de serveurs"
+        lore:
+          - "&7Joueurs sur le réseau: &f%server_online%"
+          - "&7Clique pour choisir une destination"
+        actions:
+          - "[MENU] servers_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  shop_menu:
+    title: "&aBoutique"
+    size: 27
+    items:
+      cosmetics:
+        slot: 11
+        material: NETHER_STAR
+        name: "&dCosmétiques"
+        lore:
+          - "&7Débloque des effets uniques"
+          - "&7Solde: &6%player_coins%"
+        actions:
+          - "[COMMAND] warp cosmetics"
+      boosters:
+        slot: 13
+        material: EXPERIENCE_BOTTLE
+        name: "&bBoosters"
+        lore:
+          - "&7Accélère ta progression"
+          - "&7Tokens: &d%player_tokens%"
+        actions:
+          - "[COMMAND] warp boosters"
+      ranks:
+        slot: 15
+        material: GOLD_INGOT
+        name: "&6Grades"
+        lore:
+          - "&7Profite d'avantages spéciaux"
+        actions:
+          - "[COMMAND] warp ranks"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Revenir au menu principal"
+        actions:
+          - "[MENU] main_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer la boutique"
+        actions:
+          - "[CLOSE]"
+
+  servers_menu:
+    title: "&eSélecteur de serveurs"
+    size: 36
+    items:
+      lobby:
+        slot: 10
+        material: GRASS_BLOCK
+        name: "&aLobby Principal"
+        lore:
+          - "&7Joueurs: &f%server_online_lobby%"
+          - "&7Clique pour rejoindre"
+        actions:
+          - "[COMMAND] send %player_name% lobby"
+      skyblock:
+        slot: 12
+        material: OAK_SAPLING
+        name: "&2Skyblock"
+        lore:
+          - "&7Joueurs: &f%server_online_skyblock%"
+          - "&7Îles et automation"
+        actions:
+          - "[COMMAND] send %player_name% skyblock"
+      practice:
+        slot: 14
+        material: IRON_SWORD
+        name: "&cPractice"
+        lore:
+          - "&7Joueurs: &f%server_online_practice%"
+          - "&7Entraîne-toi au PvP"
+        actions:
+          - "[COMMAND] send %player_name% practice"
+      creative:
+        slot: 16
+        material: BRICKS
+        name: "&dCréatif"
+        lore:
+          - "&7Joueurs: &f%server_online_creative%"
+          - "&7Construis sans limites"
+        actions:
+          - "[COMMAND] send %player_name% creative"
+      back:
+        slot: 27
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour au menu principal"
+        actions:
+          - "[MENU] main_menu"
+      close:
+        slot: 35
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le sélecteur"
+        actions:
+          - "[CLOSE]"
+
+  profile_menu:
+    title: "&bProfil de %player_name%"
+    size: 27
+    items:
+      overview:
+        slot: 11
+        material: BOOK
+        name: "&aRésumé"
+        lore:
+          - "&7Coins: &6%player_coins%"
+          - "&7Tokens: &d%player_tokens%"
+          - "&7Temps de jeu: &f%player_playtime%"
+          - "&7Dernière connexion: &f%player_last_join%"
+        actions:
+          - "[MENU] stats_menu"
+      rewards:
+        slot: 13
+        material: CHEST
+        name: "&6Récompenses quotidiennes"
+        lore:
+          - "&7Récupère ton bonus journalier"
+        actions:
+          - "[COMMAND] reward daily"
+      settings:
+        slot: 15
+        material: REDSTONE_COMPARATOR
+        name: "&cParamètres"
+        lore:
+          - "&7Personnalise ton expérience"
+        actions:
+          - "[COMMAND] settings open %player_name%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour au menu principal"
+        actions:
+          - "[MENU] main_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le profil"
+        actions:
+          - "[CLOSE]"
+
+  stats_menu:
+    title: "&bStatistiques"
+    size: 27
+    items:
+      summary:
+        slot: 13
+        material: CLOCK
+        name: "&fRésumé de &b%player_name%"
+        lore:
+          - "&7Coins: &6%player_coins%"
+          - "&7Tokens: &d%player_tokens%"
+          - "&7Temps de jeu: &f%player_playtime%"
+          - "&7Première connexion: &f%player_first_join%"
+          - "&7Dernière connexion: &f%player_last_join%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour au profil"
+        actions:
+          - "[MENU] profile_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer les statistiques"
+        actions:
+          - "[CLOSE]"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -11,6 +11,8 @@ commands:
   profile_unavailable: "&cLe profil joueur n'est pas encore disponible."
   discord_unavailable: "&cLa liaison Discord n'est pas encore disponible."
   unavailable: "&cLa commande {command} n'est pas encore disponible."
+menus:
+  not_found: "&cLe menu &e{menu} &cn'est pas disponible pour le moment."
 economy:
   player_only: "&cSeuls les joueurs peuvent exécuter cette commande."
   player_not_found: "&cLe joueur &e{player} &cest introuvable."


### PR DESCRIPTION
## Summary
- add a lightweight menu framework that reads definitions from config/menus.yml and drives inventory navigation actions
- extend the plugin bootstrap, command handling, and placeholder utilities to expose the new GUI menus and reuse NPC actions
- wire default menu layouts and messaging so players can browse the main, shop, server, profile, and stats menus

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach repo.maven.apache.org for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cdad58bb1c83299348c25c67e32152