### PR TITLE
Remove unnecessary SQLException catch in EconomyManager

### DIFF
--- a/src/main/java/com/lobby/economy/EconomyManager.java
+++ b/src/main/java/com/lobby/economy/EconomyManager.java
@@ -182,8 +182,6 @@ public class EconomyManager implements EconomyAPI {
             }
             cache.put(uuid, updated);
             leaderboardManager.invalidate();
-        } catch (final SQLException exception) {
-            plugin.getLogger().log(Level.WARNING, "Failed to open connection for balance synchronization", exception);
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
## Summary
- remove the outer SQLException catch in EconomyManager.synchronizeBalances since no SQLException is thrown in the try block

## Testing
- mvn -q clean compile *(fails: Network is unreachable while resolving maven-clean-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb97cff188329867f43085d796dfd