### PR TITLE
Fix illegal escape sequence in ShopCommands

### DIFF
--- a/src/main/java/com/lobby/commands/ShopCommands.java
+++ b/src/main/java/com/lobby/commands/ShopCommands.java
@@ -339,7 +339,7 @@ public class ShopCommands implements CommandExecutor, TabExecutor {
             return "";
         }
         final String normalized = Normalizer.normalize(name, Normalizer.Form.NFD)
-                .replaceAll("\p{InCombiningDiacriticalMarks}+", "");
+                .replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
         final String sanitized = NON_ALPHANUMERIC.matcher(normalized.toLowerCase(Locale.ROOT)).replaceAll("-");
         final String compact = sanitized.replaceAll("-+", "-").replaceAll("(^-|-$)", "");
         return compact;


### PR DESCRIPTION
## Summary
- escape the Unicode character class used when removing diacritical marks in `ShopCommands`

## Testing
- `mvn -q -DskipTests compile` *(fails: network is unreachable while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68ce518e5658832991ef96104e279a15