### PR TITLE
Implement shop system with categories and admin management

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -4,6 +4,7 @@ import com.lobby.commands.AdminCommands;
 import com.lobby.commands.EconomyCommands;
 import com.lobby.commands.NPCCommands;
 import com.lobby.commands.PlayerCommands;
+import com.lobby.commands.ShopCommands;
 import com.lobby.core.ConfigManager;
 import com.lobby.core.DatabaseManager;
 import com.lobby.core.PlayerDataManager;
@@ -16,6 +17,7 @@ import com.lobby.events.PlayerJoinLeaveEvent;
 import com.lobby.lobby.LobbyManager;
 import com.lobby.lobby.listeners.LobbyPlayerListener;
 import com.lobby.lobby.listeners.LobbyProtectionListener;
+import com.lobby.shop.ShopManager;
 import com.lobby.utils.LogUtils;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.PluginCommand;
@@ -33,6 +35,8 @@ public final class LobbyPlugin extends JavaPlugin {
     private NPCManager npcManager;
     private LobbyManager lobbyManager;
     private MenuManager menuManager;
+    private ShopManager shopManager;
+    private ShopCommands shopCommands;
 
     public static LobbyPlugin getInstance() {
         return instance;
@@ -61,6 +65,9 @@ public final class LobbyPlugin extends JavaPlugin {
         lobbyManager = new LobbyManager(this);
         lobbyManager.applyWorldSettings();
         menuManager = new MenuManager(this);
+        shopManager = new ShopManager(this);
+        shopManager.initialize();
+        shopCommands = new ShopCommands(this, shopManager);
 
         registerCommands();
 
@@ -82,6 +89,9 @@ public final class LobbyPlugin extends JavaPlugin {
         }
         if (economyManager != null) {
             economyManager.shutdown();
+        }
+        if (shopManager != null) {
+            shopManager.shutdown();
         }
         if (databaseManager != null) {
             databaseManager.shutdown();
@@ -123,6 +133,10 @@ public final class LobbyPlugin extends JavaPlugin {
         return menuManager;
     }
 
+    public ShopManager getShopManager() {
+        return shopManager;
+    }
+
     public LobbyManager getLobbyManager() {
         return lobbyManager;
     }
@@ -154,10 +168,13 @@ public final class LobbyPlugin extends JavaPlugin {
     private void registerCommands() {
         final PlayerCommands playerCommands = new PlayerCommands(lobbyManager, menuManager);
         registerCommand("lobby", playerCommands);
-        registerCommand("shop", playerCommands);
         registerCommand("serveurs", playerCommands);
         registerCommand("profil", playerCommands);
         registerCommand("discord", playerCommands);
+
+        if (shopCommands != null) {
+            registerCommand("shop", shopCommands);
+        }
 
         final EconomyCommands economyCommands = new EconomyCommands(this, economyManager);
         registerCommand("coins", economyCommands);
@@ -165,7 +182,7 @@ public final class LobbyPlugin extends JavaPlugin {
         registerCommand("pay", economyCommands);
         registerCommand("top", economyCommands);
 
-        final AdminCommands adminCommands = new AdminCommands(this, economyManager, hologramManager, npcManager, lobbyManager);
+        final AdminCommands adminCommands = new AdminCommands(this, economyManager, hologramManager, npcManager, lobbyManager, shopCommands);
         registerCommand("lobbyadmin", adminCommands);
 
         final NPCCommands npcCommands = new NPCCommands(this);

--- a/src/main/java/com/lobby/commands/AdminCommands.java
+++ b/src/main/java/com/lobby/commands/AdminCommands.java
@@ -30,15 +30,17 @@ public class AdminCommands implements CommandExecutor, TabExecutor {
     private final HologramCommands hologramCommands;
     private final NPCCommands npcCommands;
     private final LobbyManager lobbyManager;
+    private final ShopCommands shopCommands;
 
     public AdminCommands(final LobbyPlugin plugin, final EconomyManager economyManager,
                          final HologramManager hologramManager, final NPCManager npcManager,
-                         final LobbyManager lobbyManager) {
+                         final LobbyManager lobbyManager, final ShopCommands shopCommands) {
         this.plugin = plugin;
         this.economyManager = economyManager;
         this.hologramCommands = new HologramCommands(hologramManager);
         this.npcCommands = new NPCCommands(npcManager);
         this.lobbyManager = lobbyManager;
+        this.shopCommands = shopCommands;
     }
 
     @Override
@@ -49,6 +51,13 @@ public class AdminCommands implements CommandExecutor, TabExecutor {
         }
 
         final String subCommand = args[0].toLowerCase(Locale.ROOT);
+        if (subCommand.equals("shop")) {
+            if (shopCommands != null) {
+                final String[] shopArgs = Arrays.copyOfRange(args, 1, args.length);
+                return shopCommands.handleAdminCommand(sender, shopArgs);
+            }
+            return true;
+        }
         if (subCommand.equals("holo") || subCommand.equals("hologram")) {
             final String[] hologramArgs = Arrays.copyOfRange(args, 1, args.length);
             hologramCommands.handle(sender, hologramArgs);
@@ -93,10 +102,14 @@ public class AdminCommands implements CommandExecutor, TabExecutor {
                 final String[] hologramArgs = Arrays.copyOfRange(args, 1, args.length);
                 return hologramCommands.tabComplete(sender, hologramArgs);
             }
+            if (first.equals("shop")) {
+                final String[] shopArgs = Arrays.copyOfRange(args, 1, args.length);
+                return shopCommands != null ? shopCommands.tabCompleteAdmin(sender, shopArgs) : Collections.emptyList();
+            }
         }
 
         if (args.length == 1) {
-            final List<String> options = List.of("give", "take", "balance", "holo", "hologram", "npc", "setlobby", "bypass");
+            final List<String> options = List.of("give", "take", "balance", "holo", "hologram", "npc", "setlobby", "bypass", "shop");
             final String prefix = args[0].toLowerCase(Locale.ROOT);
             return options.stream().filter(option -> option.startsWith(prefix)).toList();
         }
@@ -106,6 +119,7 @@ public class AdminCommands implements CommandExecutor, TabExecutor {
                 case "give", "take" -> List.of("coins", "tokens");
                 case "balance" -> completePlayerNames(args[1]);
                 case "npc" -> npcCommands.tabComplete(sender, Arrays.copyOfRange(args, 1, args.length));
+                case "shop" -> shopCommands != null ? shopCommands.tabCompleteAdmin(sender, Arrays.copyOfRange(args, 1, args.length)) : Collections.emptyList();
                 default -> Collections.emptyList();
             };
         }

--- a/src/main/java/com/lobby/commands/PlayerCommands.java
+++ b/src/main/java/com/lobby/commands/PlayerCommands.java
@@ -17,14 +17,11 @@ import java.util.Map;
 public class PlayerCommands implements CommandExecutor, TabExecutor {
 
     private static final Map<String, String> COMMAND_MESSAGES = Map.of(
-            "shop", "commands.shop_unavailable",
-            "serveurs", "commands.servers_unavailable",
             "profil", "commands.profile_unavailable",
             "discord", "commands.discord_unavailable"
     );
 
     private static final Map<String, String> MENU_COMMANDS = Map.of(
-            "shop", "shop_menu",
             "serveurs", "servers_menu",
             "profil", "profile_menu"
     );

--- a/src/main/java/com/lobby/commands/ShopCommands.java
+++ b/src/main/java/com/lobby/commands/ShopCommands.java
@@ -1,0 +1,291 @@
+package com.lobby.commands;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.shop.ShopManager;
+import com.lobby.utils.LogUtils;
+import com.lobby.utils.MessageUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+public class ShopCommands implements CommandExecutor, TabExecutor {
+
+    private final LobbyPlugin plugin;
+    private final ShopManager shopManager;
+
+    public ShopCommands(final LobbyPlugin plugin, final ShopManager shopManager) {
+        this.plugin = plugin;
+        this.shopManager = shopManager;
+    }
+
+    @Override
+    public boolean onCommand(final CommandSender sender, final Command command, final String label, final String[] args) {
+        final String commandName = command.getName().toLowerCase(Locale.ROOT);
+        if (commandName.equals("shop")) {
+            if (!(sender instanceof Player player)) {
+                MessageUtils.sendConfigMessage(sender, "commands.player_only");
+                return true;
+            }
+            shopManager.openShopMainMenu(player);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public List<String> onTabComplete(final CommandSender sender, final Command command, final String alias, final String[] args) {
+        return Collections.emptyList();
+    }
+
+    public boolean handleAdminCommand(final CommandSender sender, final String[] args) {
+        if (!sender.hasPermission("lobby.admin.shop")) {
+            MessageUtils.sendConfigMessage(sender, "no_permission");
+            return true;
+        }
+        if (args.length == 0) {
+            MessageUtils.sendConfigMessage(sender, "shop.admin.usage");
+            return true;
+        }
+        final String subCommand = args[0].toLowerCase(Locale.ROOT);
+        return switch (subCommand) {
+            case "addcategory" -> handleAddCategory(sender, args);
+            case "additem" -> handleAddItem(sender, args);
+            case "reload" -> handleReload(sender);
+            default -> {
+                MessageUtils.sendConfigMessage(sender, "shop.admin.usage");
+                yield true;
+            }
+        };
+    }
+
+    public List<String> tabCompleteAdmin(final CommandSender sender, final String[] args) {
+        if (!sender.hasPermission("lobby.admin.shop")) {
+            return Collections.emptyList();
+        }
+        if (args.length <= 1) {
+            final String prefix = args.length == 0 ? "" : args[0].toLowerCase(Locale.ROOT);
+            return Arrays.asList("addcategory", "additem", "reload").stream()
+                    .filter(option -> option.startsWith(prefix))
+                    .collect(Collectors.toList());
+        }
+        final String subCommand = args[0].toLowerCase(Locale.ROOT);
+        if (subCommand.equals("additem") && args.length == 2) {
+            final String prefix = args[1].toLowerCase(Locale.ROOT);
+            return shopManager.getCategoryIds().stream()
+                    .filter(id -> id.toLowerCase(Locale.ROOT).startsWith(prefix))
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+
+    private boolean handleReload(final CommandSender sender) {
+        shopManager.initialize();
+        MessageUtils.sendConfigMessage(sender, "shop.admin.reloaded");
+        return true;
+    }
+
+    private boolean handleAddCategory(final CommandSender sender, final String[] args) {
+        final List<String> parameters = parseArguments(args, 1);
+        if (parameters.size() < 2) {
+            MessageUtils.sendConfigMessage(sender, "shop.admin.addcategory_usage");
+            return true;
+        }
+        final String id = parameters.get(0);
+        final String displayName = parameters.get(1);
+        final String description = parameters.size() >= 3 ? parameters.get(2) : "";
+        final String iconMaterial = parameters.size() >= 4 ? parameters.get(3) : "CHEST";
+        final int sortOrder = parameters.size() >= 5 ? parseInteger(parameters.get(4)) : 0;
+        final boolean visible = parameters.size() < 6 || parseBoolean(parameters.get(5), true);
+
+        if (id.isBlank()) {
+            MessageUtils.sendConfigMessage(sender, "shop.admin.invalid_category_id");
+            return true;
+        }
+        if (shopManager.categoryExists(id)) {
+            MessageUtils.sendConfigMessage(sender, "shop.admin.category_exists", Map.of("id", id));
+            return true;
+        }
+
+        final String sql = "INSERT INTO shop_categories (id, display_name, description, icon_material, sort_order, visible) "
+                + "VALUES (?, ?, ?, ?, ?, ?)";
+        try (Connection connection = plugin.getDatabaseManager().getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, id);
+            statement.setString(2, displayName);
+            statement.setString(3, description);
+            statement.setString(4, iconMaterial);
+            statement.setInt(5, sortOrder);
+            statement.setBoolean(6, visible);
+            statement.executeUpdate();
+            MessageUtils.sendConfigMessage(sender, "shop.admin.category_created", Map.of("id", id));
+            shopManager.initialize();
+        } catch (final SQLException exception) {
+            LogUtils.severe(plugin, "Failed to create shop category", exception);
+            MessageUtils.sendConfigMessage(sender, "shop.admin.category_error");
+        }
+        return true;
+    }
+
+    private boolean handleAddItem(final CommandSender sender, final String[] args) {
+        final List<String> parameters = parseArguments(args, 1);
+        if (parameters.size() < 6) {
+            MessageUtils.sendConfigMessage(sender, "shop.admin.additem_usage");
+            return true;
+        }
+        final String id = parameters.get(0);
+        final String categoryId = parameters.get(1);
+        final String displayName = parameters.get(2);
+        final long priceCoins = parseLong(parameters.get(3));
+        final long priceTokens = parseLong(parameters.get(4));
+        if (priceCoins < 0 || priceTokens < 0) {
+            MessageUtils.sendConfigMessage(sender, "shop.admin.invalid_price");
+            return true;
+        }
+        if (!shopManager.categoryExists(categoryId)) {
+            MessageUtils.sendConfigMessage(sender, "shop.admin.unknown_category", Map.of("category", categoryId));
+            return true;
+        }
+
+        String description = "";
+        String iconMaterial = "PLAYER_HEAD";
+        String iconHead = "hdb:35472";
+        boolean confirmRequired = false;
+        boolean enabled = true;
+        final List<String> commands = new ArrayList<>();
+
+        for (int index = 5; index < parameters.size(); index++) {
+            final String parameter = parameters.get(index);
+            final int equalsIndex = parameter.indexOf('=');
+            if (equalsIndex > 0) {
+                final String key = parameter.substring(0, equalsIndex).toLowerCase(Locale.ROOT);
+                final String value = parameter.substring(equalsIndex + 1);
+                switch (key) {
+                    case "description" -> description = value;
+                    case "icon" -> iconMaterial = value;
+                    case "head" -> iconHead = value;
+                    case "confirm" -> confirmRequired = parseBoolean(value, false);
+                    case "enabled" -> enabled = parseBoolean(value, true);
+                    default -> commands.add(parameter);
+                }
+            } else {
+                commands.add(parameter);
+            }
+        }
+
+        if (commands.isEmpty()) {
+            MessageUtils.sendConfigMessage(sender, "shop.admin.no_commands");
+            return true;
+        }
+
+        final String commandPayload = joinCommands(commands);
+        final String sql = "INSERT INTO shop_items (id, category_id, display_name, description, icon_material, icon_head_texture, "
+                + "price_coins, price_tokens, commands, confirm_required, enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        try (Connection connection = plugin.getDatabaseManager().getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, id);
+            statement.setString(2, categoryId);
+            statement.setString(3, displayName);
+            statement.setString(4, description);
+            statement.setString(5, iconMaterial);
+            statement.setString(6, iconHead);
+            statement.setLong(7, priceCoins);
+            statement.setLong(8, priceTokens);
+            statement.setString(9, commandPayload);
+            statement.setBoolean(10, confirmRequired);
+            statement.setBoolean(11, enabled);
+            statement.executeUpdate();
+            MessageUtils.sendConfigMessage(sender, "shop.admin.item_created", Map.of("id", id));
+            shopManager.initialize();
+        } catch (final SQLException exception) {
+            LogUtils.severe(plugin, "Failed to create shop item", exception);
+            MessageUtils.sendConfigMessage(sender, "shop.admin.item_error");
+        }
+        return true;
+    }
+
+    private List<String> parseArguments(final String[] args, final int startIndex) {
+        if (args.length <= startIndex) {
+            return List.of();
+        }
+        final String joined = Arrays.stream(args, startIndex, args.length).collect(Collectors.joining(" "));
+        if (joined.isEmpty()) {
+            return List.of();
+        }
+        final List<String> tokens = new ArrayList<>();
+        final StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        for (int i = 0; i < joined.length(); i++) {
+            final char c = joined.charAt(i);
+            if (c == '"') {
+                inQuotes = !inQuotes;
+                continue;
+            }
+            if (Character.isWhitespace(c) && !inQuotes) {
+                if (current.length() > 0) {
+                    tokens.add(current.toString());
+                    current.setLength(0);
+                }
+                continue;
+            }
+            current.append(c);
+        }
+        if (current.length() > 0) {
+            tokens.add(current.toString());
+        }
+        return tokens;
+    }
+
+    private long parseLong(final String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (final NumberFormatException exception) {
+            return -1L;
+        }
+    }
+
+    private int parseInteger(final String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (final NumberFormatException exception) {
+            return 0;
+        }
+    }
+
+    private boolean parseBoolean(final String value, final boolean defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        final String normalized = value.toLowerCase(Locale.ROOT);
+        if (normalized.equals("true") || normalized.equals("yes") || normalized.equals("1")) {
+            return true;
+        }
+        if (normalized.equals("false") || normalized.equals("no") || normalized.equals("0")) {
+            return false;
+        }
+        return defaultValue;
+    }
+
+    private String joinCommands(final List<String> commands) {
+        final StringJoiner joiner = new StringJoiner("\n");
+        commands.stream()
+                .map(String::trim)
+                .filter(command -> !command.isBlank())
+                .forEach(joiner::add);
+        return joiner.toString();
+    }
+}

--- a/src/main/java/com/lobby/core/DatabaseManager.java
+++ b/src/main/java/com/lobby/core/DatabaseManager.java
@@ -141,7 +141,9 @@ public class DatabaseManager {
                     ? "VARCHAR(32) DEFAULT 'NONE'"
                     : "TEXT DEFAULT 'NONE'";
             addColumnIfMissing("holograms", "animation", animationDefinition);
-            executeSQL(getCreateShopTableSQL());
+            executeSQL(getCreateShopCategoriesTableSQL());
+            executeSQL(getCreateShopItemsTableSQL());
+            ensureShopTables();
             executeSQL(getCreateTransactionsTableSQL());
 
             createTransactionIndexes();
@@ -546,36 +548,139 @@ public class DatabaseManager {
                 """;
     }
 
-    private String getCreateShopTableSQL() {
+    private String getCreateShopCategoriesTableSQL() {
+        if (databaseType == DatabaseType.MYSQL) {
+            return """
+                    CREATE TABLE IF NOT EXISTS shop_categories (
+                        id VARCHAR(50) PRIMARY KEY,
+                        display_name VARCHAR(100) NOT NULL,
+                        description TEXT,
+                        icon_material VARCHAR(50) DEFAULT 'CHEST',
+                        sort_order INT DEFAULT 0,
+                        visible BOOLEAN DEFAULT TRUE
+                    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+                    """;
+        }
+
+        return """
+                CREATE TABLE IF NOT EXISTS shop_categories (
+                    id TEXT PRIMARY KEY,
+                    display_name TEXT NOT NULL,
+                    description TEXT,
+                    icon_material TEXT DEFAULT 'CHEST',
+                    sort_order INTEGER DEFAULT 0,
+                    visible INTEGER DEFAULT 1
+                )
+                """;
+    }
+
+    private String getCreateShopItemsTableSQL() {
         if (databaseType == DatabaseType.MYSQL) {
             return """
                     CREATE TABLE IF NOT EXISTS shop_items (
-                        id INT AUTO_INCREMENT PRIMARY KEY,
-                        category VARCHAR(50) NOT NULL,
-                        item_name VARCHAR(100) NOT NULL,
+                        id VARCHAR(50) PRIMARY KEY,
+                        category_id VARCHAR(50) NOT NULL,
+                        display_name VARCHAR(100) NOT NULL,
                         description TEXT,
+                        icon_material VARCHAR(50) DEFAULT 'PLAYER_HEAD',
+                        icon_head_texture VARCHAR(200) DEFAULT 'hdb:35472',
                         price_coins BIGINT DEFAULT 0,
                         price_tokens BIGINT DEFAULT 0,
                         commands TEXT,
+                        confirm_required BOOLEAN DEFAULT FALSE,
                         enabled BOOLEAN DEFAULT TRUE,
-                        INDEX idx_category (category),
-                        INDEX idx_enabled (enabled)
+                        FOREIGN KEY (category_id) REFERENCES shop_categories(id)
                     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
                     """;
         }
 
         return """
                 CREATE TABLE IF NOT EXISTS shop_items (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    category TEXT NOT NULL,
-                    item_name TEXT NOT NULL,
+                    id TEXT PRIMARY KEY,
+                    category_id TEXT NOT NULL,
+                    display_name TEXT NOT NULL,
                     description TEXT,
-                    price_coins INTEGER DEFAULT 0,
-                    price_tokens INTEGER DEFAULT 0,
+                    icon_material TEXT DEFAULT 'PLAYER_HEAD',
+                    icon_head_texture TEXT DEFAULT 'hdb:35472',
+                    price_coins BIGINT DEFAULT 0,
+                    price_tokens BIGINT DEFAULT 0,
                     commands TEXT,
-                    enabled INTEGER DEFAULT 1
+                    confirm_required INTEGER DEFAULT 0,
+                    enabled INTEGER DEFAULT 1,
+                    FOREIGN KEY (category_id) REFERENCES shop_categories(id)
                 )
                 """;
+    }
+
+    private void ensureShopTables() throws SQLException {
+        if (databaseType == DatabaseType.MYSQL) {
+            addColumnIfNotExists("shop_items", "category_id", "VARCHAR(50) NOT NULL DEFAULT ''");
+            addColumnIfNotExists("shop_items", "display_name", "VARCHAR(100) NOT NULL DEFAULT ''");
+            addColumnIfNotExists("shop_items", "description", "TEXT");
+            addColumnIfNotExists("shop_items", "icon_material", "VARCHAR(50) DEFAULT 'PLAYER_HEAD'");
+            addColumnIfNotExists("shop_items", "icon_head_texture", "VARCHAR(200) DEFAULT 'hdb:35472'");
+            addColumnIfNotExists("shop_items", "price_coins", "BIGINT DEFAULT 0");
+            addColumnIfNotExists("shop_items", "price_tokens", "BIGINT DEFAULT 0");
+            addColumnIfNotExists("shop_items", "commands", "TEXT");
+            addColumnIfNotExists("shop_items", "confirm_required", "BOOLEAN DEFAULT FALSE");
+            addColumnIfNotExists("shop_items", "enabled", "BOOLEAN DEFAULT TRUE");
+        } else {
+            addColumnIfNotExists("shop_items", "category_id", "TEXT DEFAULT ''");
+            addColumnIfNotExists("shop_items", "display_name", "TEXT DEFAULT ''");
+            addColumnIfNotExists("shop_items", "description", "TEXT");
+            addColumnIfNotExists("shop_items", "icon_material", "TEXT DEFAULT 'PLAYER_HEAD'");
+            addColumnIfNotExists("shop_items", "icon_head_texture", "TEXT DEFAULT 'hdb:35472'");
+            addColumnIfNotExists("shop_items", "price_coins", "BIGINT DEFAULT 0");
+            addColumnIfNotExists("shop_items", "price_tokens", "BIGINT DEFAULT 0");
+            addColumnIfNotExists("shop_items", "commands", "TEXT");
+            addColumnIfNotExists("shop_items", "confirm_required", "INTEGER DEFAULT 0");
+            addColumnIfNotExists("shop_items", "enabled", "INTEGER DEFAULT 1");
+        }
+
+        if (columnExists("shop_items", "category") && columnExists("shop_items", "category_id")) {
+            final String migrateCategory = "UPDATE shop_items SET category_id = category WHERE (category_id IS NULL OR category_id = '')";
+            executeSQL(migrateCategory);
+        }
+        if (columnExists("shop_items", "item_name") && columnExists("shop_items", "display_name")) {
+            final String migrateName = "UPDATE shop_items SET display_name = item_name WHERE (display_name IS NULL OR display_name = '')";
+            executeSQL(migrateName);
+        }
+    }
+
+    private boolean columnExists(final String table, final String column) {
+        try (Connection connection = getConnection()) {
+            if (databaseType == DatabaseType.MYSQL) {
+                final String checkSql = """
+                        SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+                        WHERE TABLE_SCHEMA = DATABASE()
+                          AND TABLE_NAME = ?
+                          AND COLUMN_NAME = ?
+                        """;
+                try (PreparedStatement statement = connection.prepareStatement(checkSql)) {
+                    statement.setString(1, table);
+                    statement.setString(2, column);
+                    try (ResultSet resultSet = statement.executeQuery()) {
+                        if (resultSet.next()) {
+                            return resultSet.getInt(1) > 0;
+                        }
+                    }
+                }
+            } else {
+                final String pragmaSql = "PRAGMA table_info(" + table + ")";
+                try (Statement statement = connection.createStatement();
+                     ResultSet resultSet = statement.executeQuery(pragmaSql)) {
+                    while (resultSet.next()) {
+                        final String existing = resultSet.getString("name");
+                        if (existing != null && existing.equalsIgnoreCase(column)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.WARNING, "Failed to check column existence for " + table + '.' + column, exception);
+        }
+        return false;
     }
 
     private String getCreateTransactionsTableSQL() {

--- a/src/main/java/com/lobby/data/ShopData.java
+++ b/src/main/java/com/lobby/data/ShopData.java
@@ -1,0 +1,49 @@
+package com.lobby.data;
+
+import java.util.List;
+
+public final class ShopData {
+
+    private ShopData() {
+    }
+
+    public record ShopCategoryData(
+            String id,
+            String displayName,
+            String description,
+            String iconMaterial,
+            int sortOrder,
+            boolean visible
+    ) {
+        public ShopCategoryData {
+            id = id == null ? "" : id.trim();
+            displayName = displayName == null ? id : displayName;
+            description = description == null ? "" : description;
+            iconMaterial = iconMaterial == null || iconMaterial.isBlank() ? "CHEST" : iconMaterial;
+        }
+    }
+
+    public record ShopItemData(
+            String id,
+            String categoryId,
+            String displayName,
+            String description,
+            String iconMaterial,
+            String iconHeadTexture,
+            long priceCoins,
+            long priceTokens,
+            List<String> commands,
+            boolean confirmRequired,
+            boolean enabled
+    ) {
+        public ShopItemData {
+            id = id == null ? "" : id.trim();
+            categoryId = categoryId == null ? "" : categoryId.trim();
+            displayName = displayName == null || displayName.isBlank() ? id : displayName;
+            description = description == null ? "" : description;
+            iconMaterial = iconMaterial == null ? "PLAYER_HEAD" : iconMaterial;
+            iconHeadTexture = iconHeadTexture == null || iconHeadTexture.isBlank() ? "hdb:35472" : iconHeadTexture;
+            commands = List.copyOf(commands == null ? List.of() : commands);
+        }
+    }
+}

--- a/src/main/java/com/lobby/shop/HeadItemBuilder.java
+++ b/src/main/java/com/lobby/shop/HeadItemBuilder.java
@@ -1,0 +1,45 @@
+package com.lobby.shop;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.utils.LogUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+
+public final class HeadItemBuilder {
+
+    private HeadItemBuilder() {
+    }
+
+    public static ItemStack createHeadItem(final String headId) {
+        if (headId != null && headId.startsWith("hdb:")) {
+            final String trimmed = headId.substring(4);
+            if (!trimmed.isEmpty()) {
+                final ItemStack databaseHead = getHeadFromDatabase(trimmed);
+                if (databaseHead != null) {
+                    return databaseHead;
+                }
+            }
+        }
+        return new ItemStack(Material.PLAYER_HEAD);
+    }
+
+    private static ItemStack getHeadFromDatabase(final String headId) {
+        try {
+            final Plugin headDatabase = Bukkit.getPluginManager().getPlugin("HeadDatabase");
+            if (headDatabase == null || !headDatabase.isEnabled()) {
+                return null;
+            }
+            final Class<?> apiClass = Class.forName("me.arcaniax.hdb.api.HeadDatabaseAPI");
+            final Object apiInstance = apiClass.getMethod("getAPI").invoke(null);
+            final Object result = apiInstance.getClass().getMethod("getItemHead", String.class).invoke(apiInstance, headId);
+            if (result instanceof ItemStack itemStack) {
+                return itemStack;
+            }
+        } catch (final Exception exception) {
+            LogUtils.warning(LobbyPlugin.getInstance(), "Error accessing HeadDatabase: " + exception.getMessage());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/lobby/shop/ShopCategory.java
+++ b/src/main/java/com/lobby/shop/ShopCategory.java
@@ -1,0 +1,20 @@
+package com.lobby.shop;
+
+import com.lobby.data.ShopData.ShopCategoryData;
+
+public class ShopCategory {
+
+    private final ShopCategoryData data;
+
+    public ShopCategory(final ShopCategoryData data) {
+        this.data = data;
+    }
+
+    public ShopCategoryData getData() {
+        return data;
+    }
+
+    public boolean isVisible() {
+        return data.visible();
+    }
+}

--- a/src/main/java/com/lobby/shop/ShopItem.java
+++ b/src/main/java/com/lobby/shop/ShopItem.java
@@ -1,0 +1,20 @@
+package com.lobby.shop;
+
+import com.lobby.data.ShopData.ShopItemData;
+
+public class ShopItem {
+
+    private final ShopItemData data;
+
+    public ShopItem(final ShopItemData data) {
+        this.data = data;
+    }
+
+    public ShopItemData getData() {
+        return data;
+    }
+
+    public boolean isEnabled() {
+        return data.enabled();
+    }
+}

--- a/src/main/java/com/lobby/shop/ShopManager.java
+++ b/src/main/java/com/lobby/shop/ShopManager.java
@@ -1,0 +1,492 @@
+package com.lobby.shop;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.data.ShopData.ShopCategoryData;
+import com.lobby.data.ShopData.ShopItemData;
+import com.lobby.economy.EconomyManager;
+import com.lobby.utils.LogUtils;
+import com.lobby.utils.MessageUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public class ShopManager implements Listener {
+
+    private static final String DEFAULT_HEAD = "hdb:35472";
+
+    private final LobbyPlugin plugin;
+    private final Map<String, ShopCategory> categories = new LinkedHashMap<>();
+    private final Map<String, ShopItem> items = new LinkedHashMap<>();
+    private final Map<UUID, MenuContext> openMenus = new ConcurrentHashMap<>();
+    private final Map<UUID, String> pendingConfirmations = new ConcurrentHashMap<>();
+    private final NamespacedKey categoryKey;
+    private final NamespacedKey itemKey;
+
+    public ShopManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        this.categoryKey = new NamespacedKey(plugin, "shop_category");
+        this.itemKey = new NamespacedKey(plugin, "shop_item");
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    public void initialize() {
+        closeOpenMenus();
+        loadShopData();
+        LogUtils.info(plugin, "ShopManager initialized with " + categories.size() + " categories and " + items.size() + " items");
+    }
+
+    public void shutdown() {
+        closeOpenMenus();
+        categories.clear();
+        items.clear();
+        pendingConfirmations.clear();
+    }
+
+    public void openShopMainMenu(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final Inventory inventory = Bukkit.createInventory(null, 54, MessageUtils.colorize("&6&lBoutique"));
+        final ItemStack borderItem = createBorderItem();
+        fillBorder(inventory, borderItem);
+
+        int slot = 10;
+        for (ShopCategory category : categories.values()) {
+            if (!category.isVisible()) {
+                continue;
+            }
+            if (slot >= 44) {
+                break;
+            }
+            final ItemStack icon = createCategoryIcon(category);
+            inventory.setItem(slot, icon);
+            slot = nextSlot(slot);
+        }
+
+        openMenus.put(player.getUniqueId(), new MenuContext(MenuType.MAIN, null, inventory));
+        player.openInventory(inventory);
+    }
+
+    public void openCategoryMenu(final Player player, final String categoryId) {
+        if (player == null) {
+            return;
+        }
+        final ShopCategory category = categories.get(categoryId);
+        if (category == null) {
+            MessageUtils.sendConfigMessage(player, "shop.category_not_found");
+            return;
+        }
+
+        final List<ShopItem> categoryItems = items.values().stream()
+                .filter(item -> Objects.equals(item.getData().categoryId(), categoryId))
+                .filter(ShopItem::isEnabled)
+                .sorted(Comparator.comparing(item -> item.getData().displayName(), String.CASE_INSENSITIVE_ORDER))
+                .collect(Collectors.toList());
+
+        final String title = MessageUtils.colorize("&6" + category.getData().displayName());
+        final Inventory inventory = Bukkit.createInventory(null, 54, title);
+        final ItemStack borderItem = createBorderItem();
+        fillBorder(inventory, borderItem);
+
+        int slot = 10;
+        for (ShopItem item : categoryItems) {
+            if (slot >= 44) {
+                break;
+            }
+            final ItemStack icon = createShopItemIcon(item);
+            inventory.setItem(slot, icon);
+            slot = nextSlot(slot);
+        }
+
+        openMenus.put(player.getUniqueId(), new MenuContext(MenuType.CATEGORY, categoryId, inventory));
+        player.openInventory(inventory);
+    }
+
+    public boolean purchaseItem(final Player player, final ShopItem item) {
+        if (player == null || item == null) {
+            return false;
+        }
+        final EconomyManager economyManager = plugin.getEconomyManager();
+        if (economyManager == null) {
+            return false;
+        }
+        final ShopItemData data = item.getData();
+        if (data.priceCoins() > 0 && !economyManager.hasCoins(player.getUniqueId(), data.priceCoins())) {
+            MessageUtils.sendConfigMessage(player, "shop.insufficient_coins");
+            return false;
+        }
+        if (data.priceTokens() > 0 && !economyManager.hasTokens(player.getUniqueId(), data.priceTokens())) {
+            MessageUtils.sendConfigMessage(player, "shop.insufficient_tokens");
+            return false;
+        }
+
+        if (data.priceCoins() > 0) {
+            economyManager.removeCoins(player.getUniqueId(), data.priceCoins(), "Shop: " + data.displayName());
+        }
+        if (data.priceTokens() > 0) {
+            economyManager.removeTokens(player.getUniqueId(), data.priceTokens(), "Shop: " + data.displayName());
+        }
+
+        for (String command : data.commands()) {
+            if (command == null || command.isBlank()) {
+                continue;
+            }
+            final String parsed = command.replace("%player%", player.getName());
+            Bukkit.getScheduler().runTask(plugin, () ->
+                    Bukkit.dispatchCommand(Bukkit.getConsoleSender(), parsed));
+        }
+
+        MessageUtils.sendConfigMessage(player, "shop.purchase_success", Map.of("item", data.displayName()));
+        return true;
+    }
+
+    public Set<String> getCategoryIds() {
+        return Set.copyOf(categories.keySet());
+    }
+
+    public boolean categoryExists(final String categoryId) {
+        return categoryId != null && categories.containsKey(categoryId);
+    }
+
+    private void closeOpenMenus() {
+        openMenus.keySet().forEach(uuid -> {
+            final Player target = Bukkit.getPlayer(uuid);
+            if (target != null && target.isOnline()) {
+                target.closeInventory();
+            }
+        });
+        openMenus.clear();
+        pendingConfirmations.clear();
+    }
+
+    private void loadShopData() {
+        categories.clear();
+        items.clear();
+        try (Connection connection = plugin.getDatabaseManager().getConnection()) {
+            loadCategories(connection);
+            loadItems(connection);
+        } catch (final SQLException exception) {
+            LogUtils.severe(plugin, "Failed to load shop data", exception);
+        }
+    }
+
+    private void loadCategories(final Connection connection) throws SQLException {
+        final String sql = "SELECT id, display_name, description, icon_material, sort_order, visible FROM shop_categories "
+                + "ORDER BY sort_order ASC, display_name ASC";
+        try (PreparedStatement statement = connection.prepareStatement(sql);
+             ResultSet resultSet = statement.executeQuery()) {
+            while (resultSet.next()) {
+                final String id = resultSet.getString("id");
+                if (id == null || id.isBlank()) {
+                    continue;
+                }
+                final String displayName = resultSet.getString("display_name");
+                final String description = resultSet.getString("description");
+                final String iconMaterial = resultSet.getString("icon_material");
+                final int sortOrder = resultSet.getInt("sort_order");
+                final boolean visible = resultSet.getBoolean("visible");
+                final ShopCategoryData data = new ShopCategoryData(id, displayName, description, iconMaterial, sortOrder, visible);
+                categories.put(data.id(), new ShopCategory(data));
+            }
+        }
+    }
+
+    private void loadItems(final Connection connection) throws SQLException {
+        final String sql = "SELECT * FROM shop_items";
+        try (PreparedStatement statement = connection.prepareStatement(sql);
+             ResultSet resultSet = statement.executeQuery()) {
+            final ResultSetMetaData metaData = resultSet.getMetaData();
+            final boolean hasCategoryId = hasColumn(metaData, "category_id");
+            final boolean hasLegacyCategory = hasColumn(metaData, "category");
+            final boolean hasDisplayName = hasColumn(metaData, "display_name");
+            final boolean hasLegacyName = hasColumn(metaData, "item_name");
+            final boolean hasDescription = hasColumn(metaData, "description");
+            final boolean hasIconMaterial = hasColumn(metaData, "icon_material");
+            final boolean hasIconHead = hasColumn(metaData, "icon_head_texture");
+            final boolean hasPriceCoins = hasColumn(metaData, "price_coins");
+            final boolean hasPriceTokens = hasColumn(metaData, "price_tokens");
+            final boolean hasCommands = hasColumn(metaData, "commands");
+            final boolean hasConfirm = hasColumn(metaData, "confirm_required");
+            final boolean hasEnabled = hasColumn(metaData, "enabled");
+
+            while (resultSet.next()) {
+                final String id = resultSet.getString("id");
+                if (id == null || id.isBlank()) {
+                    continue;
+                }
+                String categoryId = hasCategoryId ? resultSet.getString("category_id")
+                        : hasLegacyCategory ? resultSet.getString("category") : "";
+                if (categoryId == null) {
+                    categoryId = "";
+                }
+                final String displayName = hasDisplayName ? resultSet.getString("display_name")
+                        : hasLegacyName ? resultSet.getString("item_name") : id;
+                final String description = hasDescription ? resultSet.getString("description") : "";
+                final String iconMaterial = hasIconMaterial ? resultSet.getString("icon_material") : "PLAYER_HEAD";
+                final String iconHeadTexture = hasIconHead ? resultSet.getString("icon_head_texture") : DEFAULT_HEAD;
+                final long priceCoins = hasPriceCoins ? resultSet.getLong("price_coins") : 0L;
+                final long priceTokens = hasPriceTokens ? resultSet.getLong("price_tokens") : 0L;
+                final List<String> commands = hasCommands ? parseCommands(resultSet.getString("commands")) : List.of();
+                final boolean confirmRequired = hasConfirm && resultSet.getBoolean("confirm_required");
+                final boolean enabled = !hasEnabled || resultSet.getBoolean("enabled");
+
+                final ShopItemData data = new ShopItemData(id, categoryId, displayName, description, iconMaterial,
+                        iconHeadTexture, priceCoins, priceTokens, commands, confirmRequired, enabled);
+                items.put(data.id(), new ShopItem(data));
+            }
+        }
+    }
+
+    private List<String> parseCommands(final String raw) {
+        if (raw == null || raw.isBlank()) {
+            return List.of();
+        }
+        final String[] split = raw.split("\\r?\\n|;");
+        final List<String> commands = new ArrayList<>();
+        for (String entry : split) {
+            if (entry == null) {
+                continue;
+            }
+            final String trimmed = entry.trim();
+            if (!trimmed.isEmpty()) {
+                commands.add(trimmed);
+            }
+        }
+        return List.copyOf(commands);
+    }
+
+    private boolean hasColumn(final ResultSetMetaData metaData, final String column) throws SQLException {
+        final int columnCount = metaData.getColumnCount();
+        for (int i = 1; i <= columnCount; i++) {
+            final String name = metaData.getColumnName(i);
+            if (name != null && name.equalsIgnoreCase(column)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private ItemStack createCategoryIcon(final ShopCategory category) {
+        final ShopCategoryData data = category.getData();
+        final Material material = matchMaterial(data.iconMaterial(), Material.CHEST);
+        final ItemStack itemStack = new ItemStack(material);
+        final ItemMeta meta = itemStack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(MessageUtils.colorize("&e" + data.displayName()));
+            final List<String> lore = new ArrayList<>();
+            if (data.description() != null && !data.description().isBlank()) {
+                lore.add(MessageUtils.colorize("&7" + data.description()));
+            }
+            lore.add(MessageUtils.colorize("&aCliquez pour ouvrir"));
+            meta.setLore(lore);
+            final PersistentDataContainer container = meta.getPersistentDataContainer();
+            container.set(categoryKey, PersistentDataType.STRING, data.id());
+            itemStack.setItemMeta(meta);
+        }
+        return itemStack;
+    }
+
+    private ItemStack createShopItemIcon(final ShopItem item) {
+        final ShopItemData data = item.getData();
+        ItemStack baseItem;
+        if (data.iconHeadTexture() != null && !data.iconHeadTexture().isBlank()) {
+            baseItem = HeadItemBuilder.createHeadItem(data.iconHeadTexture());
+        } else {
+            baseItem = HeadItemBuilder.createHeadItem(DEFAULT_HEAD);
+        }
+        if (baseItem.getType() == Material.PLAYER_HEAD && data.iconMaterial() != null && !data.iconMaterial().isBlank()
+                && !data.iconMaterial().equalsIgnoreCase("PLAYER_HEAD")) {
+            final Material override = matchMaterial(data.iconMaterial(), Material.PLAYER_HEAD);
+            baseItem = new ItemStack(override);
+        }
+        final ItemMeta meta = baseItem.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(MessageUtils.colorize("&a" + data.displayName()));
+            final List<String> lore = new ArrayList<>();
+            if (data.description() != null && !data.description().isBlank()) {
+                lore.add(MessageUtils.colorize("&7" + data.description()));
+            }
+            lore.add(MessageUtils.colorize(""));
+            lore.add(MessageUtils.colorize("&ePrix:"));
+            if (data.priceCoins() > 0) {
+                lore.add(MessageUtils.colorize("&6  " + data.priceCoins() + " coins"));
+            }
+            if (data.priceTokens() > 0) {
+                lore.add(MessageUtils.colorize("&b  " + data.priceTokens() + " tokens"));
+            }
+            if (data.priceCoins() <= 0 && data.priceTokens() <= 0) {
+                lore.add(MessageUtils.colorize("&aGratuit"));
+            }
+            lore.add(MessageUtils.colorize(""));
+            if (data.confirmRequired()) {
+                lore.add(MessageUtils.colorize("&cConfirmation requise"));
+            }
+            lore.add(MessageUtils.colorize("&aCliquez pour acheter !"));
+            meta.setLore(lore);
+            final PersistentDataContainer container = meta.getPersistentDataContainer();
+            container.set(itemKey, PersistentDataType.STRING, data.id());
+            baseItem.setItemMeta(meta);
+        }
+        return baseItem;
+    }
+
+    private ItemStack createBorderItem() {
+        final ItemStack itemStack = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        final ItemMeta meta = itemStack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            itemStack.setItemMeta(meta);
+        }
+        return itemStack;
+    }
+
+    private void fillBorder(final Inventory inventory, final ItemStack itemStack) {
+        final int size = inventory.getSize();
+        final int rows = size / 9;
+        for (int slot = 0; slot < size; slot++) {
+            final int row = slot / 9;
+            final int column = slot % 9;
+            if (row == 0 || row == rows - 1 || column == 0 || column == 8) {
+                inventory.setItem(slot, itemStack);
+            }
+        }
+    }
+
+    private int nextSlot(final int current) {
+        int next = current + 1;
+        if ((next + 1) % 9 == 0) {
+            next += 2;
+        }
+        return next;
+    }
+
+    private Material matchMaterial(final String name, final Material fallback) {
+        if (name == null || name.isBlank()) {
+            return fallback;
+        }
+        final Material material = Material.matchMaterial(name.trim().toUpperCase(Locale.ROOT));
+        return material != null ? material : fallback;
+    }
+
+    @EventHandler
+    public void onInventoryClick(final InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        final MenuContext context = openMenus.get(player.getUniqueId());
+        if (context == null) {
+            return;
+        }
+        final Inventory topInventory = event.getView().getTopInventory();
+        if (topInventory == null || !topInventory.equals(context.inventory())) {
+            return;
+        }
+        event.setCancelled(true);
+        final ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || clicked.getType() == Material.AIR) {
+            return;
+        }
+        final ItemMeta meta = clicked.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+        final PersistentDataContainer container = meta.getPersistentDataContainer();
+        if (context.type() == MenuType.MAIN) {
+            final String categoryId = container.get(categoryKey, PersistentDataType.STRING);
+            if (categoryId != null && !categoryId.isBlank()) {
+                Bukkit.getScheduler().runTask(plugin, () -> openCategoryMenu(player, categoryId));
+            }
+            return;
+        }
+        if (context.type() == MenuType.CATEGORY) {
+            final String itemId = container.get(itemKey, PersistentDataType.STRING);
+            if (itemId == null || itemId.isBlank()) {
+                return;
+            }
+            final ShopItem shopItem = items.get(itemId);
+            if (shopItem == null || !shopItem.isEnabled()) {
+                return;
+            }
+            handleItemClick(player, shopItem);
+        }
+    }
+
+    private void handleItemClick(final Player player, final ShopItem shopItem) {
+        final ShopItemData data = shopItem.getData();
+        if (data.confirmRequired()) {
+            final String pending = pendingConfirmations.get(player.getUniqueId());
+            if (!data.id().equals(pending)) {
+                pendingConfirmations.put(player.getUniqueId(), data.id());
+                MessageUtils.sendConfigMessage(player, "shop.confirmation_required", Map.of("item", data.displayName()));
+                return;
+            }
+            pendingConfirmations.remove(player.getUniqueId());
+        }
+        final boolean purchased = purchaseItem(player, shopItem);
+        if (purchased) {
+            pendingConfirmations.remove(player.getUniqueId());
+        }
+    }
+
+    @EventHandler
+    public void onInventoryDrag(final InventoryDragEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (openMenus.containsKey(player.getUniqueId())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(final InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player player)) {
+            return;
+        }
+        openMenus.remove(player.getUniqueId());
+        pendingConfirmations.remove(player.getUniqueId());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(final PlayerQuitEvent event) {
+        openMenus.remove(event.getPlayer().getUniqueId());
+        pendingConfirmations.remove(event.getPlayer().getUniqueId());
+    }
+
+    private enum MenuType {
+        MAIN,
+        CATEGORY
+    }
+
+    private record MenuContext(MenuType type, String categoryId, Inventory inventory) {
+    }
+}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -11,6 +11,26 @@ commands:
   profile_unavailable: "&cLe profil joueur n'est pas encore disponible."
   discord_unavailable: "&cLa liaison Discord n'est pas encore disponible."
   unavailable: "&cLa commande {command} n'est pas encore disponible."
+shop:
+  purchase_success: "&aVous avez acheté &6{item}&a !"
+  insufficient_coins: "&cPas assez de coins !"
+  insufficient_tokens: "&cPas assez de tokens !"
+  category_not_found: "&cCatégorie introuvable !"
+  confirmation_required: "&eCliquez à nouveau pour confirmer l'achat de &6{item}&e."
+  admin:
+    usage: "&cUtilisation: /ladmin shop <addcategory|additem|reload>"
+    reloaded: "&aBoutique rechargée !"
+    addcategory_usage: "&cUtilisation: /ladmin shop addcategory <id> <nom> [description] [icon] [ordre] [visible]"
+    additem_usage: "&cUtilisation: /ladmin shop additem <id> <categorie> <nom> <prixCoins> <prixTokens> <commande...>"
+    invalid_category_id: "&cIdentifiant de catégorie invalide."
+    category_exists: "&cLa catégorie &6{id} &cexiste déjà."
+    category_created: "&aCatégorie &6{id} &acréée !"
+    category_error: "&cErreur lors de la création de la catégorie."
+    invalid_price: "&cPrix invalide."
+    unknown_category: "&cCatégorie inconnue: &6{category}&c."
+    no_commands: "&cVous devez fournir au moins une commande pour l'item."
+    item_created: "&aItem &6{id} &acréé !"
+    item_error: "&cErreur lors de la création de l'item."
 menus:
   not_found: "&cLe menu &e{menu} &cn'est pas disponible pour le moment."
 economy:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -63,3 +63,5 @@ permissions:
     default: op
   lobby.admin.bypass:
     default: op
+  lobby.admin.shop:
+    default: op


### PR DESCRIPTION
## Summary
- add shop data structures, manager, and head item helper to load categories and items from the database with support for HeadDatabase icons and confirmation flow
- wire new ShopCommands into the plugin alongside admin subcommands for creating categories/items and reloading shop content
- extend the database schema, messages, and permissions to support the shop system and ensure legacy data is migrated

## Testing
- `mvn -q -DskipTests package` *(fails: Maven central unreachable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc238d1cc83299ed74491521a3836