### PR TITLE
Fix HeadDatabase integration for lobby inventory items

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -9,6 +9,7 @@ import com.lobby.core.ConfigManager;
 import com.lobby.core.DatabaseManager;
 import com.lobby.core.PlayerDataManager;
 import com.lobby.economy.EconomyManager;
+import com.lobby.heads.HeadDatabaseManager;
 import com.lobby.holograms.HologramManager;
 import com.lobby.menus.MenuManager;
 import com.lobby.npcs.NPCInteractionHandler;
@@ -36,6 +37,7 @@ public final class LobbyPlugin extends JavaPlugin {
     private NPCManager npcManager;
     private LobbyManager lobbyManager;
     private MenuManager menuManager;
+    private HeadDatabaseManager headDatabaseManager;
     private ShopManager shopManager;
     private ShopCommands shopCommands;
 
@@ -52,6 +54,8 @@ public final class LobbyPlugin extends JavaPlugin {
 
         configManager = new ConfigManager(this);
         configManager.loadConfigs();
+
+        headDatabaseManager = new HeadDatabaseManager(this);
 
         databaseManager = new DatabaseManager(this);
         if (!databaseManager.initialize()) {
@@ -99,6 +103,9 @@ public final class LobbyPlugin extends JavaPlugin {
         if (shopManager != null) {
             shopManager.shutdown();
         }
+        if (headDatabaseManager != null) {
+            headDatabaseManager.clearCache();
+        }
         if (databaseManager != null) {
             databaseManager.shutdown();
         }
@@ -139,6 +146,10 @@ public final class LobbyPlugin extends JavaPlugin {
         return menuManager;
     }
 
+    public HeadDatabaseManager getHeadDatabaseManager() {
+        return headDatabaseManager;
+    }
+
     public ShopManager getShopManager() {
         return shopManager;
     }
@@ -159,6 +170,9 @@ public final class LobbyPlugin extends JavaPlugin {
         }
         if (hologramManager != null) {
             hologramManager.reload();
+        }
+        if (headDatabaseManager != null) {
+            headDatabaseManager.reload();
         }
         if (npcManager != null) {
             npcManager.reload();

--- a/src/main/java/com/lobby/heads/HeadDatabaseManager.java
+++ b/src/main/java/com/lobby/heads/HeadDatabaseManager.java
@@ -1,0 +1,297 @@
+package com.lobby.heads;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.utils.LogUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.plugin.Plugin;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Central manager for interactions with the HeadDatabase plugin.
+ * <p>
+ * The implementation relies on reflection to avoid a hard dependency on the HeadDatabase API while still
+ * providing caching, fallback materials and optional debug logging.
+ */
+public class HeadDatabaseManager {
+
+    private static final String HDB_PLUGIN_NAME = "HeadDatabase";
+    private static final String HDB_API_CLASS = "me.arcaniax.hdb.api.HeadDatabaseAPI";
+
+    private final LobbyPlugin plugin;
+    private final Map<String, ItemStack> headCache = new ConcurrentHashMap<>();
+
+    private volatile Object apiInstance;
+    private volatile Method getItemHeadMethod;
+    private volatile boolean headDatabaseEnabled;
+    private volatile boolean debugLogging;
+    private volatile boolean missingPluginLogged;
+
+    public HeadDatabaseManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        reload();
+    }
+
+    /**
+     * Reload the manager by clearing the cache and re-evaluating the HeadDatabase availability.
+     */
+    public synchronized void reload() {
+        headCache.clear();
+        apiInstance = null;
+        getItemHeadMethod = null;
+        headDatabaseEnabled = false;
+        missingPluginLogged = false;
+        initializeHeadDatabase();
+    }
+
+    /**
+     * Toggle verbose logging for debugging purposes.
+     *
+     * @param enabled true to enable verbose logging, false otherwise
+     */
+    public void setDebugLogging(final boolean enabled) {
+        debugLogging = enabled;
+    }
+
+    /**
+     * Returns whether the HeadDatabase plugin is currently available.
+     *
+     * @return true if the plugin is enabled and the API could be accessed, false otherwise
+     */
+    public boolean isHeadDatabaseEnabled() {
+        ensureInitialized();
+        return headDatabaseEnabled;
+    }
+
+    /**
+     * Obtain a custom head for the given identifier. The identifier can either be a HeadDatabase id prefixed with
+     * {@code hdb:} or the name of a vanilla {@link Material}. When the head cannot be retrieved, the provided
+     * fallback material (or a player head by default) is used instead.
+     *
+     * @param headId           the identifier of the head to fetch
+     * @param fallbackMaterial optional fallback material when the head cannot be resolved
+     * @return a clone-safe {@link ItemStack} representing the requested head or fallback
+     */
+    public ItemStack getHead(final String headId, final Material fallbackMaterial) {
+        final String trimmedId = headId == null ? "" : headId.trim();
+        final Material resolvedFallback = fallbackMaterial != null ? fallbackMaterial : Material.PLAYER_HEAD;
+        final String cacheKey = createCacheKey(trimmedId, resolvedFallback);
+
+        final ItemStack cached = headCache.get(cacheKey);
+        if (cached != null) {
+            debug("Cache hit for head " + trimmedId + " (fallback=" + resolvedFallback + ")");
+            return cached.clone();
+        }
+
+        ItemStack resolved = null;
+
+        if (!trimmedId.isEmpty() && trimmedId.toLowerCase(Locale.ROOT).startsWith("hdb:")) {
+            resolved = getHeadFromDatabase(trimmedId.substring(4));
+        } else if (!trimmedId.isEmpty()) {
+            resolved = resolveVanillaMaterial(trimmedId);
+        }
+
+        if (resolved == null) {
+            debug("Using fallback material for head " + trimmedId + " -> " + resolvedFallback);
+            resolved = createFallbackHead(resolvedFallback);
+        }
+
+        headCache.put(cacheKey, resolved.clone());
+        return resolved;
+    }
+
+    /**
+     * Shortcut for fetching a HeadDatabase head with a default player head fallback.
+     *
+     * @param headId identifier of the head
+     * @return the resolved head item stack
+     */
+    public ItemStack getHead(final String headId) {
+        return getHead(headId, Material.PLAYER_HEAD);
+    }
+
+    /**
+     * Fetch a player head for the provided player. The result is cached by player name to improve performance.
+     *
+     * @param player the player for which to build a head item
+     * @return a player specific head
+     */
+    public ItemStack getPlayerHead(final Player player) {
+        if (player == null) {
+            return createFallbackHead(Material.PLAYER_HEAD);
+        }
+        final String cacheKey = "player:" + player.getUniqueId();
+        final ItemStack cached = headCache.get(cacheKey);
+        if (cached != null) {
+            return cached.clone();
+        }
+
+        final ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        final SkullMeta meta = (SkullMeta) head.getItemMeta();
+        if (meta != null) {
+            meta.setOwningPlayer(player);
+            head.setItemMeta(meta);
+        }
+
+        headCache.put(cacheKey, head.clone());
+        return head;
+    }
+
+    /**
+     * Fetch a player head for the provided offline player.
+     *
+     * @param player the offline player reference
+     * @return a head item for the given player or a generic fallback
+     */
+    public ItemStack getPlayerHead(final OfflinePlayer player) {
+        if (player == null) {
+            return createFallbackHead(Material.PLAYER_HEAD);
+        }
+        final UUID uniqueId = player.getUniqueId();
+        final String cacheKey = uniqueId != null ? "player:" + uniqueId : "player:" + player.getName();
+        final ItemStack cached = headCache.get(cacheKey);
+        if (cached != null) {
+            return cached.clone();
+        }
+
+        final ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        final SkullMeta meta = (SkullMeta) head.getItemMeta();
+        if (meta != null) {
+            meta.setOwningPlayer(player);
+            head.setItemMeta(meta);
+        }
+
+        headCache.put(cacheKey, head.clone());
+        return head;
+    }
+
+    /**
+     * Clear the internal head cache.
+     */
+    public void clearCache() {
+        headCache.clear();
+    }
+
+    private String createCacheKey(final String headId, final Material fallbackMaterial) {
+        return headId.toLowerCase(Locale.ROOT) + '|' + fallbackMaterial.name();
+    }
+
+    private ItemStack resolveVanillaMaterial(final String materialName) {
+        final Material material = Material.matchMaterial(materialName);
+        if (material == null) {
+            LogUtils.warning(plugin, "Unknown material '" + materialName + "' requested from HeadDatabaseManager.");
+            return null;
+        }
+        return new ItemStack(material);
+    }
+
+    private ItemStack getHeadFromDatabase(final String rawId) {
+        if (!ensureInitialized()) {
+            debug("HeadDatabase unavailable when requesting id " + rawId);
+            return null;
+        }
+
+        if (rawId == null || rawId.isBlank()) {
+            return null;
+        }
+
+        try {
+            final Object result = getItemHeadMethod.invoke(apiInstance, rawId);
+            if (result instanceof ItemStack itemStack) {
+                debug("Fetched head from HeadDatabase id=" + rawId);
+                return itemStack;
+            }
+            LogUtils.warning(plugin, "HeadDatabase returned an unexpected result type for id " + rawId + '.');
+        } catch (final Exception exception) {
+            LogUtils.warning(plugin, "Failed to fetch head '" + rawId + "' from HeadDatabase: " + exception.getMessage());
+        }
+
+        return null;
+    }
+
+    private ItemStack createFallbackHead(final Material fallbackMaterial) {
+        final ItemStack fallback = new ItemStack(fallbackMaterial);
+        if (fallbackMaterial == Material.PLAYER_HEAD) {
+            final SkullMeta meta = (SkullMeta) fallback.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName("§cTête non disponible");
+                fallback.setItemMeta(meta);
+            }
+        }
+        return fallback;
+    }
+
+    private boolean ensureInitialized() {
+        if (headDatabaseEnabled && apiInstance != null && getItemHeadMethod != null) {
+            return true;
+        }
+        initializeHeadDatabase();
+        return headDatabaseEnabled && apiInstance != null && getItemHeadMethod != null;
+    }
+
+    private synchronized void initializeHeadDatabase() {
+        if (headDatabaseEnabled && apiInstance != null && getItemHeadMethod != null) {
+            return;
+        }
+
+        final Plugin headDatabasePlugin = Bukkit.getPluginManager().getPlugin(HDB_PLUGIN_NAME);
+        if (headDatabasePlugin == null || !headDatabasePlugin.isEnabled()) {
+            if (!missingPluginLogged) {
+                LogUtils.warning(plugin, "HeadDatabase plugin not found or disabled. Falling back to default heads.");
+                missingPluginLogged = true;
+            }
+            headDatabaseEnabled = false;
+            apiInstance = null;
+            getItemHeadMethod = null;
+            return;
+        }
+
+        missingPluginLogged = false;
+
+        try {
+            final Class<?> apiClass = Class.forName(HDB_API_CLASS);
+            try {
+                final Method getApiMethod = apiClass.getMethod("getAPI");
+                apiInstance = getApiMethod.invoke(null);
+            } catch (final NoSuchMethodException ignored) {
+                final Constructor<?> constructor = apiClass.getDeclaredConstructor();
+                constructor.setAccessible(true);
+                apiInstance = constructor.newInstance();
+            }
+
+            if (apiInstance == null) {
+                LogUtils.warning(plugin, "Unable to obtain HeadDatabase API instance. Heads will use fallbacks.");
+                headDatabaseEnabled = false;
+                return;
+            }
+
+            getItemHeadMethod = apiInstance.getClass().getMethod("getItemHead", String.class);
+            headDatabaseEnabled = true;
+            LogUtils.info(plugin, "HeadDatabase integration initialised (" + headDatabasePlugin.getDescription().getVersion()
+                    + ")");
+        } catch (final Exception exception) {
+            LogUtils.warning(plugin, "Failed to initialize HeadDatabase integration: " + exception.getMessage());
+            apiInstance = null;
+            getItemHeadMethod = null;
+            headDatabaseEnabled = false;
+        }
+    }
+
+    private void debug(final String message) {
+        if (debugLogging) {
+            LogUtils.info(plugin, "[HeadDatabase] " + Objects.requireNonNullElse(message, ""));
+        }
+    }
+}
+

--- a/src/main/java/com/lobby/lobby/items/LobbyItem.java
+++ b/src/main/java/com/lobby/lobby/items/LobbyItem.java
@@ -13,6 +13,7 @@ public record LobbyItem(
         List<String> lore,
         List<String> actions,
         String headId,
+        Material fallbackMaterial,
         boolean glow,
         Integer customModelData
 ) {

--- a/src/main/java/com/lobby/lobby/items/LobbyItemManager.java
+++ b/src/main/java/com/lobby/lobby/items/LobbyItemManager.java
@@ -1,8 +1,8 @@
 package com.lobby.lobby.items;
 
 import com.lobby.LobbyPlugin;
+import com.lobby.heads.HeadDatabaseManager;
 import com.lobby.lobby.LobbyManager;
-import com.lobby.shop.HeadItemBuilder;
 import com.lobby.utils.LogUtils;
 import com.lobby.utils.MessageUtils;
 import com.lobby.utils.PlaceholderUtils;
@@ -33,6 +33,7 @@ public class LobbyItemManager {
 
     private final LobbyPlugin plugin;
     private final NamespacedKey lobbyItemKey;
+    private final HeadDatabaseManager headDatabaseManager;
     private final Map<String, LobbyItem> items = new LinkedHashMap<>();
     private boolean enabled = true;
     private boolean clearInventoryOnJoin = true;
@@ -46,6 +47,7 @@ public class LobbyItemManager {
     public LobbyItemManager(final LobbyPlugin plugin) {
         this.plugin = plugin;
         this.lobbyItemKey = new NamespacedKey(plugin, "lobby_item");
+        this.headDatabaseManager = plugin.getHeadDatabaseManager();
         reload();
     }
 
@@ -62,6 +64,12 @@ public class LobbyItemManager {
         clearInventoryOnJoin = root.getBoolean("clear_inventory_on_join", true);
         restoreOnDeath = root.getBoolean("restore_on_death", true);
         heldSlot = root.getInt("held_slot", -1);
+
+        final boolean debugHeads = root.getBoolean("debug_heads", false);
+        if (headDatabaseManager != null) {
+            headDatabaseManager.setDebugLogging(debugHeads);
+            headDatabaseManager.clearCache();
+        }
 
         final ConfigurationSection protectionSection = root.getConfigurationSection("protection");
         if (protectionSection != null) {
@@ -234,8 +242,10 @@ public class LobbyItemManager {
     }
 
     private ItemStack createItemStack(final Player player, final LobbyItem lobbyItem) {
-        ItemStack baseItem = createBaseItem(player, lobbyItem);
-        if (baseItem.getType() != lobbyItem.material()) {
+        final ItemStack baseItem = createBaseItem(player, lobbyItem);
+        final Material fallbackMaterial = lobbyItem.fallbackMaterial();
+        final boolean usingFallbackMaterial = fallbackMaterial != null && baseItem.getType() == fallbackMaterial;
+        if (!usingFallbackMaterial && baseItem.getType() != lobbyItem.material()) {
             baseItem.setType(lobbyItem.material());
         }
         baseItem.setAmount(Math.max(1, lobbyItem.amount()));
@@ -277,38 +287,66 @@ public class LobbyItemManager {
     }
 
     private ItemStack createBaseItem(final Player player, final LobbyItem lobbyItem) {
-        if (lobbyItem.material() == Material.PLAYER_HEAD) {
-            final String headId = lobbyItem.headId();
-            if (headId != null && !headId.isBlank()) {
-                if ("%player_name%".equalsIgnoreCase(headId.trim())) {
-                    final ItemStack head = new ItemStack(Material.PLAYER_HEAD);
-                    final ItemMeta meta = head.getItemMeta();
-                    if (meta instanceof SkullMeta skullMeta && player != null) {
-                        skullMeta.setOwningPlayer(player);
-                        head.setItemMeta(skullMeta);
-                    }
-                    return head;
-                }
-                if (headId.startsWith("hdb:")) {
-                    final ItemStack databaseHead = HeadItemBuilder.createHeadItem(headId);
-                    if (databaseHead != null) {
-                        return databaseHead;
-                    }
-                }
-            }
-            final ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
-            if (player != null && headId != null && !headId.isBlank()) {
-                final ItemMeta meta = skull.getItemMeta();
-                if (meta instanceof SkullMeta skullMeta) {
-                    final String processed = PlaceholderUtils.applyPlaceholders(plugin, headId, player);
-                    final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(processed);
-                    skullMeta.setOwningPlayer(offlinePlayer);
-                    skull.setItemMeta(skullMeta);
-                }
-            }
-            return skull;
+        if (lobbyItem.material() != Material.PLAYER_HEAD) {
+            return new ItemStack(lobbyItem.material());
         }
-        return new ItemStack(lobbyItem.material());
+
+        final String headId = lobbyItem.headId();
+        final Material fallbackMaterial = lobbyItem.fallbackMaterial();
+        if (headId != null && !headId.isBlank()) {
+            final String trimmed = headId.trim();
+            if ("%player_name%".equalsIgnoreCase(trimmed)) {
+                return createPlayerHead(player);
+            }
+
+            if (trimmed.toLowerCase(Locale.ROOT).startsWith("hdb:")) {
+                if (headDatabaseManager != null) {
+                    return headDatabaseManager.getHead(trimmed, fallbackMaterial);
+                }
+                return createFallbackItem(fallbackMaterial);
+            }
+
+            final String processed = PlaceholderUtils.applyPlaceholders(plugin, trimmed, player);
+            if (processed != null && !processed.isBlank()) {
+                final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(processed);
+                return createPlayerHead(offlinePlayer);
+            }
+        }
+
+        return createFallbackItem(fallbackMaterial);
+    }
+
+    private ItemStack createPlayerHead(final Player player) {
+        if (headDatabaseManager != null) {
+            return headDatabaseManager.getPlayerHead(player);
+        }
+        final ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        if (player == null) {
+            return head;
+        }
+        final ItemMeta meta = head.getItemMeta();
+        if (meta instanceof SkullMeta skullMeta) {
+            skullMeta.setOwningPlayer(player);
+            head.setItemMeta(skullMeta);
+        }
+        return head;
+    }
+
+    private ItemStack createPlayerHead(final OfflinePlayer player) {
+        if (headDatabaseManager != null) {
+            return headDatabaseManager.getPlayerHead(player);
+        }
+        final ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+        final ItemMeta meta = head.getItemMeta();
+        if (meta instanceof SkullMeta skullMeta) {
+            skullMeta.setOwningPlayer(player);
+            head.setItemMeta(skullMeta);
+        }
+        return head;
+    }
+
+    private ItemStack createFallbackItem(final Material fallbackMaterial) {
+        return fallbackMaterial != null ? new ItemStack(fallbackMaterial) : new ItemStack(Material.PLAYER_HEAD);
     }
 
     private Optional<LobbyItem> parseItem(final String id, final ConfigurationSection section) {
@@ -325,11 +363,21 @@ public class LobbyItemManager {
         final List<String> lore = sanitizeList(section.getStringList("lore"));
         final List<String> actions = extractActions(section);
         final String headId = section.getString("head_id");
+        Material fallbackMaterial = null;
+        if (section.isString("fallback_material")) {
+            final String fallbackName = section.getString("fallback_material");
+            if (fallbackName != null && !fallbackName.isBlank()) {
+                fallbackMaterial = Material.matchMaterial(fallbackName);
+                if (fallbackMaterial == null) {
+                    LogUtils.warning(plugin, "Invalid fallback material '" + fallbackName + "' for lobby item '" + id + "'.");
+                }
+            }
+        }
         final boolean glow = section.getBoolean("glow", false);
         final Integer customModelData = section.contains("custom_model_data") ? section.getInt("custom_model_data") : null;
 
-        final LobbyItem lobbyItem = new LobbyItem(id, material, slot, amount, name, lore, actions, headId, glow,
-                customModelData);
+        final LobbyItem lobbyItem = new LobbyItem(id, material, slot, amount, name, lore, actions, headId,
+                fallbackMaterial, glow, customModelData);
         return Optional.of(lobbyItem);
     }
 

--- a/src/main/java/com/lobby/shop/HeadItemBuilder.java
+++ b/src/main/java/com/lobby/shop/HeadItemBuilder.java
@@ -1,11 +1,13 @@
 package com.lobby.shop;
 
 import com.lobby.LobbyPlugin;
+import com.lobby.heads.HeadDatabaseManager;
 import com.lobby.utils.LogUtils;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
+
+import java.util.Locale;
 
 public final class HeadItemBuilder {
 
@@ -13,10 +15,20 @@ public final class HeadItemBuilder {
     }
 
     public static ItemStack createHeadItem(final String headId) {
-        if (headId != null && headId.startsWith("hdb:")) {
-            final String trimmed = headId.substring(4);
-            if (!trimmed.isEmpty()) {
-                final ItemStack databaseHead = getHeadFromDatabase(trimmed);
+        if (headId == null || headId.isBlank()) {
+            return new ItemStack(Material.PLAYER_HEAD);
+        }
+
+        final String trimmed = headId.trim();
+        if (trimmed.toLowerCase(Locale.ROOT).startsWith("hdb:")) {
+            final LobbyPlugin plugin = LobbyPlugin.getInstance();
+            final HeadDatabaseManager manager = plugin != null ? plugin.getHeadDatabaseManager() : null;
+            if (manager != null) {
+                return manager.getHead(trimmed, Material.PLAYER_HEAD);
+            }
+            final String legacyId = trimmed.substring(4);
+            if (!legacyId.isEmpty()) {
+                final ItemStack databaseHead = getHeadFromDatabase(legacyId);
                 if (databaseHead != null) {
                     return databaseHead;
                 }
@@ -27,7 +39,9 @@ public final class HeadItemBuilder {
 
     private static ItemStack getHeadFromDatabase(final String headId) {
         try {
-            final Plugin headDatabase = Bukkit.getPluginManager().getPlugin("HeadDatabase");
+            final Plugin headDatabase = LobbyPlugin.getInstance() != null
+                    ? LobbyPlugin.getInstance().getServer().getPluginManager().getPlugin("HeadDatabase")
+                    : null;
             if (headDatabase == null || !headDatabase.isEnabled()) {
                 return null;
             }

--- a/src/main/resources/config/lobby-items.yml
+++ b/src/main/resources/config/lobby-items.yml
@@ -1,5 +1,6 @@
 lobby_items:
   enabled: true
+  debug_heads: false
   clear_inventory_on_join: true
   restore_on_death: true
   held_slot: 0
@@ -9,6 +10,7 @@ lobby_items:
       slot: 0
       material: PLAYER_HEAD
       head_id: "hdb:35517"
+      fallback_material: COMPASS
       name: "&aMenu des Jeux &7(Clic-droit)"
       lore:
         - "&7Rejoignez un mode de jeu."
@@ -20,6 +22,7 @@ lobby_items:
       slot: 1
       material: PLAYER_HEAD
       head_id: "%player_name%"
+      fallback_material: PLAYER_HEAD
       name: "&6Mon Profil &7(Clic-droit)"
       lore:
         - "&7Consulte tes informations personnelles."
@@ -30,6 +33,7 @@ lobby_items:
       slot: 4
       material: PLAYER_HEAD
       head_id: "hdb:35472"
+      fallback_material: CHEST
       name: "&eBoutique &7(Clic-droit)"
       lore:
         - "&7Découvre des offres exclusives."
@@ -40,6 +44,7 @@ lobby_items:
       slot: 7
       material: PLAYER_HEAD
       head_id: "hdb:67678"
+      fallback_material: ARMOR_STAND
       name: "&dCosmétiques &7(Clic-droit)"
       lore:
         - "&7Personnalise ton expérience."
@@ -50,6 +55,7 @@ lobby_items:
       slot: 8
       material: PLAYER_HEAD
       head_id: "hdb:15082"
+      fallback_material: COMPASS
       name: "&bSélecteur de Hub &7(Clic-droit)"
       lore:
         - "&7Navigue entre les hubs."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: LobbyCore
 version: '${project.version}'
 main: com.lobby.LobbyPlugin
 api-version: '1.21'
+softdepend: [HeadDatabase]
 commands:
   lobby:
     description: Commande principale du lobby


### PR DESCRIPTION
## Summary
- add a dedicated HeadDatabaseManager that handles API access, caching, fallbacks and debug logging
- wire the lobby item pipeline to use the manager, support per-item fallback materials, and expose a reusable player-head builder
- document new configuration options and declare HeadDatabase as a soft dependency

## Testing
- `mvn -q -DskipTests package` *(fails: network unreachable while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68ce61c7bd00832999addaa39ed9fe9e