### PR TITLE
Fix runTask ambiguity with Consumer lambda

### DIFF
--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -72,7 +72,7 @@ public class ActionProcessor {
             if (!menuId.isEmpty()) {
                 final MenuManager menuManager = plugin.getMenuManager();
                 if (menuManager != null) {
-                    Bukkit.getScheduler().runTask(plugin, (Runnable) () -> {
+                    Bukkit.getScheduler().runTask(plugin, task -> {
                         menuManager.openMenu(player, menuId);
                     });
                 } else {


### PR DESCRIPTION
## Summary
- switch the menu scheduling lambda to accept a BukkitTask parameter to disambiguate the runTask overload

## Testing
- mvn clean package *(fails: unable to download maven-clean-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb39cb26883299b7e4c911fbd3dcf