### PR TITLE
feat: implement lobby item system and modular menus

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -15,6 +15,7 @@ import com.lobby.npcs.NPCInteractionHandler;
 import com.lobby.npcs.NPCManager;
 import com.lobby.events.PlayerJoinLeaveEvent;
 import com.lobby.lobby.LobbyManager;
+import com.lobby.lobby.listeners.LobbyItemListener;
 import com.lobby.lobby.listeners.LobbyPlayerListener;
 import com.lobby.lobby.listeners.LobbyProtectionListener;
 import com.lobby.shop.ShopManager;
@@ -46,6 +47,9 @@ public final class LobbyPlugin extends JavaPlugin {
     public void onEnable() {
         instance = this;
 
+        getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
+        getServer().getMessenger().registerOutgoingPluginChannel(this, "bungeecord:main");
+
         configManager = new ConfigManager(this);
         configManager.loadConfigs();
 
@@ -73,6 +77,7 @@ public final class LobbyPlugin extends JavaPlugin {
 
         getServer().getPluginManager().registerEvents(new PlayerJoinLeaveEvent(this, playerDataManager, economyManager), this);
         getServer().getPluginManager().registerEvents(new LobbyPlayerListener(lobbyManager), this);
+        getServer().getPluginManager().registerEvents(new LobbyItemListener(lobbyManager, lobbyManager.getItemManager()), this);
         getServer().getPluginManager().registerEvents(new LobbyProtectionListener(lobbyManager), this);
         getServer().getPluginManager().registerEvents(new NPCInteractionHandler(npcManager), this);
 
@@ -81,6 +86,7 @@ public final class LobbyPlugin extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        getServer().getMessenger().unregisterOutgoingPluginChannel(this);
         if (hologramManager != null) {
             hologramManager.shutdown();
         }
@@ -162,6 +168,7 @@ public final class LobbyPlugin extends JavaPlugin {
         }
         if (menuManager != null) {
             menuManager.closeAll();
+            menuManager.reloadMenus();
         }
     }
 

--- a/src/main/java/com/lobby/commands/PlayerCommands.java
+++ b/src/main/java/com/lobby/commands/PlayerCommands.java
@@ -74,7 +74,7 @@ public class PlayerCommands implements CommandExecutor, TabExecutor {
         final boolean hasSpawn = lobbyManager.hasLobbySpawn();
         final boolean teleported = lobbyManager.teleportToLobby(player);
         if (!lobbyManager.isBypassing(player)) {
-            lobbyManager.preparePlayer(player);
+            lobbyManager.preparePlayer(player, LobbyManager.PreparationCause.COMMAND);
         }
         if (!hasSpawn) {
             if (player.hasPermission("lobby.admin")) {

--- a/src/main/java/com/lobby/core/ConfigManager.java
+++ b/src/main/java/com/lobby/core/ConfigManager.java
@@ -15,8 +15,10 @@ public class ConfigManager {
     private final LobbyPlugin plugin;
     private FileConfiguration messagesConfig;
     private FileConfiguration menusConfig;
+    private FileConfiguration lobbyItemsConfig;
     private File messagesFile;
     private File menusFile;
+    private File lobbyItemsFile;
 
     public ConfigManager(final LobbyPlugin plugin) {
         this.plugin = plugin;
@@ -27,12 +29,14 @@ public class ConfigManager {
         plugin.reloadConfig();
         loadMessages();
         loadMenus();
+        loadLobbyItems();
     }
 
     public void reloadConfigs() {
         plugin.reloadConfig();
         loadMessages();
         loadMenus();
+        loadLobbyItems();
     }
 
     public FileConfiguration getMainConfig() {
@@ -51,6 +55,13 @@ public class ConfigManager {
             loadMenus();
         }
         return menusConfig;
+    }
+
+    public FileConfiguration getLobbyItemsConfig() {
+        if (lobbyItemsConfig == null) {
+            loadLobbyItems();
+        }
+        return lobbyItemsConfig;
     }
 
     public boolean isDebugEnabled() {
@@ -126,6 +137,44 @@ public class ConfigManager {
             }
         } catch (IOException | InvalidConfigurationException exception) {
             plugin.getLogger().severe("Unable to load default config/menus.yml: " + exception.getMessage());
+        }
+    }
+
+    private void loadLobbyItems() {
+        if (lobbyItemsFile == null) {
+            final File configDirectory = new File(plugin.getDataFolder(), "config");
+            if (!configDirectory.exists() && !configDirectory.mkdirs()) {
+                plugin.getLogger().severe("Unable to create config directory for lobby items.");
+            }
+            lobbyItemsFile = new File(configDirectory, "lobby-items.yml");
+        }
+
+        if (!plugin.getDataFolder().exists() && !plugin.getDataFolder().mkdirs()) {
+            plugin.getLogger().severe("Unable to create plugin data folder for configuration files.");
+        }
+
+        if (!lobbyItemsFile.exists()) {
+            plugin.saveResource("config/lobby-items.yml", false);
+        }
+
+        lobbyItemsConfig = new YamlConfiguration();
+        try {
+            lobbyItemsConfig.load(lobbyItemsFile);
+        } catch (IOException | InvalidConfigurationException exception) {
+            plugin.getLogger().severe("Unable to load config/lobby-items.yml: " + exception.getMessage());
+            loadDefaultLobbyItems();
+        }
+    }
+
+    private void loadDefaultLobbyItems() {
+        lobbyItemsConfig = new YamlConfiguration();
+        try (InputStream inputStream = plugin.getResource("config/lobby-items.yml")) {
+            if (inputStream != null) {
+                Files.copy(inputStream, lobbyItemsFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                lobbyItemsConfig.load(lobbyItemsFile);
+            }
+        } catch (IOException | InvalidConfigurationException exception) {
+            plugin.getLogger().severe("Unable to load default config/lobby-items.yml: " + exception.getMessage());
         }
     }
 }

--- a/src/main/java/com/lobby/lobby/LobbyManager.java
+++ b/src/main/java/com/lobby/lobby/LobbyManager.java
@@ -1,18 +1,14 @@
 package com.lobby.lobby;
 
 import com.lobby.LobbyPlugin;
-import com.lobby.utils.MessageUtils;
+import com.lobby.lobby.items.LobbyItemManager;
 import org.bukkit.Bukkit;
 import org.bukkit.GameRule;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
 
 import java.util.Collections;
@@ -25,16 +21,19 @@ public class LobbyManager {
 
     private final LobbyPlugin plugin;
     private final Set<UUID> bypassPlayers = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final LobbyItemManager itemManager;
     private Location lobbySpawn;
 
     public LobbyManager(final LobbyPlugin plugin) {
         this.plugin = plugin;
+        itemManager = new LobbyItemManager(plugin);
         loadSpawn();
     }
 
     public void reload() {
         loadSpawn();
         applyWorldSettings();
+        itemManager.reload();
     }
 
     public void loadSpawn() {
@@ -162,13 +161,13 @@ public class LobbyManager {
     }
 
     public void preparePlayer(final Player player) {
+        preparePlayer(player, PreparationCause.JOIN);
+    }
+
+    public void preparePlayer(final Player player, final PreparationCause cause) {
         if (player == null) {
             return;
         }
-        player.getInventory().clear();
-        player.getInventory().setArmorContents(null);
-        player.getInventory().setExtraContents(new ItemStack[0]);
-        player.getInventory().setItemInOffHand(null);
         player.setFireTicks(0);
         player.setFallDistance(0);
         player.setHealth(player.getMaxHealth());
@@ -177,59 +176,7 @@ public class LobbyManager {
         player.getActivePotionEffects().stream()
                 .map(PotionEffect::getType)
                 .forEach(player::removePotionEffect);
-        giveLobbyItems(player);
-    }
-
-    public void giveLobbyItems(final Player player) {
-        if (player == null) {
-            return;
-        }
-        final FileConfiguration config = plugin.getConfig();
-        if (!config.getBoolean("lobby.inventory.enabled", true)) {
-            return;
-        }
-        final ConfigurationSection itemsSection = config.getConfigurationSection("lobby.inventory.items");
-        if (itemsSection == null) {
-            return;
-        }
-        final PlayerInventory inventory = player.getInventory();
-        for (String key : itemsSection.getKeys(false)) {
-            final ConfigurationSection itemSection = itemsSection.getConfigurationSection(key);
-            if (itemSection == null) {
-                continue;
-            }
-            final String materialName = itemSection.getString("material", "STONE");
-            final Material material = Material.matchMaterial(materialName);
-            if (material == null) {
-                plugin.getLogger().warning("Matériau invalide pour l'item de lobby '" + key + "': " + materialName);
-                continue;
-            }
-            final int amount = Math.max(1, itemSection.getInt("amount", 1));
-            final ItemStack itemStack = new ItemStack(material, amount);
-            final ItemMeta meta = itemStack.getItemMeta();
-            if (meta != null) {
-                if (itemSection.isString("name")) {
-                    meta.setDisplayName(MessageUtils.colorize(itemSection.getString("name")));
-                }
-                if (itemSection.isList("lore")) {
-                    meta.setLore(itemSection.getStringList("lore").stream()
-                            .map(MessageUtils::colorize)
-                            .toList());
-                }
-                itemStack.setItemMeta(meta);
-            }
-            final int slot = itemSection.getInt("slot", -1);
-            if (slot >= 0 && slot < inventory.getSize()) {
-                inventory.setItem(slot, itemStack);
-            } else {
-                inventory.addItem(itemStack);
-            }
-        }
-        final int heldSlot = config.getInt("lobby.inventory.held_slot", inventory.getHeldItemSlot());
-        if (heldSlot >= 0 && heldSlot < 9) {
-            inventory.setHeldItemSlot(heldSlot);
-        }
-        player.updateInventory();
+        itemManager.apply(player, cause);
     }
 
     public boolean teleportToLobby(final Player player) {
@@ -259,5 +206,16 @@ public class LobbyManager {
 
     public void shutdown() {
         bypassPlayers.clear();
+        itemManager.shutdown();
+    }
+
+    public LobbyItemManager getItemManager() {
+        return itemManager;
+    }
+
+    public enum PreparationCause {
+        JOIN,
+        RESPAWN,
+        COMMAND
     }
 }

--- a/src/main/java/com/lobby/lobby/items/LobbyItem.java
+++ b/src/main/java/com/lobby/lobby/items/LobbyItem.java
@@ -1,0 +1,19 @@
+package com.lobby.lobby.items;
+
+import org.bukkit.Material;
+
+import java.util.List;
+
+public record LobbyItem(
+        String id,
+        Material material,
+        int slot,
+        int amount,
+        String displayName,
+        List<String> lore,
+        List<String> actions,
+        String headId,
+        boolean glow,
+        Integer customModelData
+) {
+}

--- a/src/main/java/com/lobby/lobby/items/LobbyItemManager.java
+++ b/src/main/java/com/lobby/lobby/items/LobbyItemManager.java
@@ -1,0 +1,374 @@
+package com.lobby.lobby.items;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.lobby.LobbyManager;
+import com.lobby.shop.HeadItemBuilder;
+import com.lobby.utils.LogUtils;
+import com.lobby.utils.MessageUtils;
+import com.lobby.utils.PlaceholderUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+public class LobbyItemManager {
+
+    private final LobbyPlugin plugin;
+    private final NamespacedKey lobbyItemKey;
+    private final Map<String, LobbyItem> items = new LinkedHashMap<>();
+    private boolean enabled = true;
+    private boolean clearInventoryOnJoin = true;
+    private boolean restoreOnDeath = true;
+    private boolean preventDrop = true;
+    private boolean preventMove = true;
+    private boolean preventDamage = true;
+    private boolean preventConsume = true;
+    private int heldSlot = -1;
+
+    public LobbyItemManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        this.lobbyItemKey = new NamespacedKey(plugin, "lobby_item");
+        reload();
+    }
+
+    public void reload() {
+        items.clear();
+        final FileConfiguration configuration = plugin.getConfigManager().getLobbyItemsConfig();
+        final ConfigurationSection root = configuration.getConfigurationSection("lobby_items");
+        if (root == null) {
+            enabled = false;
+            return;
+        }
+
+        enabled = root.getBoolean("enabled", true);
+        clearInventoryOnJoin = root.getBoolean("clear_inventory_on_join", true);
+        restoreOnDeath = root.getBoolean("restore_on_death", true);
+        heldSlot = root.getInt("held_slot", -1);
+
+        final ConfigurationSection protectionSection = root.getConfigurationSection("protection");
+        if (protectionSection != null) {
+            preventDrop = protectionSection.getBoolean("prevent_drop", true);
+            preventMove = protectionSection.getBoolean("prevent_move", true);
+            preventDamage = protectionSection.getBoolean("prevent_damage", true);
+            preventConsume = protectionSection.getBoolean("prevent_consume", true);
+        } else {
+            preventDrop = true;
+            preventMove = true;
+            preventDamage = true;
+            preventConsume = true;
+        }
+
+        final ConfigurationSection itemsSection = root.getConfigurationSection("items");
+        if (itemsSection == null) {
+            return;
+        }
+
+        for (String key : itemsSection.getKeys(false)) {
+            final ConfigurationSection section = itemsSection.getConfigurationSection(key);
+            if (section == null) {
+                continue;
+            }
+            final Optional<LobbyItem> item = parseItem(key, section);
+            item.ifPresent(lobbyItem -> items.put(lobbyItem.id().toLowerCase(Locale.ROOT), lobbyItem));
+        }
+    }
+
+    public void apply(final Player player, final LobbyManager.PreparationCause cause) {
+        if (!enabled || player == null) {
+            return;
+        }
+
+        if (cause == LobbyManager.PreparationCause.RESPAWN && !restoreOnDeath) {
+            return;
+        }
+
+        final PlayerInventory inventory = player.getInventory();
+
+        if (cause == LobbyManager.PreparationCause.JOIN) {
+            if (clearInventoryOnJoin) {
+                clearInventory(inventory);
+            } else {
+                removeLobbyItems(inventory);
+            }
+        } else {
+            removeLobbyItems(inventory);
+        }
+
+        if (items.isEmpty()) {
+            player.updateInventory();
+            return;
+        }
+
+        for (LobbyItem item : items.values()) {
+            placeItem(player, inventory, item);
+        }
+
+        if (heldSlot >= 0 && heldSlot < 9) {
+            Bukkit.getScheduler().runTask(plugin, () -> player.getInventory().setHeldItemSlot(heldSlot));
+        }
+
+        player.updateInventory();
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public boolean shouldRestoreOnDeath() {
+        return restoreOnDeath;
+    }
+
+    public boolean shouldPreventDrop() {
+        return preventDrop;
+    }
+
+    public boolean shouldPreventMove() {
+        return preventMove;
+    }
+
+    public boolean shouldPreventDamage() {
+        return preventDamage;
+    }
+
+    public boolean shouldPreventConsume() {
+        return preventConsume;
+    }
+
+    public NamespacedKey getLobbyItemKey() {
+        return lobbyItemKey;
+    }
+
+    public Optional<LobbyItem> getLobbyItem(final ItemStack itemStack) {
+        if (!isLobbyItem(itemStack)) {
+            return Optional.empty();
+        }
+        final ItemMeta meta = itemStack.getItemMeta();
+        if (meta == null) {
+            return Optional.empty();
+        }
+        final PersistentDataContainer container = meta.getPersistentDataContainer();
+        final String identifier = container.get(lobbyItemKey, PersistentDataType.STRING);
+        if (identifier == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(items.get(identifier.toLowerCase(Locale.ROOT)));
+    }
+
+    public boolean isLobbyItem(final ItemStack itemStack) {
+        if (itemStack == null) {
+            return false;
+        }
+        final ItemMeta meta = itemStack.getItemMeta();
+        if (meta == null) {
+            return false;
+        }
+        final PersistentDataContainer container = meta.getPersistentDataContainer();
+        return container.has(lobbyItemKey, PersistentDataType.STRING);
+    }
+
+    public void handleInteraction(final Player player, final ItemStack itemStack) {
+        if (player == null || itemStack == null) {
+            return;
+        }
+        final Optional<LobbyItem> optionalItem = getLobbyItem(itemStack);
+        if (optionalItem.isEmpty()) {
+            return;
+        }
+        final LobbyItem lobbyItem = optionalItem.get();
+        final List<String> actions = lobbyItem.actions();
+        if (actions.isEmpty()) {
+            return;
+        }
+        final var npcManager = plugin.getNpcManager();
+        if (npcManager == null || npcManager.getActionProcessor() == null) {
+            LogUtils.warning(plugin, "Unable to execute lobby item actions: ActionProcessor unavailable.");
+            return;
+        }
+        npcManager.getActionProcessor().processActions(actions, player, null);
+    }
+
+    public void removeLobbyItems(final PlayerInventory inventory) {
+        if (inventory == null) {
+            return;
+        }
+        for (int slot = 0; slot < inventory.getSize(); slot++) {
+            final ItemStack itemStack = inventory.getItem(slot);
+            if (isLobbyItem(itemStack)) {
+                inventory.setItem(slot, null);
+            }
+        }
+        if (isLobbyItem(inventory.getItemInOffHand())) {
+            inventory.setItemInOffHand(null);
+        }
+    }
+
+    public void shutdown() {
+        items.clear();
+    }
+
+    private void placeItem(final Player player, final PlayerInventory inventory, final LobbyItem lobbyItem) {
+        final ItemStack itemStack = createItemStack(player, lobbyItem);
+        if (lobbyItem.slot() >= 0 && lobbyItem.slot() < inventory.getSize()) {
+            inventory.setItem(lobbyItem.slot(), itemStack);
+        } else {
+            inventory.addItem(itemStack);
+        }
+    }
+
+    private ItemStack createItemStack(final Player player, final LobbyItem lobbyItem) {
+        ItemStack baseItem = createBaseItem(player, lobbyItem);
+        if (baseItem.getType() != lobbyItem.material()) {
+            baseItem.setType(lobbyItem.material());
+        }
+        baseItem.setAmount(Math.max(1, lobbyItem.amount()));
+
+        final ItemMeta meta = baseItem.getItemMeta();
+        if (meta != null) {
+            if (lobbyItem.displayName() != null && !lobbyItem.displayName().isBlank()) {
+                final String processedName = MessageUtils.colorize(PlaceholderUtils.applyPlaceholders(plugin,
+                        lobbyItem.displayName(), player));
+                meta.setDisplayName(processedName);
+            }
+
+            if (!lobbyItem.lore().isEmpty()) {
+                final List<String> lore = PlaceholderUtils.applyPlaceholders(plugin, lobbyItem.lore(), player)
+                        .stream()
+                        .map(MessageUtils::colorize)
+                        .toList();
+                meta.setLore(lore);
+            }
+
+            meta.setUnbreakable(true);
+            meta.addItemFlags(ItemFlag.HIDE_UNBREAKABLE, ItemFlag.HIDE_ATTRIBUTES);
+            final PersistentDataContainer container = meta.getPersistentDataContainer();
+            container.set(lobbyItemKey, PersistentDataType.STRING, lobbyItem.id());
+
+            if (lobbyItem.customModelData() != null) {
+                meta.setCustomModelData(lobbyItem.customModelData());
+            }
+
+            if (lobbyItem.glow()) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                meta.addEnchant(org.bukkit.enchantments.Enchantment.UNBREAKING, 1, true);
+            }
+
+            baseItem.setItemMeta(meta);
+        }
+
+        return baseItem;
+    }
+
+    private ItemStack createBaseItem(final Player player, final LobbyItem lobbyItem) {
+        if (lobbyItem.material() == Material.PLAYER_HEAD) {
+            final String headId = lobbyItem.headId();
+            if (headId != null && !headId.isBlank()) {
+                if ("%player_name%".equalsIgnoreCase(headId.trim())) {
+                    final ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+                    final ItemMeta meta = head.getItemMeta();
+                    if (meta instanceof SkullMeta skullMeta && player != null) {
+                        skullMeta.setOwningPlayer(player);
+                        head.setItemMeta(skullMeta);
+                    }
+                    return head;
+                }
+                if (headId.startsWith("hdb:")) {
+                    final ItemStack databaseHead = HeadItemBuilder.createHeadItem(headId);
+                    if (databaseHead != null) {
+                        return databaseHead;
+                    }
+                }
+            }
+            final ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
+            if (player != null && headId != null && !headId.isBlank()) {
+                final ItemMeta meta = skull.getItemMeta();
+                if (meta instanceof SkullMeta skullMeta) {
+                    final String processed = PlaceholderUtils.applyPlaceholders(plugin, headId, player);
+                    final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(processed);
+                    skullMeta.setOwningPlayer(offlinePlayer);
+                    skull.setItemMeta(skullMeta);
+                }
+            }
+            return skull;
+        }
+        return new ItemStack(lobbyItem.material());
+    }
+
+    private Optional<LobbyItem> parseItem(final String id, final ConfigurationSection section) {
+        final String materialName = section.getString("material", "PLAYER_HEAD");
+        final Material material = Material.matchMaterial(materialName);
+        if (material == null) {
+            LogUtils.warning(plugin, "Invalid material '" + materialName + "' for lobby item '" + id + "'.");
+            return Optional.empty();
+        }
+
+        final int slot = section.getInt("slot", -1);
+        final int amount = Math.max(1, section.getInt("amount", 1));
+        final String name = section.getString("name");
+        final List<String> lore = sanitizeList(section.getStringList("lore"));
+        final List<String> actions = extractActions(section);
+        final String headId = section.getString("head_id");
+        final boolean glow = section.getBoolean("glow", false);
+        final Integer customModelData = section.contains("custom_model_data") ? section.getInt("custom_model_data") : null;
+
+        final LobbyItem lobbyItem = new LobbyItem(id, material, slot, amount, name, lore, actions, headId, glow,
+                customModelData);
+        return Optional.of(lobbyItem);
+    }
+
+    private List<String> extractActions(final ConfigurationSection section) {
+        final List<String> actions = new ArrayList<>();
+        if (section.isString("action")) {
+            final String action = section.getString("action");
+            if (action != null && !action.isBlank()) {
+                actions.add(action.trim());
+            }
+        }
+        if (section.isList("actions")) {
+            for (String action : section.getStringList("actions")) {
+                if (action == null || action.isBlank()) {
+                    continue;
+                }
+                actions.add(action.trim());
+            }
+        }
+        return actions.isEmpty() ? Collections.emptyList() : List.copyOf(actions);
+    }
+
+    private List<String> sanitizeList(final List<String> lines) {
+        if (lines == null || lines.isEmpty()) {
+            return List.of();
+        }
+        final List<String> sanitized = new ArrayList<>();
+        for (String line : lines) {
+            if (line != null) {
+                sanitized.add(line);
+            }
+        }
+        return sanitized.isEmpty() ? List.of() : List.copyOf(sanitized);
+    }
+
+    private void clearInventory(final PlayerInventory inventory) {
+        inventory.clear();
+        inventory.setArmorContents(null);
+        inventory.setExtraContents(new ItemStack[0]);
+        inventory.setItemInOffHand(null);
+    }
+}

--- a/src/main/java/com/lobby/lobby/listeners/LobbyItemListener.java
+++ b/src/main/java/com/lobby/lobby/listeners/LobbyItemListener.java
@@ -1,0 +1,163 @@
+package com.lobby.lobby.listeners;
+
+import com.lobby.lobby.LobbyManager;
+import com.lobby.lobby.items.LobbyItemManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.event.player.PlayerItemDamageEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Iterator;
+
+public class LobbyItemListener implements Listener {
+
+    private final LobbyManager lobbyManager;
+    private final LobbyItemManager itemManager;
+
+    public LobbyItemListener(final LobbyManager lobbyManager, final LobbyItemManager itemManager) {
+        this.lobbyManager = lobbyManager;
+        this.itemManager = itemManager;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onInventoryClick(final InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (!itemManager.isEnabled()) {
+            return;
+        }
+        if (!itemManager.shouldPreventMove() && lobbyManager.isBypassing(player)) {
+            return;
+        }
+        final ItemStack currentItem = event.getCurrentItem();
+        final ItemStack cursorItem = event.getCursor();
+        if (event.getHotbarButton() >= 0) {
+            final ItemStack hotbarItem = player.getInventory().getItem(event.getHotbarButton());
+            if (itemManager.isLobbyItem(hotbarItem)) {
+                event.setCancelled(true);
+                player.updateInventory();
+                return;
+            }
+        }
+        if (itemManager.isLobbyItem(currentItem) || itemManager.isLobbyItem(cursorItem)) {
+            event.setCancelled(true);
+            player.updateInventory();
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onInventoryDrag(final InventoryDragEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (!itemManager.isEnabled()) {
+            return;
+        }
+        if (!itemManager.shouldPreventMove() && lobbyManager.isBypassing(player)) {
+            return;
+        }
+        if (itemManager.isLobbyItem(event.getOldCursor())) {
+            event.setCancelled(true);
+            player.updateInventory();
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onDrop(final PlayerDropItemEvent event) {
+        final Player player = event.getPlayer();
+        if (!itemManager.isEnabled()) {
+            return;
+        }
+        if (!itemManager.shouldPreventDrop() && lobbyManager.isBypassing(player)) {
+            return;
+        }
+        if (itemManager.isLobbyItem(event.getItemDrop().getItemStack())) {
+            event.setCancelled(true);
+            player.updateInventory();
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onSwapHands(final PlayerSwapHandItemsEvent event) {
+        final Player player = event.getPlayer();
+        if (!itemManager.isEnabled()) {
+            return;
+        }
+        if (!itemManager.shouldPreventMove() && lobbyManager.isBypassing(player)) {
+            return;
+        }
+        if (itemManager.isLobbyItem(event.getMainHandItem()) || itemManager.isLobbyItem(event.getOffHandItem())) {
+            event.setCancelled(true);
+            player.updateInventory();
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onItemDamage(final PlayerItemDamageEvent event) {
+        if (!itemManager.shouldPreventDamage()) {
+            return;
+        }
+        if (itemManager.isLobbyItem(event.getItem())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onItemConsume(final PlayerItemConsumeEvent event) {
+        if (!itemManager.shouldPreventConsume()) {
+            return;
+        }
+        if (itemManager.isLobbyItem(event.getItem())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onInteract(final PlayerInteractEvent event) {
+        final Player player = event.getPlayer();
+        if (!itemManager.isEnabled()) {
+            return;
+        }
+        if (event.getHand() == EquipmentSlot.OFF_HAND) {
+            return;
+        }
+        switch (event.getAction()) {
+            case RIGHT_CLICK_AIR, RIGHT_CLICK_BLOCK -> {
+            }
+            default -> {
+                return;
+            }
+        }
+        final ItemStack item = event.getItem();
+        if (!itemManager.isLobbyItem(item)) {
+            return;
+        }
+        event.setCancelled(true);
+        itemManager.handleInteraction(player, item);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onDeath(final PlayerDeathEvent event) {
+        if (!itemManager.isEnabled()) {
+            return;
+        }
+        final Iterator<ItemStack> iterator = event.getDrops().iterator();
+        while (iterator.hasNext()) {
+            final ItemStack drop = iterator.next();
+            if (itemManager.isLobbyItem(drop)) {
+                iterator.remove();
+            }
+        }
+    }
+}

--- a/src/main/java/com/lobby/lobby/listeners/LobbyPlayerListener.java
+++ b/src/main/java/com/lobby/lobby/listeners/LobbyPlayerListener.java
@@ -29,7 +29,7 @@ public class LobbyPlayerListener implements Listener {
         final Player player = event.getPlayer();
         final boolean hasSpawn = lobbyManager.hasLobbySpawn();
         final boolean teleported = lobbyManager.teleportToLobby(player);
-        lobbyManager.preparePlayer(player);
+        lobbyManager.preparePlayer(player, LobbyManager.PreparationCause.JOIN);
         if (!hasSpawn && player.hasPermission("lobby.admin")) {
             MessageUtils.sendConfigMessage(player, "lobby.spawn_not_set");
         } else if (!teleported) {
@@ -63,7 +63,7 @@ public class LobbyPlayerListener implements Listener {
         }
         final Player player = event.getPlayer();
         if (!lobbyManager.isBypassing(player)) {
-            lobbyManager.preparePlayer(player);
+            lobbyManager.preparePlayer(player, LobbyManager.PreparationCause.RESPAWN);
         }
     }
 

--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -45,6 +45,13 @@ public class ConfiguredMenu implements Menu {
         inventory = Bukkit.createInventory(null, size, title);
         actionsBySlot.clear();
 
+        final ItemStack filler = createFillerItem(menuSection.getString("fill_material"));
+        if (filler != null) {
+            for (int slot = 0; slot < inventory.getSize(); slot++) {
+                inventory.setItem(slot, filler.clone());
+            }
+        }
+
         final ConfigurationSection itemsSection = menuSection.getConfigurationSection("items");
         if (itemsSection != null) {
             for (String key : itemsSection.getKeys(false)) {
@@ -193,6 +200,25 @@ public class ConfiguredMenu implements Menu {
         final int clamped = Math.max(9, Math.min(54, requested));
         final int remainder = clamped % 9;
         return remainder == 0 ? clamped : clamped + (9 - remainder);
+    }
+
+    private ItemStack createFillerItem(final String materialName) {
+        if (materialName == null || materialName.isBlank()) {
+            return null;
+        }
+        final Material material = Material.matchMaterial(materialName);
+        if (material == null) {
+            LogUtils.warning(plugin, "Invalid filler material '" + materialName + "' in menu '" + menuId + "'.");
+            return null;
+        }
+        final ItemStack itemStack = new ItemStack(material);
+        final ItemMeta meta = itemStack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            meta.addItemFlags(ItemFlag.values());
+            itemStack.setItemMeta(meta);
+        }
+        return itemStack;
     }
 
     private ActionProcessor resolveActionProcessor() {

--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -5,6 +5,7 @@ import com.lobby.utils.MessageUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -15,8 +16,10 @@ import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.Inventory;
 
+import java.io.File;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -24,24 +27,30 @@ public class MenuManager implements Listener {
 
     private final LobbyPlugin plugin;
     private final Map<UUID, Menu> openMenus = new ConcurrentHashMap<>();
+    private final Map<String, ConfigurationSection> menuDefinitions = new ConcurrentHashMap<>();
 
     public MenuManager(final LobbyPlugin plugin) {
         this.plugin = plugin;
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        reloadMenus();
     }
 
     public boolean openMenu(final Player player, final String menuId) {
         if (player == null || menuId == null || menuId.isBlank()) {
             return false;
         }
-        final FileConfiguration menusConfig = plugin.getConfigManager().getMenusConfig();
-        final ConfigurationSection menuSection = menusConfig.getConfigurationSection("menus." + menuId);
+        final String normalizedId = menuId.toLowerCase(java.util.Locale.ROOT);
+        ConfigurationSection menuSection = menuDefinitions.get(normalizedId);
         if (menuSection == null) {
-            MessageUtils.sendConfigMessage(player, "menus.not_found", Map.of("menu", menuId));
-            return false;
+            reloadMenus();
+            menuSection = menuDefinitions.get(normalizedId);
+            if (menuSection == null) {
+                MessageUtils.sendConfigMessage(player, "menus.not_found", Map.of("menu", menuId));
+                return false;
+            }
         }
 
-        final Menu menu = new ConfiguredMenu(plugin, menuId, menuSection);
+        final Menu menu = new ConfiguredMenu(plugin, normalizedId, menuSection);
         openMenus.put(player.getUniqueId(), menu);
         menu.open(player);
         if (menu.getInventory() == null) {
@@ -67,6 +76,12 @@ public class MenuManager implements Listener {
             }
         });
         openMenus.clear();
+    }
+
+    public void reloadMenus() {
+        menuDefinitions.clear();
+        loadMenusFromMainConfig();
+        loadMenusFromDirectory();
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
@@ -114,5 +129,69 @@ public class MenuManager implements Listener {
     @EventHandler
     public void onPlayerQuit(final PlayerQuitEvent event) {
         openMenus.remove(event.getPlayer().getUniqueId());
+    }
+
+    private void loadMenusFromMainConfig() {
+        final FileConfiguration menusConfig = plugin.getConfigManager().getMenusConfig();
+        final ConfigurationSection menusSection = menusConfig.getConfigurationSection("menus");
+        if (menusSection == null) {
+            return;
+        }
+        for (String key : menusSection.getKeys(false)) {
+            final ConfigurationSection section = menusSection.getConfigurationSection(key);
+            if (section == null) {
+                continue;
+            }
+            menuDefinitions.put(key.toLowerCase(java.util.Locale.ROOT), section);
+        }
+    }
+
+    private void loadMenusFromDirectory() {
+        final File menusDirectory = ensureMenusDirectory();
+        final File[] files = menusDirectory.listFiles((dir, name) -> name.endsWith(".yml"));
+        if (files == null || files.length == 0) {
+            return;
+        }
+        for (File file : files) {
+            final YamlConfiguration configuration = YamlConfiguration.loadConfiguration(file);
+            ConfigurationSection menuSection = configuration.getConfigurationSection("menu");
+            if (menuSection == null) {
+                menuSection = configuration;
+            }
+            final String id = menuSection.getString("id", stripExtension(file.getName()));
+            if (id == null || id.isBlank()) {
+                continue;
+            }
+            menuDefinitions.put(id.toLowerCase(java.util.Locale.ROOT), menuSection);
+        }
+    }
+
+    private File ensureMenusDirectory() {
+        final File directory = new File(plugin.getDataFolder(), "config/menus");
+        if (!directory.exists() && !directory.mkdirs()) {
+            plugin.getLogger().severe("Unable to create config/menus directory for menu definitions.");
+        }
+        final Set<String> defaults = Set.of(
+                "jeux_menu.yml",
+                "profil_menu.yml",
+                "shop_menu.yml",
+                "cosmetiques_menu.yml",
+                "hub_menu.yml"
+        );
+        for (String fileName : defaults) {
+            final File target = new File(directory, fileName);
+            if (!target.exists()) {
+                plugin.saveResource("config/menus/" + fileName, false);
+            }
+        }
+        return directory;
+    }
+
+    private String stripExtension(final String fileName) {
+        final int index = fileName.lastIndexOf('.');
+        if (index <= 0) {
+            return fileName;
+        }
+        return fileName.substring(0, index);
     }
 }

--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -12,6 +12,9 @@ import org.bukkit.Registry;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
@@ -60,10 +63,21 @@ public class ActionProcessor {
             Bukkit.getScheduler().runTask(plugin, (Runnable) player::closeInventory);
             return;
         }
+        if (startsWithIgnoreCase(trimmed, "[CLOSE_MENU]")) {
+            Bukkit.getScheduler().runTask(plugin, (Runnable) player::closeInventory);
+            return;
+        }
         if (startsWithIgnoreCase(trimmed, "[COMMAND]")) {
             final String command = processed.substring(9).trim();
             if (!command.isEmpty()) {
                 Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
+            }
+            return;
+        }
+        if (startsWithIgnoreCase(trimmed, "[PLAYER_COMMAND]")) {
+            final String command = processed.substring(15).trim();
+            if (!command.isEmpty()) {
+                Bukkit.getScheduler().runTask(plugin, (Runnable) () -> player.performCommand(command));
             }
             return;
         }
@@ -81,6 +95,18 @@ public class ActionProcessor {
             }
             return;
         }
+        if (startsWithIgnoreCase(trimmed, "[OPEN_MENU]")) {
+            final String menuId = processed.substring(10).trim();
+            if (!menuId.isEmpty()) {
+                final MenuManager menuManager = plugin.getMenuManager();
+                if (menuManager != null) {
+                    Bukkit.getScheduler().runTask(plugin, (Runnable) () -> menuManager.openMenu(player, menuId));
+                } else {
+                    LogUtils.warning(plugin, "Menu action requested but MenuManager is not available: " + menuId);
+                }
+            }
+            return;
+        }
         if (startsWithIgnoreCase(trimmed, "[COINS_ADD]")) {
             final String amountRaw = processed.substring(11).trim();
             parseAmountAndApply(amountRaw, value -> plugin.getEconomyManager().addCoins(player.getUniqueId(), value,
@@ -91,6 +117,13 @@ public class ActionProcessor {
             final String amountRaw = processed.substring(12).trim();
             parseAmountAndApply(amountRaw, value -> plugin.getEconomyManager().addTokens(player.getUniqueId(), value,
                     "NPC interaction"));
+            return;
+        }
+        if (startsWithIgnoreCase(trimmed, "[SERVER_SEND]")) {
+            final String server = processed.substring(12).trim();
+            if (!server.isEmpty()) {
+                sendToServer(player, server);
+            }
             return;
         }
         if (startsWithIgnoreCase(trimmed, "[TELEPORT]")) {
@@ -132,6 +165,26 @@ public class ActionProcessor {
         } catch (final NumberFormatException exception) {
             LogUtils.warning(plugin, "Invalid teleport coordinates for NPC '" + (npc != null ? npc.getData().name()
                     : "unknown") + "': " + coordinates);
+        }
+    }
+
+    private void sendToServer(final Player player, final String server) {
+        if (player == null || server == null || server.isBlank()) {
+            return;
+        }
+        final String target = server.trim();
+        try {
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            try (DataOutputStream dataOutputStream = new DataOutputStream(outputStream)) {
+                dataOutputStream.writeUTF("Connect");
+                dataOutputStream.writeUTF(target);
+            }
+            final byte[] payload = outputStream.toByteArray();
+            player.sendPluginMessage(plugin, "BungeeCord", payload);
+            player.sendPluginMessage(plugin, "bungeecord:main", payload);
+        } catch (final IOException exception) {
+            LogUtils.warning(plugin, "Failed to send player '" + player.getName() + "' to server '" + target + "': "
+                    + exception.getMessage());
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -62,25 +62,4 @@ lobby:
       random_tick_speed: 0
   protection:
     void_teleport_y: 0.0
-  inventory:
-    enabled: true
-    held_slot: 4
-    items:
-      navigator:
-        material: COMPASS
-        slot: 0
-        name: "&aSélecteur de serveurs"
-        lore:
-          - "&7Clique pour choisir un serveur"
-      profile:
-        material: CLOCK
-        slot: 4
-        name: "&bProfil joueur"
-        lore:
-          - "&7Consulte tes informations"
-      cosmetics:
-        material: NETHER_STAR
-        slot: 8
-        name: "&dCosmétiques"
-        lore:
-          - "&7Découvre des gadgets uniques"
+  items_config: "config/lobby-items.yml"

--- a/src/main/resources/config/lobby-items.yml
+++ b/src/main/resources/config/lobby-items.yml
@@ -1,0 +1,63 @@
+lobby_items:
+  enabled: true
+  clear_inventory_on_join: true
+  restore_on_death: true
+  held_slot: 0
+
+  items:
+    games_selector:
+      slot: 0
+      material: PLAYER_HEAD
+      head_id: "hdb:35517"
+      name: "&aMenu des Jeux &7(Clic-droit)"
+      lore:
+        - "&7Rejoignez un mode de jeu."
+        - "&7Statistiques dynamiques disponibles."
+      actions:
+        - "[MENU] jeux_menu"
+
+    profile:
+      slot: 1
+      material: PLAYER_HEAD
+      head_id: "%player_name%"
+      name: "&6Mon Profil &7(Clic-droit)"
+      lore:
+        - "&7Consulte tes informations personnelles."
+      actions:
+        - "[MENU] profil_menu"
+
+    shop:
+      slot: 4
+      material: PLAYER_HEAD
+      head_id: "hdb:35472"
+      name: "&eBoutique &7(Clic-droit)"
+      lore:
+        - "&7Découvre des offres exclusives."
+      actions:
+        - "[MENU] shop_menu"
+
+    cosmetics:
+      slot: 7
+      material: PLAYER_HEAD
+      head_id: "hdb:67678"
+      name: "&dCosmétiques &7(Clic-droit)"
+      lore:
+        - "&7Personnalise ton expérience."
+      actions:
+        - "[MENU] cosmetiques_menu"
+
+    hub_selector:
+      slot: 8
+      material: PLAYER_HEAD
+      head_id: "hdb:15082"
+      name: "&bSélecteur de Hub &7(Clic-droit)"
+      lore:
+        - "&7Navigue entre les hubs."
+      actions:
+        - "[MENU] hub_menu"
+
+  protection:
+    prevent_drop: true
+    prevent_move: true
+    prevent_damage: true
+    prevent_consume: true

--- a/src/main/resources/config/menus/cosmetiques_menu.yml
+++ b/src/main/resources/config/menus/cosmetiques_menu.yml
@@ -1,0 +1,45 @@
+menu:
+  id: "cosmetiques_menu"
+  title: "&8» &dCosmétiques"
+  size: 45
+  fill_material: "PINK_STAINED_GLASS_PANE"
+
+  items:
+    particles:
+      slot: 20
+      material: "GHAST_TEAR"
+      name: "&dParticules"
+      lore:
+        - "&7Sélectionne un effet visuel"
+        - "&7unique pour ton personnage."
+      actions:
+        - "[COMMAND] cosmetics open particles"
+
+    morphs:
+      slot: 22
+      material: "CREEPER_HEAD"
+      name: "&aMorphs"
+      lore:
+        - "&7Transforme-toi en créatures"
+        - "&7et amuse-toi avec tes amis."
+      actions:
+        - "[COMMAND] cosmetics open morphs"
+
+    gadgets:
+      slot: 24
+      material: "BLAZE_ROD"
+      name: "&bGadgets"
+      lore:
+        - "&7Débloque des gadgets amusants"
+        - "&7et interactifs."
+      actions:
+        - "[COMMAND] cosmetics open gadgets"
+
+    back:
+      slot: 40
+      material: "ARROW"
+      name: "&cRetour"
+      lore:
+        - "&7Revenir à la boutique"
+      actions:
+        - "[MENU] shop_menu"

--- a/src/main/resources/config/menus/hub_menu.yml
+++ b/src/main/resources/config/menus/hub_menu.yml
@@ -1,0 +1,45 @@
+menu:
+  id: "hub_menu"
+  title: "&8» &bSélecteur de Hub"
+  size: 27
+  fill_material: "CYAN_STAINED_GLASS_PANE"
+
+  items:
+    hub1:
+      slot: 11
+      material: "ENDER_PEARL"
+      name: "&bHub #1"
+      lore:
+        - "&7Serveur principal"
+        - "&7Joueurs: &f%server_online_hub1%"
+      actions:
+        - "[SERVER_SEND] hub1"
+
+    hub2:
+      slot: 13
+      material: "ENDER_EYE"
+      name: "&bHub #2"
+      lore:
+        - "&7Serveur alternatif"
+        - "&7Joueurs: &f%server_online_hub2%"
+      actions:
+        - "[SERVER_SEND] hub2"
+
+    hub3:
+      slot: 15
+      material: "HEART_OF_THE_SEA"
+      name: "&bHub #3"
+      lore:
+        - "&7Serveur événementiel"
+        - "&7Joueurs: &f%server_online_hub3%"
+      actions:
+        - "[SERVER_SEND] hub3"
+
+    close:
+      slot: 22
+      material: "BARRIER"
+      name: "&cFermer"
+      lore:
+        - "&7Retour"
+      actions:
+        - "[CLOSE_MENU]"

--- a/src/main/resources/config/menus/jeux_menu.yml
+++ b/src/main/resources/config/menus/jeux_menu.yml
@@ -1,0 +1,54 @@
+menu:
+  id: "jeux_menu"
+  title: "&8» &aMenu des Jeux"
+  size: 36
+  fill_material: "BLACK_STAINED_GLASS_PANE"
+
+  items:
+    factions:
+      slot: 11
+      material: "DIAMOND_SWORD"
+      name: "&cMode de Jeu 1"
+      lore:
+        - "&7Rejoignez le serveur Faction," 
+        - "&7pillez, combattez et dominez !"
+        - "     "
+        - "&eJoueurs: &f%server_online_factions%"
+        - "&a► Cliquez pour jouer !"
+      actions:
+        - "[SERVER_SEND] factions"
+
+    bedwars:
+      slot: 13
+      material: "RED_BED"
+      name: "&aMode de Jeu 2"
+      lore:
+        - "&7Défendez votre lit et"
+        - "&7détruisez celui des autres."
+        - "     "
+        - "&eJoueurs: &f%server_online_bedwars%"
+        - "&a► Cliquez pour jouer !"
+      actions:
+        - "[SERVER_SEND] bedwars"
+
+    skyblock:
+      slot: 15
+      material: "GRASS_BLOCK"
+      name: "&bMode de Jeu 3"
+      lore:
+        - "&7Développez votre île volante"
+        - "&7et devenez le plus riche."
+        - "     "
+        - "&eJoueurs: &f%server_online_skyblock%"
+        - "&a► Cliquez pour jouer !"
+      actions:
+        - "[SERVER_SEND] skyblock"
+
+    close:
+      slot: 31
+      material: "BARRIER"
+      name: "&cQuitter"
+      lore:
+        - "&7Fermer ce menu"
+      actions:
+        - "[CLOSE_MENU]"

--- a/src/main/resources/config/menus/profil_menu.yml
+++ b/src/main/resources/config/menus/profil_menu.yml
@@ -1,0 +1,38 @@
+menu:
+  id: "profil_menu"
+  title: "&8» &6Mon Profil"
+  size: 27
+  fill_material: "GRAY_STAINED_GLASS_PANE"
+
+  items:
+    profile_overview:
+      slot: 11
+      material: "PLAYER_HEAD"
+      head: "%player_name%"
+      name: "&eStatistiques"
+      lore:
+        - "&7Pseudo: &f%player_name%"
+        - "&7Coins: &f%player_coins%"
+        - "&7Tokens: &f%player_tokens%"
+        - "&7Première connexion: &f%player_first_join%"
+        - "&7Dernière connexion: &f%player_last_join%"
+        - "&7Temps de jeu: &f%player_playtime%"
+
+    economy_history:
+      slot: 13
+      material: "GOLD_INGOT"
+      name: "&6Historique économique"
+      lore:
+        - "&7Consulte tes transactions"
+        - "&7et récompenses récentes."
+      actions:
+        - "[MESSAGE] &eFonctionnalité à venir !"
+
+    close:
+      slot: 15
+      material: "BARRIER"
+      name: "&cFermer"
+      lore:
+        - "&7Revenir au jeu"
+      actions:
+        - "[CLOSE_MENU]"

--- a/src/main/resources/config/menus/shop_menu.yml
+++ b/src/main/resources/config/menus/shop_menu.yml
@@ -1,0 +1,44 @@
+menu:
+  id: "shop_menu"
+  title: "&8» &eBoutique"
+  size: 45
+  fill_material: "LIGHT_BLUE_STAINED_GLASS_PANE"
+
+  items:
+    ranks:
+      slot: 20
+      material: "EMERALD"
+      name: "&aGrades"
+      lore:
+        - "&7Découvrez les grades premium"
+        - "&7et leurs avantages exclusifs."
+      actions:
+        - "[COMMAND] shop open ranks"
+
+    boosters:
+      slot: 22
+      material: "NETHER_STAR"
+      name: "&dBoosters"
+      lore:
+        - "&7Augmentez vos gains"
+        - "&7pendant une durée limitée."
+      actions:
+        - "[COMMAND] shop open boosters"
+
+    cosmetics:
+      slot: 24
+      material: "FIREWORK_ROCKET"
+      name: "&bCosmétiques"
+      lore:
+        - "&7Particules, gadgets et plus encore."
+      actions:
+        - "[MENU] cosmetiques_menu"
+
+    close:
+      slot: 40
+      material: "BARRIER"
+      name: "&cFermer"
+      lore:
+        - "&7Retour"
+      actions:
+        - "[CLOSE_MENU]"


### PR DESCRIPTION
## Summary
- implement a dedicated lobby item manager with YAML configuration, placeholder-aware item creation, and persistent protection
- add a lobby item listener to guard interactions, hook item actions into the existing processor, and wire everything through LobbyManager and LobbyPlugin
- revamp menu loading with filler slots, per-file menu definitions, and new default menu configurations alongside extended action support

## Testing
- `mvn -q -DskipTests package` *(fails: repository download blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5c685d288329a5fa57ef67d154c8