### PR TITLE
Fix clan rank display names default handling

### DIFF
--- a/src/main/java/com/lobby/core/DatabaseManager.java
+++ b/src/main/java/com/lobby/core/DatabaseManager.java
@@ -1563,7 +1563,7 @@ public class DatabaseManager {
                         id INT AUTO_INCREMENT PRIMARY KEY,
                         clan_id INT NOT NULL,
                         name VARCHAR(30) NOT NULL,
-                        display_name VARCHAR(50) NOT NULL,
+                        display_name VARCHAR(50) NOT NULL DEFAULT 'Membre',
                         priority INT DEFAULT 0 NOT NULL,
                         permissions JSON NULL,
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -1573,9 +1573,10 @@ public class DatabaseManager {
                     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
                     """;
             executeSQL(sql);
-            addColumnIfNotExists("clan_ranks", "display_name", "VARCHAR(50) NOT NULL DEFAULT ''");
+            addColumnIfNotExists("clan_ranks", "display_name", "VARCHAR(50) NOT NULL DEFAULT 'Membre'");
             addColumnIfNotExists("clan_ranks", "permissions", "JSON NULL");
             addColumnIfNotExists("clan_ranks", "created_at", "TIMESTAMP DEFAULT CURRENT_TIMESTAMP");
+            ensureClanRankDisplayNames();
             return;
         }
 
@@ -1584,7 +1585,7 @@ public class DatabaseManager {
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     clan_id INTEGER NOT NULL,
                     name TEXT NOT NULL,
-                    display_name TEXT NOT NULL,
+                    display_name TEXT NOT NULL DEFAULT 'Membre',
                     priority INTEGER DEFAULT 0,
                     permissions TEXT,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -1596,9 +1597,30 @@ public class DatabaseManager {
             executeSQL("CREATE INDEX IF NOT EXISTS idx_clan_ranks_clan_id ON clan_ranks(clan_id)");
             executeSQL("CREATE INDEX IF NOT EXISTS idx_clan_ranks_priority ON clan_ranks(priority)");
         }
-        addColumnIfNotExists("clan_ranks", "display_name", "TEXT NOT NULL DEFAULT ''");
+        addColumnIfNotExists("clan_ranks", "display_name", "TEXT NOT NULL DEFAULT 'Membre'");
         addColumnIfNotExists("clan_ranks", "permissions", "TEXT");
         addColumnIfNotExists("clan_ranks", "created_at", "TIMESTAMP DEFAULT CURRENT_TIMESTAMP");
+        ensureClanRankDisplayNames();
+    }
+
+    private void ensureClanRankDisplayNames() {
+        try {
+            executeSQL("UPDATE clan_ranks SET display_name = name WHERE display_name IS NULL OR TRIM(display_name) = ''");
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.WARNING,
+                    "Failed to backfill clan rank display names: " + exception.getMessage(), exception);
+        }
+
+        if (databaseType != DatabaseType.MYSQL) {
+            return;
+        }
+
+        final String alterSql = "ALTER TABLE clan_ranks MODIFY COLUMN display_name VARCHAR(50) NOT NULL DEFAULT 'Membre'";
+        try {
+            executeSQL(alterSql);
+        } catch (final SQLException exception) {
+            plugin.getLogger().fine("Skipping clan_ranks display_name default enforcement: " + exception.getMessage());
+        }
     }
 
     private void createClanInvitationsTable() throws SQLException {

--- a/src/main/java/com/lobby/social/clans/ClanManager.java
+++ b/src/main/java/com/lobby/social/clans/ClanManager.java
@@ -252,12 +252,13 @@ public class ClanManager {
     }
 
     private void saveRank(final int clanId, final ClanRank rank) {
-        final String query = "INSERT INTO clan_ranks (clan_id, name, permissions, priority) VALUES (?, ?, ?, ?)";
+        final String query = "INSERT INTO clan_ranks (clan_id, name, display_name, permissions, priority) VALUES (?, ?, ?, ?, ?)";
         try (Connection connection = databaseManager.getConnection(); PreparedStatement statement = connection.prepareStatement(query)) {
             statement.setInt(1, clanId);
             statement.setString(2, rank.getName());
-            statement.setString(3, serializePermissions(rank.getPermissions()));
-            statement.setInt(4, rank.getPriority());
+            statement.setString(3, rank.getDisplayName());
+            statement.setString(4, serializePermissions(rank.getPermissions()));
+            statement.setInt(5, rank.getPriority());
             statement.executeUpdate();
         } catch (final SQLException exception) {
             plugin.getLogger().log(Level.SEVERE, "Failed to save clan rank", exception);
@@ -574,16 +575,17 @@ public class ClanManager {
     }
 
     private void loadClanRanks(final Clan clan, final Connection connection) throws SQLException {
-        final String query = "SELECT name, permissions, priority FROM clan_ranks WHERE clan_id = ?";
+        final String query = "SELECT name, display_name, permissions, priority FROM clan_ranks WHERE clan_id = ?";
         try (PreparedStatement statement = connection.prepareStatement(query)) {
             statement.setInt(1, clan.getId());
             try (ResultSet resultSet = statement.executeQuery()) {
                 while (resultSet.next()) {
                     final String name = resultSet.getString("name");
+                    final String displayName = resultSet.getString("display_name");
                     final String permissionsString = resultSet.getString("permissions");
                     final int priority = resultSet.getInt("priority");
                     final Set<ClanPermission> permissions = deserializePermissions(permissionsString);
-                    clan.addRank(new ClanRank(name, priority, permissions));
+                    clan.addRank(new ClanRank(name, displayName, priority, permissions));
                 }
             }
         }

--- a/src/main/java/com/lobby/social/clans/ClanRank.java
+++ b/src/main/java/com/lobby/social/clans/ClanRank.java
@@ -2,22 +2,38 @@ package com.lobby.social.clans;
 
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Objects;
 import java.util.Set;
 
 public class ClanRank {
 
     private final String name;
+    private final String displayName;
     private final int priority;
     private final EnumSet<ClanPermission> permissions;
 
     public ClanRank(final String name, final int priority, final Set<ClanPermission> permissions) {
-        this.name = name;
+        this(name, name, priority, permissions);
+    }
+
+    public ClanRank(final String name, final String displayName, final int priority, final Set<ClanPermission> permissions) {
+        this.name = Objects.requireNonNull(name, "name");
+        final String normalizedDisplayName = displayName == null ? null : displayName.trim();
+        this.displayName = (normalizedDisplayName == null || normalizedDisplayName.isEmpty()) ? this.name : normalizedDisplayName;
         this.priority = priority;
-        this.permissions = permissions.isEmpty() ? EnumSet.noneOf(ClanPermission.class) : EnumSet.copyOf(permissions);
+        if (permissions == null || permissions.isEmpty()) {
+            this.permissions = EnumSet.noneOf(ClanPermission.class);
+        } else {
+            this.permissions = EnumSet.copyOf(permissions);
+        }
     }
 
     public String getName() {
         return name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
     }
 
     public int getPriority() {


### PR DESCRIPTION
## Summary
- add an explicit display name field to ClanRank and persist it when saving or loading clan ranks
- ensure clan rank inserts always provide a display_name value to the database
- set and backfill sensible defaults for the clan_ranks.display_name column during schema creation

## Testing
- `mvn -q -DskipTests package` *(fails: maven central unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ced067cb3883299d3273e0894ad288