### PR TITLE
Improve lobby item protection and menu loading

### DIFF
--- a/src/main/java/com/lobby/lobby/LobbyManager.java
+++ b/src/main/java/com/lobby/lobby/LobbyManager.java
@@ -98,15 +98,20 @@ public class LobbyManager {
         final UUID uniqueId = player.getUniqueId();
         if (bypassPlayers.contains(uniqueId)) {
             bypassPlayers.remove(uniqueId);
+            preparePlayer(player, PreparationCause.COMMAND);
             return false;
         }
         bypassPlayers.add(uniqueId);
+        itemManager.removeProtection(uniqueId);
+        itemManager.removeLobbyItems(player.getInventory());
+        player.updateInventory();
         return true;
     }
 
     public void removeBypass(final UUID uniqueId) {
         if (uniqueId != null) {
             bypassPlayers.remove(uniqueId);
+            itemManager.removeProtection(uniqueId);
         }
     }
 

--- a/src/main/java/com/lobby/lobby/items/LobbyItemManager.java
+++ b/src/main/java/com/lobby/lobby/items/LobbyItemManager.java
@@ -28,6 +28,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class LobbyItemManager {
 
@@ -43,6 +46,7 @@ public class LobbyItemManager {
     private boolean preventDamage = true;
     private boolean preventConsume = true;
     private int heldSlot = -1;
+    private final Set<UUID> protectedPlayers = ConcurrentHashMap.newKeySet();
 
     public LobbyItemManager(final LobbyPlugin plugin) {
         this.plugin = plugin;
@@ -122,6 +126,7 @@ public class LobbyItemManager {
 
         if (items.isEmpty()) {
             player.updateInventory();
+            removeProtection(player);
             return;
         }
 
@@ -134,6 +139,7 @@ public class LobbyItemManager {
         }
 
         player.updateInventory();
+        markProtected(player);
     }
 
     public boolean isEnabled() {
@@ -178,6 +184,42 @@ public class LobbyItemManager {
             return Optional.empty();
         }
         return Optional.ofNullable(items.get(identifier.toLowerCase(Locale.ROOT)));
+    }
+
+    public Optional<LobbyItem> getLobbyItem(final String identifier) {
+        if (identifier == null || identifier.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(items.get(identifier.toLowerCase(Locale.ROOT)));
+    }
+
+    public void markProtected(final Player player) {
+        if (player == null) {
+            return;
+        }
+        protectedPlayers.add(player.getUniqueId());
+    }
+
+    public boolean isProtected(final Player player) {
+        return player != null && isProtected(player.getUniqueId());
+    }
+
+    public boolean isProtected(final UUID uniqueId) {
+        return uniqueId != null && protectedPlayers.contains(uniqueId);
+    }
+
+    public void removeProtection(final Player player) {
+        if (player == null) {
+            return;
+        }
+        removeProtection(player.getUniqueId());
+    }
+
+    public void removeProtection(final UUID uniqueId) {
+        if (uniqueId == null) {
+            return;
+        }
+        protectedPlayers.remove(uniqueId);
     }
 
     public boolean isLobbyItem(final ItemStack itemStack) {
@@ -230,6 +272,7 @@ public class LobbyItemManager {
 
     public void shutdown() {
         items.clear();
+        protectedPlayers.clear();
     }
 
     private void placeItem(final Player player, final PlayerInventory inventory, final LobbyItem lobbyItem) {

--- a/src/main/java/com/lobby/lobby/listeners/LobbyItemListener.java
+++ b/src/main/java/com/lobby/lobby/listeners/LobbyItemListener.java
@@ -37,7 +37,10 @@ public class LobbyItemListener implements Listener {
         if (!itemManager.isEnabled()) {
             return;
         }
-        if (!itemManager.shouldPreventMove() && lobbyManager.isBypassing(player)) {
+        if (!itemManager.isProtected(player)) {
+            return;
+        }
+        if (lobbyManager.isBypassing(player)) {
             return;
         }
         final ItemStack currentItem = event.getCurrentItem();
@@ -53,6 +56,14 @@ public class LobbyItemListener implements Listener {
         if (itemManager.isLobbyItem(currentItem) || itemManager.isLobbyItem(cursorItem)) {
             event.setCancelled(true);
             player.updateInventory();
+            return;
+        }
+        if (!itemManager.shouldPreventMove()) {
+            return;
+        }
+        if (event.getClickedInventory() != null && event.getClickedInventory().equals(player.getInventory())) {
+            event.setCancelled(true);
+            player.updateInventory();
         }
     }
 
@@ -64,7 +75,10 @@ public class LobbyItemListener implements Listener {
         if (!itemManager.isEnabled()) {
             return;
         }
-        if (!itemManager.shouldPreventMove() && lobbyManager.isBypassing(player)) {
+        if (!itemManager.isProtected(player)) {
+            return;
+        }
+        if (lobbyManager.isBypassing(player)) {
             return;
         }
         if (itemManager.isLobbyItem(event.getOldCursor())) {
@@ -79,7 +93,13 @@ public class LobbyItemListener implements Listener {
         if (!itemManager.isEnabled()) {
             return;
         }
-        if (!itemManager.shouldPreventDrop() && lobbyManager.isBypassing(player)) {
+        if (!itemManager.isProtected(player)) {
+            return;
+        }
+        if (lobbyManager.isBypassing(player)) {
+            return;
+        }
+        if (!itemManager.shouldPreventDrop()) {
             return;
         }
         if (itemManager.isLobbyItem(event.getItemDrop().getItemStack())) {
@@ -94,7 +114,10 @@ public class LobbyItemListener implements Listener {
         if (!itemManager.isEnabled()) {
             return;
         }
-        if (!itemManager.shouldPreventMove() && lobbyManager.isBypassing(player)) {
+        if (!itemManager.isProtected(player)) {
+            return;
+        }
+        if (lobbyManager.isBypassing(player)) {
             return;
         }
         if (itemManager.isLobbyItem(event.getMainHandItem()) || itemManager.isLobbyItem(event.getOffHandItem())) {
@@ -108,6 +131,13 @@ public class LobbyItemListener implements Listener {
         if (!itemManager.shouldPreventDamage()) {
             return;
         }
+        final Player player = event.getPlayer();
+        if (!itemManager.isProtected(player)) {
+            return;
+        }
+        if (lobbyManager.isBypassing(player)) {
+            return;
+        }
         if (itemManager.isLobbyItem(event.getItem())) {
             event.setCancelled(true);
         }
@@ -116,6 +146,13 @@ public class LobbyItemListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onItemConsume(final PlayerItemConsumeEvent event) {
         if (!itemManager.shouldPreventConsume()) {
+            return;
+        }
+        final Player player = event.getPlayer();
+        if (!itemManager.isProtected(player)) {
+            return;
+        }
+        if (lobbyManager.isBypassing(player)) {
             return;
         }
         if (itemManager.isLobbyItem(event.getItem())) {
@@ -127,6 +164,12 @@ public class LobbyItemListener implements Listener {
     public void onInteract(final PlayerInteractEvent event) {
         final Player player = event.getPlayer();
         if (!itemManager.isEnabled()) {
+            return;
+        }
+        if (!itemManager.isProtected(player)) {
+            return;
+        }
+        if (lobbyManager.isBypassing(player)) {
             return;
         }
         if (event.getHand() == EquipmentSlot.OFF_HAND) {
@@ -150,6 +193,9 @@ public class LobbyItemListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onDeath(final PlayerDeathEvent event) {
         if (!itemManager.isEnabled()) {
+            return;
+        }
+        if (!itemManager.isProtected(event.getEntity())) {
             return;
         }
         final Iterator<ItemStack> iterator = event.getDrops().iterator();

--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -21,8 +21,8 @@ import org.bukkit.inventory.meta.SkullMeta;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 public class ConfiguredMenu implements Menu {
@@ -49,8 +49,21 @@ public class ConfiguredMenu implements Menu {
 
         final ItemStack filler = createFillerItem(menuSection.getString("fill_material"));
         if (filler != null) {
-            for (int slot = 0; slot < inventory.getSize(); slot++) {
-                inventory.setItem(slot, filler.clone());
+            final List<Integer> fillSlots = menuSection.getIntegerList("fill_slots");
+            if (fillSlots == null || fillSlots.isEmpty()) {
+                for (int slot = 0; slot < inventory.getSize(); slot++) {
+                    inventory.setItem(slot, filler.clone());
+                }
+            } else {
+                for (Integer slot : fillSlots) {
+                    if (slot == null) {
+                        continue;
+                    }
+                    final int index = slot;
+                    if (index >= 0 && index < inventory.getSize()) {
+                        inventory.setItem(index, filler.clone());
+                    }
+                }
             }
         }
 
@@ -62,7 +75,7 @@ public class ConfiguredMenu implements Menu {
                     continue;
                 }
                 final Optional<Integer> slot = createItem(player, itemSection);
-                slot.ifPresent(index -> storeActions(index, itemSection.getStringList("actions")));
+                slot.ifPresent(index -> storeActions(index, itemSection));
             }
         }
 
@@ -107,7 +120,10 @@ public class ConfiguredMenu implements Menu {
         }
 
         final int amount = Math.max(1, itemSection.getInt("amount", 1));
-        final String rawHead = itemSection.getString("head");
+        String rawHead = itemSection.getString("head");
+        if (rawHead == null) {
+            rawHead = itemSection.getString("head_id");
+        }
         final String resolvedHead = resolveHeadValue(rawHead, player);
 
         final ItemStack itemStack;
@@ -217,16 +233,21 @@ public class ConfiguredMenu implements Menu {
         return processed;
     }
 
-    private void storeActions(final int slot, final List<String> actions) {
-        if (actions == null || actions.isEmpty()) {
-            return;
-        }
+    private void storeActions(final int slot, final ConfigurationSection itemSection) {
         final List<String> sanitized = new ArrayList<>();
-        for (String action : actions) {
-            if (action == null || action.isBlank()) {
-                continue;
+        if (itemSection.isString("action")) {
+            final String action = itemSection.getString("action");
+            if (action != null && !action.isBlank()) {
+                sanitized.add(action.trim());
             }
-            sanitized.add(action.trim());
+        }
+        if (itemSection.isList("actions")) {
+            for (String action : itemSection.getStringList("actions")) {
+                if (action == null || action.isBlank()) {
+                    continue;
+                }
+                sanitized.add(action.trim());
+            }
         }
         if (!sanitized.isEmpty()) {
             actionsBySlot.put(slot, List.copyOf(sanitized));


### PR DESCRIPTION
## Summary
- track which players currently hold lobby items and expose helpers for protection-aware checks
- update bypass toggles and listeners so protected players keep their lobby loadout while admins can opt out safely
- enhance the configured menu loader with selective fillers, head_id support and single-action definitions

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cec9fcb7ac8329bf78b4e0b401ae15