### PR TITLE
Implement detailed game and profile menus

### DIFF
--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -1,6 +1,7 @@
 package com.lobby.menus;
 
 import com.lobby.LobbyPlugin;
+import com.lobby.heads.HeadDatabaseManager;
 import com.lobby.npcs.ActionProcessor;
 import com.lobby.utils.LogUtils;
 import com.lobby.utils.MessageUtils;
@@ -21,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Locale;
 import java.util.Optional;
 
 public class ConfiguredMenu implements Menu {
@@ -105,7 +107,16 @@ public class ConfiguredMenu implements Menu {
         }
 
         final int amount = Math.max(1, itemSection.getInt("amount", 1));
-        final ItemStack itemStack = new ItemStack(material, amount);
+        final String rawHead = itemSection.getString("head");
+        final String resolvedHead = resolveHeadValue(rawHead, player);
+
+        final ItemStack itemStack;
+        if (material == Material.PLAYER_HEAD && resolvedHead != null
+                && resolvedHead.toLowerCase(Locale.ROOT).startsWith("hdb:")) {
+            itemStack = createHeadItem(amount, resolvedHead, itemSection);
+        } else {
+            itemStack = new ItemStack(material, amount);
+        }
         final ItemMeta meta = itemStack.getItemMeta();
         if (meta != null) {
             if (itemSection.isString("name")) {
@@ -132,7 +143,7 @@ public class ConfiguredMenu implements Menu {
             }
 
             if (meta instanceof SkullMeta skullMeta) {
-                applyHead(itemSection, player, skullMeta);
+                applyHead(rawHead, resolvedHead, player, skullMeta);
             }
 
             itemStack.setItemMeta(meta);
@@ -146,22 +157,64 @@ public class ConfiguredMenu implements Menu {
         return Optional.of(targetSlot);
     }
 
-    private void applyHead(final ConfigurationSection itemSection, final Player player, final SkullMeta skullMeta) {
-        final String head = itemSection.getString("head");
-        if (head == null || head.isEmpty()) {
+    private void applyHead(final String rawHead, final String resolvedHead, final Player player, final SkullMeta skullMeta) {
+        if (rawHead == null || rawHead.isBlank()) {
             return;
         }
-        if (player != null && head.equalsIgnoreCase("%player_name%")) {
+        if (resolvedHead != null && resolvedHead.toLowerCase(Locale.ROOT).startsWith("hdb:")) {
+            return;
+        }
+        if (player != null && rawHead.equalsIgnoreCase("%player_name%")) {
             skullMeta.setOwningPlayer(player);
             return;
         }
-        final String processed = PlaceholderUtils.applyPlaceholders(plugin, head, player);
+        final String processed = resolvedHead != null ? resolvedHead : PlaceholderUtils.applyPlaceholders(plugin, rawHead, player);
+        if (processed == null || processed.isBlank()) {
+            return;
+        }
         if (player != null && processed.equalsIgnoreCase(player.getName())) {
             skullMeta.setOwningPlayer(player);
             return;
         }
         final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(processed);
         skullMeta.setOwningPlayer(offlinePlayer);
+    }
+
+    private ItemStack createHeadItem(final int amount, final String headId, final ConfigurationSection itemSection) {
+        final Material fallbackMaterial = resolveHeadFallbackMaterial(itemSection.getString("head_fallback_material"));
+        final HeadDatabaseManager manager = plugin.getHeadDatabaseManager();
+        ItemStack headItem = null;
+        if (manager != null) {
+            headItem = manager.getHead(headId, fallbackMaterial);
+        }
+        if (headItem == null) {
+            headItem = new ItemStack(fallbackMaterial != null ? fallbackMaterial : Material.PLAYER_HEAD);
+        }
+        headItem.setAmount(amount);
+        return headItem;
+    }
+
+    private Material resolveHeadFallbackMaterial(final String fallbackName) {
+        if (fallbackName == null || fallbackName.isBlank()) {
+            return Material.PLAYER_HEAD;
+        }
+        final Material material = Material.matchMaterial(fallbackName.trim());
+        if (material == null) {
+            LogUtils.warning(plugin, "Invalid head fallback material '" + fallbackName + "' in menu '" + menuId + "'.");
+            return Material.PLAYER_HEAD;
+        }
+        return material;
+    }
+
+    private String resolveHeadValue(final String head, final Player player) {
+        if (head == null || head.isBlank()) {
+            return null;
+        }
+        final String processed = PlaceholderUtils.applyPlaceholders(plugin, head, player);
+        if (processed == null || processed.isBlank()) {
+            return null;
+        }
+        return processed;
     }
 
     private void storeActions(final int slot, final List<String> actions) {

--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -176,7 +176,9 @@ public class MenuManager implements Listener {
                 "profil_menu.yml",
                 "shop_menu.yml",
                 "cosmetiques_menu.yml",
-                "hub_menu.yml"
+                "hub_menu.yml",
+                "settings_menu.yml",
+                "language_menu.yml"
         );
         for (String fileName : defaults) {
             final File target = new File(directory, fileName);

--- a/src/main/resources/config/menus/jeux_menu.yml
+++ b/src/main/resources/config/menus/jeux_menu.yml
@@ -1,54 +1,194 @@
 menu:
   id: "jeux_menu"
   title: "&8» &aMenu des Jeux"
-  size: 36
-  fill_material: "BLACK_STAINED_GLASS_PANE"
+  size: 54
 
   items:
-    factions:
-      slot: 11
-      material: "DIAMOND_SWORD"
-      name: "&cMode de Jeu 1"
-      lore:
-        - "&7Rejoignez le serveur Faction," 
-        - "&7pillez, combattez et dominez !"
-        - "     "
-        - "&eJoueurs: &f%server_online_factions%"
-        - "&a► Cliquez pour jouer !"
+    decor_top_left_1:
+      slot: 0
+      material: "ORANGE_STAINED_GLASS_PANE"
+      name: "&7"
       actions:
-        - "[SERVER_SEND] factions"
+        - "[NONE]"
+
+    decor_top_left_2:
+      slot: 1
+      material: "ORANGE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_top_left_3:
+      slot: 2
+      material: "ORANGE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_top_right_1:
+      slot: 6
+      material: "ORANGE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_top_right_2:
+      slot: 7
+      material: "ORANGE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_top_right_3:
+      slot: 8
+      material: "ORANGE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_left:
+      slot: 9
+      material: "ORANGE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_right:
+      slot: 17
+      material: "ORANGE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_bottom_left:
+      slot: 45
+      material: "ORANGE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_bottom_right:
+      slot: 53
+      material: "ORANGE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
 
     bedwars:
-      slot: 13
-      material: "RED_BED"
-      name: "&aMode de Jeu 2"
+      slot: 20
+      material: "PLAYER_HEAD"
+      head: "hdb:67957"
+      name: "&c&lBedWars &8- &ePopulaire"
       lore:
-        - "&7Défendez votre lit et"
-        - "&7détruisez celui des autres."
-        - "     "
-        - "&eJoueurs: &f%server_online_bedwars%"
-        - "&a► Cliquez pour jouer !"
+        - "&7Le mode de jeu le plus apprécié !"
+        - "&7Défendez votre lit et détruisez"
+        - "&7celui de vos adversaires."
+        - "&r"
+        - "&8▸ &7Joueurs: &a%server_online_bedwars%"
+        - "&8▸ &7Parties en cours: &e%bedwars_games_active%"
+        - "&8▸ &7Temps d'attente: &b~30 secondes"
+        - "&r"
+        - "&a▶ Cliquez pour jouer !"
       actions:
         - "[SERVER_SEND] bedwars"
 
-    skyblock:
-      slot: 15
-      material: "GRASS_BLOCK"
-      name: "&bMode de Jeu 3"
+    nexus:
+      slot: 22
+      material: "PLAYER_HEAD"
+      head: "hdb:38878"
+      name: "&b&lNexus &8- &dNouveauté"
       lore:
-        - "&7Développez votre île volante"
-        - "&7et devenez le plus riche."
-        - "     "
-        - "&eJoueurs: &f%server_online_skyblock%"
-        - "&a► Cliquez pour jouer !"
+        - "&7Le tout nouveau mode de jeu !"
+        - "&7Conquérez les nexus ennemis et"
+        - "&7dominez le champ de bataille."
+        - "&r"
+        - "&8▸ &7Joueurs: &a%server_online_nexus%"
+        - "&8▸ &7Parties en cours: &e%nexus_games_active%"
+        - "&8▸ &7Statut: &d✨ BETA"
+        - "&r"
+        - "&a▶ Cliquez pour découvrir !"
       actions:
-        - "[SERVER_SEND] skyblock"
+        - "[SERVER_SEND] nexus"
 
-    close:
-      slot: 31
-      material: "BARRIER"
-      name: "&cQuitter"
+    zombie:
+      slot: 24
+      material: "PLAYER_HEAD"
+      head: "hdb:23022"
+      name: "&2&lZombie &8- &cSurvie"
       lore:
-        - "&7Fermer ce menu"
+        - "&7Survivez aux hordes de zombies !"
+        - "&7Travaillez en équipe pour tenir"
+        - "&7le plus longtemps possible."
+        - "&r"
+        - "&8▸ &7Joueurs: &a%server_online_zombie%"
+        - "&8▸ &7Parties en cours: &e%zombie_games_active%"
+        - "&8▸ &7Record: &6%player_zombie_record% vagues"
+        - "&r"
+        - "&a▶ Cliquez pour survivre !"
+      actions:
+        - "[SERVER_SEND] zombie"
+
+    custom_games:
+      slot: 26
+      material: "PLAYER_HEAD"
+      head: "hdb:60776"
+      name: "&6&lJeux Inédits &8- &5Exclusif"
+      lore:
+        - "&7Des modes de jeu uniques et"
+        - "&7créatifs que vous ne trouverez"
+        - "&7nulle part ailleurs !"
+        - "&r"
+        - "&8▸ &7Joueurs: &a%server_online_custom%"
+        - "&8▸ &7Modes disponibles: &e%custom_games_count%"
+        - "&8▸ &7Nouveauté: &5Build Battle"
+        - "&r"
+        - "&a▶ Cliquez pour explorer !"
+      actions:
+        - "[SERVER_SEND] custom"
+
+    shop:
+      slot: 46
+      material: "PLAYER_HEAD"
+      head: "hdb:35472"
+      name: "&e&lBoutique"
+      lore:
+        - "&7Achetez des grades, des cosmétiques"
+        - "&7et bien plus encore !"
+        - "&r"
+        - "&8▸ &7Votre solde:"
+        - "&8  ▸ &eCoins: &f%player_coins%"
+        - "&8  ▸ &bTokens: &f%player_tokens%"
+        - "&r"
+        - "&a▶ Cliquez pour acheter !"
+      actions:
+        - "[MENU] shop_menu"
+
+    profile:
+      slot: 49
+      material: "PLAYER_HEAD"
+      head: "%player_name%"
+      name: "&6&lMon Profil"
+      lore:
+        - "&7Consultez vos statistiques,"
+        - "&7gérez vos paramètres et plus !"
+        - "&r"
+        - "&8▸ &7Grade: %luckperms_prefix%"
+        - "&8▸ &7Temps de jeu: &f%player_playtime_total%"
+        - "&8▸ &7Première connexion: &f%player_first_join%"
+        - "&r"
+        - "&a▶ Cliquez pour voir !"
+      actions:
+        - "[MENU] profil_menu"
+
+    back:
+      slot: 52
+      material: "PLAYER_HEAD"
+      head: "hdb:9334"
+      name: "&c&lRetour"
+      lore:
+        - "&7Fermer ce menu et retourner"
+        - "&7au lobby principal."
+        - "&r"
+        - "&a▶ Cliquez pour fermer !"
       actions:
         - "[CLOSE_MENU]"

--- a/src/main/resources/config/menus/language_menu.yml
+++ b/src/main/resources/config/menus/language_menu.yml
@@ -1,0 +1,57 @@
+menu:
+  id: "language_menu"
+  title: "&8» &fSélection de Langue"
+  size: 27
+
+  items:
+    french:
+      slot: 11
+      material: "PLAYER_HEAD"
+      head: "hdb:2736"
+      name: "&c&l🇫🇷 Français"
+      lore:
+        - "&7Langue française"
+        - "&r"
+        - "&8▸ &7Statut: %lang_fr_status%"
+        - "&r"
+        - "&a▶ Cliquez pour sélectionner !"
+      actions:
+        - "[COMMAND] language set fr"
+
+    english:
+      slot: 13
+      material: "PLAYER_HEAD"
+      head: "hdb:2735"
+      name: "&f&l🇬🇧 English"
+      lore:
+        - "&7English language"
+        - "&r"
+        - "&8▸ &7Status: %lang_en_status%"
+        - "&r"
+        - "&a▶ Click to select!"
+      actions:
+        - "[COMMAND] language set en"
+
+    spanish:
+      slot: 15
+      material: "PLAYER_HEAD"
+      head: "hdb:2738"
+      name: "&e&l🇪🇸 Español"
+      lore:
+        - "&7Idioma español"
+        - "&r"
+        - "&8▸ &7Estado: %lang_es_status%"
+        - "&r"
+        - "&a▶ ¡Haz clic para seleccionar!"
+      actions:
+        - "[COMMAND] language set es"
+
+    back:
+      slot: 22
+      material: "PLAYER_HEAD"
+      head: "hdb:9334"
+      name: "&c&lRetour"
+      lore:
+        - "&7Revenir au menu profil."
+      actions:
+        - "[MENU] profil_menu"

--- a/src/main/resources/config/menus/profil_menu.yml
+++ b/src/main/resources/config/menus/profil_menu.yml
@@ -1,38 +1,214 @@
 menu:
   id: "profil_menu"
   title: "&8» &6Mon Profil"
-  size: 27
-  fill_material: "GRAY_STAINED_GLASS_PANE"
+  size: 54
 
   items:
-    profile_overview:
-      slot: 11
+    decor_top_left_1:
+      slot: 0
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_top_left_2:
+      slot: 1
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_top_left_3:
+      slot: 2
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_top_right_1:
+      slot: 6
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_top_right_2:
+      slot: 7
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_top_right_3:
+      slot: 8
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_left:
+      slot: 9
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_right:
+      slot: 17
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_bottom_left:
+      slot: 45
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    decor_bottom_right:
+      slot: 53
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    friends:
+      slot: 3
+      material: "PLAYER_HEAD"
+      head: "hdb:9945"
+      name: "&a&lAmis"
+      lore:
+        - "&7Gérez votre liste d'amis,"
+        - "&7envoyez des invitations et"
+        - "&7voyez qui est en ligne."
+        - "&r"
+        - "&8▸ &7Amis en ligne: &a%friends_online%/%friends_total%"
+        - "&8▸ &7Demandes en attente: &e%friend_requests%"
+        - "&8▸ &7Statut: %friend_status%"
+        - "&r"
+        - "&c⚠ Fonctionnalité en développement"
+      actions:
+        - "[MESSAGE] &cCette fonctionnalité n'est pas encore disponible !"
+
+    groups:
+      slot: 4
+      material: "PLAYER_HEAD"
+      head: "hdb:9723"
+      name: "&e&lGroupe"
+      lore:
+        - "&7Créez ou rejoignez un groupe"
+        - "&7pour jouer avec vos amis !"
+        - "&r"
+        - "&8▸ &7Groupe actuel: %group_name%"
+        - "&8▸ &7Membres: &a%group_members%/%group_max%"
+        - "&8▸ &7Leader: &6%group_leader%"
+        - "&r"
+        - "&c⚠ Fonctionnalité en développement"
+      actions:
+        - "[MESSAGE] &cCette fonctionnalité n'est pas encore disponible !"
+
+    clans:
+      slot: 5
+      material: "PLAYER_HEAD"
+      head: "hdb:8971"
+      name: "&c&lClan"
+      lore:
+        - "&7Rejoignez un clan pour participer"
+        - "&7à des événements exclusifs et"
+        - "&7des guerres de clans !"
+        - "&r"
+        - "&8▸ &7Clan: %clan_name%"
+        - "&8▸ &7Rang: &6%clan_rank%"
+        - "&8▸ &7Membres: &a%clan_members%/%clan_max%"
+        - "&8▸ &7Points: &e%clan_points%"
+        - "&r"
+        - "&c⚠ Fonctionnalité en développement"
+      actions:
+        - "[MESSAGE] &cCette fonctionnalité n'est pas encore disponible !"
+
+    stats:
+      slot: 20
       material: "PLAYER_HEAD"
       head: "%player_name%"
-      name: "&eStatistiques"
+      name: "&b&lMes Statistiques"
       lore:
-        - "&7Pseudo: &f%player_name%"
-        - "&7Coins: &f%player_coins%"
-        - "&7Tokens: &f%player_tokens%"
-        - "&7Première connexion: &f%player_first_join%"
-        - "&7Dernière connexion: &f%player_last_join%"
-        - "&7Temps de jeu: &f%player_playtime%"
-
-    economy_history:
-      slot: 13
-      material: "GOLD_INGOT"
-      name: "&6Historique économique"
-      lore:
-        - "&7Consulte tes transactions"
-        - "&7et récompenses récentes."
+        - "&7Consultez toutes vos performances"
+        - "&7détaillées par mode de jeu."
+        - "&r"
+        - "&8▸ &7Parties jouées: &e%player_games_total%"
+        - "&8▸ &7Victoires: &a%player_wins_total%"
+        - "&8▸ &7Ratio V/D: &6%player_ratio%"
+        - "&8▸ &7Expérience: &d%player_experience%"
+        - "&r"
+        - "&a▶ Cliquez pour voir le détail !"
       actions:
-        - "[MESSAGE] &eFonctionnalité à venir !"
+        - "[MENU] stats_detailed_menu"
 
-    close:
-      slot: 15
-      material: "BARRIER"
-      name: "&cFermer"
+    language:
+      slot: 22
+      material: "PLAYER_HEAD"
+      head: "hdb:2736"
+      name: "&f&lLangue &8- &cFrançais"
       lore:
-        - "&7Revenir au jeu"
+        - "&7Changez la langue d'affichage"
+        - "&7de l'interface et des messages."
+        - "&r"
+        - "&8▸ &7Langue actuelle: &c🇫🇷 Français"
+        - "&8▸ &7Langues disponibles:"
+        - "&8  ▸ &c🇫🇷 Français"
+        - "&8  ▸ &f🇬🇧 English"
+        - "&8  ▸ &e🇪🇸 Español"
+        - "&r"
+        - "&a▶ Cliquez pour changer !"
       actions:
-        - "[CLOSE_MENU]"
+        - "[MENU] language_menu"
+
+    settings:
+      slot: 24
+      material: "PLAYER_HEAD"
+      head: "hdb:1218"
+      name: "&d&lParamètres"
+      lore:
+        - "&7Personnalisez votre expérience"
+        - "&7de jeu selon vos préférences."
+        - "&r"
+        - "&8▸ &7Messages privés: %setting_private_messages%"
+        - "&8▸ &7Demandes d'amis: %setting_friend_requests%"
+        - "&8▸ &7Visibilité: %setting_visibility%"
+        - "&r"
+        - "&a▶ Cliquez pour configurer !"
+      actions:
+        - "[MENU] settings_menu"
+
+    rewards:
+      slot: 26
+      material: "PLAYER_HEAD"
+      head: "hdb:12654"
+      name: "&6&lRécompense Journalière"
+      lore:
+        - "&7Réclamez votre récompense"
+        - "&7quotidienne gratuite !"
+        - "&r"
+        - "&8▸ &7Statut: %daily_reward_status%"
+        - "&8▸ &7Série actuelle: &e%daily_streak% jours"
+        - "&8▸ &7Prochaine récompense: %daily_next_reward%"
+        - "&8▸ &7Temps restant: &b%daily_cooldown%"
+        - "&r"
+        - "&a▶ Cliquez pour réclamer !"
+      actions:
+        - "[MENU] daily_reward_menu"
+
+    back:
+      slot: 49
+      material: "PLAYER_HEAD"
+      head: "hdb:9334"
+      name: "&c&lRetour"
+      lore:
+        - "&7Retourner au menu principal"
+        - "&7ou fermer cette interface."
+        - "&r"
+        - "&a▶ Cliquez pour revenir !"
+      actions:
+        - "[MENU] jeux_menu"

--- a/src/main/resources/config/menus/settings_menu.yml
+++ b/src/main/resources/config/menus/settings_menu.yml
@@ -1,0 +1,113 @@
+menu:
+  id: "settings_menu"
+  title: "&8» &dParamètres"
+  size: 45
+  fill_material: "PURPLE_STAINED_GLASS_PANE"
+
+  items:
+    private_messages:
+      slot: 11
+      material: "PLAYER_HEAD"
+      head: "hdb:3581"
+      name: "&a&lMessages Privés"
+      lore:
+        - "&7Autorisez ou bloquez la réception"
+        - "&7de messages privés d'autres joueurs."
+        - "&r"
+        - "&8▸ &7Statut actuel: %setting_private_messages_status%"
+        - "&r"
+        - "&a▶ Cliquez pour basculer !"
+      actions:
+        - "[COMMAND] settings toggle private_messages"
+
+    friend_requests:
+      slot: 13
+      material: "PLAYER_HEAD"
+      head: "hdb:13389"
+      name: "&e&lDemandes d'Amis"
+      lore:
+        - "&7Gérez qui peut vous envoyer"
+        - "&7des demandes d'ajout en ami."
+        - "&r"
+        - "&8▸ &7Statut actuel: %setting_friend_requests_status%"
+        - "&8▸ &7Options: Tous / Amis d'amis / Personne"
+        - "&r"
+        - "&a▶ Cliquez pour modifier !"
+      actions:
+        - "[MENU] friend_requests_settings"
+
+    group_requests:
+      slot: 15
+      material: "PLAYER_HEAD"
+      head: "hdb:8537"
+      name: "&b&lDemandes de Groupe"
+      lore:
+        - "&7Contrôlez qui peut vous inviter"
+        - "&7dans des groupes de jeu."
+        - "&r"
+        - "&8▸ &7Statut actuel: %setting_group_requests_status%"
+        - "&8▸ &7Options: Tous / Amis seulement / Personne"
+        - "&r"
+        - "&a▶ Cliquez pour ajuster !"
+      actions:
+        - "[MENU] group_requests_settings"
+
+    visibility:
+      slot: 20
+      material: "PLAYER_HEAD"
+      head: "hdb:32010"
+      name: "&f&lVisibilité des Joueurs"
+      lore:
+        - "&7Choisissez quels joueurs vous"
+        - "&7voulez voir dans le lobby."
+        - "&r"
+        - "&8▸ &7Mode actuel: %setting_visibility_status%"
+        - "&8▸ &7Options: Tous / Amis / Personne"
+        - "&r"
+        - "&a▶ Cliquez pour changer !"
+      actions:
+        - "[MENU] visibility_settings"
+
+    notifications:
+      slot: 22
+      material: "PLAYER_HEAD"
+      head: "hdb:1455"
+      name: "&c&lNotifications"
+      lore:
+        - "&7Gérez les types de notifications"
+        - "&7que vous souhaitez recevoir."
+        - "&r"
+        - "&8▸ &7Notifications d'amis: %notif_friends%"
+        - "&8▸ &7Notifications de clan: %notif_clan%"
+        - "&8▸ &7Notifications système: %notif_system%"
+        - "&r"
+        - "&a▶ Cliquez pour personnaliser !"
+      actions:
+        - "[MENU] notifications_settings"
+
+    audio:
+      slot: 24
+      material: "PLAYER_HEAD"
+      head: "hdb:7439"
+      name: "&6&lSons et Effets"
+      lore:
+        - "&7Activez ou désactivez les sons"
+        - "&7et effets visuels du lobby."
+        - "&r"
+        - "&8▸ &7Sons d'interface: %setting_ui_sounds%"
+        - "&8▸ &7Effets de particules: %setting_particles%"
+        - "&8▸ &7Musique d'ambiance: %setting_music%"
+        - "&r"
+        - "&a▶ Cliquez pour ajuster !"
+      actions:
+        - "[MENU] audio_settings"
+
+    back:
+      slot: 40
+      material: "PLAYER_HEAD"
+      head: "hdb:9334"
+      name: "&c&lRetour"
+      lore:
+        - "&7Revenir au menu profil."
+      actions:
+        - "[MENU] profil_menu"


### PR DESCRIPTION
## Summary
- enhance the configurable menu system to resolve HeadDatabase heads with fallbacks
- ensure bundled menus include the new settings and language configurations by default
- replace the game and profile menu layouts and add dedicated settings and language menu YAML files

## Testing
- ⚠️ `mvn -DskipTests package` *(fails: network unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6ecffc3c83298a6a041ab6ef6347