### PR TITLE
Fix shop command display compilation error

### DIFF
--- a/src/main/java/com/lobby/commands/ShopCommands.java
+++ b/src/main/java/com/lobby/commands/ShopCommands.java
@@ -299,8 +299,7 @@ public class ShopCommands implements CommandExecutor, TabExecutor {
                     sender.sendMessage("§7├─ Description: §f" + description);
                     final String priceDisplay = buildPriceDisplay(priceCoins, priceTokens);
                     sender.sendMessage("§7├─ Prix: " + priceDisplay);
-                    sender.sendMessage("§7└─ Commandes: §f" + commandPayload.replace('
-', ' '));
+                    sender.sendMessage("§7└─ Commandes: §f" + commandPayload.replace("\n", "§7, §f"));
                     plugin.getLogger().info("Shop item created: '" + name + "' by " + sender.getName()
                             + " (Coins: " + priceCoins + ", Tokens: " + priceTokens + ")");
                     shopManager.initialize();


### PR DESCRIPTION
## Summary
- replace the invalid character literal in the shop command confirmation message with a newline-aware string replacement to restore compilation

## Testing
- `mvn -q -DskipTests compile` *(fails: Network is unreachable while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4fefb0a48329b0a0b4059d0153e3