### PR TITLE
Fix plugin compilation issues in menu and NPC processing

### DIFF
--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -121,7 +121,7 @@ public class ConfiguredMenu implements Menu {
 
             if (itemSection.getBoolean("glow", false)) {
                 meta.addItemFlags(ItemFlag.values());
-                meta.addEnchant(org.bukkit.enchantments.Enchantment.DURABILITY, 1, true);
+                meta.addEnchant(org.bukkit.enchantments.Enchantment.UNBREAKING, 1, true);
             }
 
             if (meta instanceof SkullMeta skullMeta) {

--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -72,7 +72,7 @@ public class ActionProcessor {
             if (!menuId.isEmpty()) {
                 final MenuManager menuManager = plugin.getMenuManager();
                 if (menuManager != null) {
-                    Bukkit.getScheduler().runTask(plugin, () -> menuManager.openMenu(player, menuId));
+                    Bukkit.getScheduler().runTask(plugin, (Runnable) () -> menuManager.openMenu(player, menuId));
                 } else {
                     LogUtils.warning(plugin, "Menu action requested but MenuManager is not available: " + menuId);
                 }


### PR DESCRIPTION
## Summary
- update glow enchantment usage to reflect the renamed UNBREAKING constant
- disambiguate menu opening task scheduling by casting the lambda to Runnable

## Testing
- mvn clean package *(fails: unable to reach repo.maven.apache.org in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb045ab1083298ce751748204cf68