### PR TITLE
Fix shop item creation for schemas requiring name column

### DIFF
--- a/src/main/java/com/lobby/commands/ShopCommands.java
+++ b/src/main/java/com/lobby/commands/ShopCommands.java
@@ -225,6 +225,9 @@ public class ShopCommands implements CommandExecutor, TabExecutor {
             final String sql;
             if (hasCategoryId && hasDisplayName) {
                 final StringBuilder builder = new StringBuilder("INSERT INTO shop_items (id, category_id, display_name");
+                if (hasNameColumn) {
+                    builder.append(", name");
+                }
                 if (hasDescription) {
                     builder.append(", description");
                 }
@@ -242,6 +245,9 @@ public class ShopCommands implements CommandExecutor, TabExecutor {
                     builder.append(", enabled");
                 }
                 builder.append(") VALUES (?, ?, ?");
+                if (hasNameColumn) {
+                    builder.append(", ?");
+                }
                 if (hasDescription) {
                     builder.append(", ?");
                 }
@@ -271,6 +277,9 @@ public class ShopCommands implements CommandExecutor, TabExecutor {
                     statement.setString(index++, itemId);
                     statement.setString(index++, categoryId);
                     statement.setString(index++, name);
+                    if (hasNameColumn) {
+                        statement.setString(index++, name);
+                    }
                     if (hasDescription) {
                         statement.setString(index++, description);
                     }


### PR DESCRIPTION
## Summary
- include the optional `name` column in the dynamic INSERT when the schema exposes it to prevent NOT NULL errors
- bind the item name value for that column so legacy databases with the field stay compatible

## Testing
- `mvn -DskipTests package` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ce559247d88329a42bd1382678b256