### PR TITLE
Fix scheduler runTask ambiguity

### DIFF
--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -57,7 +57,7 @@ public class ActionProcessor {
             return;
         }
         if (startsWithIgnoreCase(trimmed, "[CLOSE]")) {
-            Bukkit.getScheduler().runTask(plugin, player::closeInventory);
+            Bukkit.getScheduler().runTask(plugin, (Runnable) player::closeInventory);
             return;
         }
         if (startsWithIgnoreCase(trimmed, "[COMMAND]")) {
@@ -72,7 +72,7 @@ public class ActionProcessor {
             if (!menuId.isEmpty()) {
                 final MenuManager menuManager = plugin.getMenuManager();
                 if (menuManager != null) {
-                    Bukkit.getScheduler().runTask(plugin, task -> {
+                    Bukkit.getScheduler().runTask(plugin, (Runnable) () -> {
                         menuManager.openMenu(player, menuId);
                     });
                 } else {


### PR DESCRIPTION
## Summary
- cast scheduler callbacks in `ActionProcessor` to `Runnable` to avoid overload ambiguity on Paper 1.21

## Testing
- `mvn clean compile` *(fails: network is unreachable while resolving maven-clean-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb629f4e483299cd34552a144e7b8