### PR TITLE
Implement social menus and placeholder improvements

### DIFF
--- a/src/main/java/com/lobby/social/SocialPlaceholderManager.java
+++ b/src/main/java/com/lobby/social/SocialPlaceholderManager.java
@@ -5,8 +5,12 @@ import com.lobby.economy.EconomyManager;
 import com.lobby.social.clans.Clan;
 import com.lobby.social.clans.ClanManager;
 import com.lobby.social.clans.ClanMember;
+import com.lobby.social.clans.ClanPermission;
+import com.lobby.social.clans.ClanRank;
+import com.lobby.social.friends.AcceptMode;
 import com.lobby.social.friends.FriendInfo;
 import com.lobby.social.friends.FriendManager;
+import com.lobby.social.friends.FriendSettings;
 import com.lobby.social.groups.Group;
 import com.lobby.social.groups.GroupManager;
 import com.lobby.velocity.VelocityManager;
@@ -14,9 +18,17 @@ import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class SocialPlaceholderManager {
 
@@ -47,83 +59,237 @@ public class SocialPlaceholderManager {
         if (economyManager == null) {
             return text;
         }
-        String replaced = text;
-        replaced = replaced.replace("%player_coins%", String.valueOf(economyManager.getCoins(player.getUniqueId())));
-        replaced = replaced.replace("%player_tokens%", String.valueOf(economyManager.getTokens(player.getUniqueId())));
-        return replaced;
+        final Map<String, String> replacements = new HashMap<>();
+        replacements.put("%player_coins%", String.valueOf(economyManager.getCoins(player.getUniqueId())));
+        replacements.put("%player_tokens%", String.valueOf(economyManager.getTokens(player.getUniqueId())));
+        return replaceAll(text, replacements);
     }
 
     private String applyFriendPlaceholders(final Player player, final String text) {
+        final Map<String, String> replacements = new HashMap<>();
+        replacements.put("%friends_total%", "0");
+        replacements.put("%friends_online%", "0");
+        replacements.put("%friends_online_count%", "0");
+        replacements.put("%friends_popular_servers%", "Aucun");
+        replacements.put("%friends_recent_activity%", "Aucune activité");
+        replacements.put("%friend_requests_received%", "0");
+        replacements.put("%friend_requests_sent%", "0");
+        replacements.put("%friend_requests_oldest%", "Aucune");
+        replacements.put("%friends_favorites%", "0");
+        replacements.put("%friends_favorites_count%", "0");
+        replacements.put("%friends_last_seen%", "Aucune donnée");
+        replacements.put("%friend_limits%", "Illimité");
+        replacements.put("%friend_request_status%", "Disponibles");
+        replacements.put("%friend_auto_accept%", "Tous");
+        replacements.put("%friend_notifications%", "Activées");
+        replacements.put("%friend_visibility%", "Visible");
+
         if (player == null) {
-            return text;
+            return replaceAll(text, replacements);
         }
+
         final FriendManager friendManager = plugin.getFriendManager();
         if (friendManager == null) {
-            return text;
+            return replaceAll(text, replacements);
         }
+
         final List<FriendInfo> friends = friendManager.getFriendsList(player.getUniqueId());
         final long online = friends.stream().filter(FriendInfo::isOnline).count();
-        final int requests = friendManager.getPendingRequests(player.getUniqueId()).size();
-        String replaced = text;
-        replaced = replaced.replace("%friends_total%", String.valueOf(friends.size()));
-        replaced = replaced.replace("%friends_online%", String.valueOf(online));
-        replaced = replaced.replace("%friend_requests%", String.valueOf(requests));
-        return replaced;
+        replacements.put("%friends_total%", String.valueOf(friends.size()));
+        replacements.put("%friends_online%", String.valueOf(online));
+        replacements.put("%friends_online_count%", String.valueOf(online));
+
+        final String popularServers = friends.stream()
+                .filter(FriendInfo::isOnline)
+                .map(FriendInfo::getServer)
+                .filter(Objects::nonNull)
+                .collect(Collectors.groupingBy(server -> server, Collectors.counting()))
+                .entrySet()
+                .stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(2)
+                .map(entry -> entry.getKey() + " (" + entry.getValue() + ")")
+                .collect(Collectors.joining(", "));
+        if (!popularServers.isEmpty()) {
+            replacements.put("%friends_popular_servers%", popularServers);
+        }
+
+        final Optional<FriendInfo> mostRecentFriend = friends.stream()
+                .max(Comparator.comparingLong(FriendInfo::getLastSeen));
+        mostRecentFriend.ifPresent(friend -> {
+            final String relative = formatRelativeTime(friend.getLastSeen());
+            replacements.put("%friends_recent_activity%", friend.getName() + " - " + relative);
+            replacements.put("%friends_last_seen%", friend.getName() + " - " + relative);
+        });
+
+        final int requestsReceived = friendManager.getPendingRequests(player.getUniqueId()).size();
+        replacements.put("%friend_requests_received%", String.valueOf(requestsReceived));
+
+        final int requestsSent = friendManager.countSentRequests(player.getUniqueId());
+        replacements.put("%friend_requests_sent%", String.valueOf(requestsSent));
+
+        final long oldestRequest = friendManager.getOldestPendingRequestTimestamp(player.getUniqueId());
+        if (oldestRequest > 0L) {
+            replacements.put("%friend_requests_oldest%", formatRelativeTime(oldestRequest));
+        }
+
+        final FriendSettings settings = friendManager.getFriendSettings(player.getUniqueId());
+        replacements.put("%friend_auto_accept%", formatAcceptMode(settings.getAcceptRequests()));
+        replacements.put("%friend_notifications%", settings.isReceiveNotifications() ? "Activées" : "Désactivées");
+        replacements.put("%friend_visibility%", settings.isShowOnlineStatus() ? "Visible" : "Caché");
+
+        if (settings.getAcceptRequests() == AcceptMode.NONE) {
+            replacements.put("%friend_request_status%", "Demandes désactivées");
+        } else if (requestsSent > 0) {
+            replacements.put("%friend_request_status%", requestsSent + " en attente");
+        } else {
+            replacements.put("%friend_request_status%", "Ouvert");
+        }
+
+        return replaceAll(text, replacements);
     }
 
     private String applyGroupPlaceholders(final Player player, final String text) {
-        if (player == null) {
-            return text;
-        }
+        final Map<String, String> replacements = new HashMap<>();
+        replacements.put("%group_name%", "Aucun");
+        replacements.put("%group_leader%", "Aucun");
+        replacements.put("%group_members%", "0");
+        replacements.put("%group_max%", "0");
+        replacements.put("%group_gamemode%", "Libre");
+        replacements.put("%group_status%", "Aucun");
+        replacements.put("%group_slots_free%", "0");
+        replacements.put("%group_auto_accept%", "Désactivé");
+        replacements.put("%group_preferred_mode%", "Automatique");
+        replacements.put("%group_visibility%", "Public");
+        replacements.put("%group_invitations%", "0");
+        replacements.put("%group_invites_sent%", "0");
+        replacements.put("%groups_open%", "0");
+        replacements.put("%groups_friends%", "0");
+        replacements.put("%friends_online_count%", "0");
+        replacements.put("%queue_available%", "0");
+        replacements.put("%queue_wait_time%", "N/A");
+        replacements.put("%queue_players%", "0");
+
         final GroupManager groupManager = plugin.getGroupManager();
-        if (groupManager == null) {
-            return text;
+        final FriendManager friendManager = plugin.getFriendManager();
+
+        if (player != null && friendManager != null) {
+            final List<FriendInfo> friends = friendManager.getFriendsList(player.getUniqueId());
+            final long online = friends.stream().filter(FriendInfo::isOnline).count();
+            replacements.put("%friends_online_count%", String.valueOf(online));
+            if (groupManager != null) {
+                final long friendsInGroups = friends.stream()
+                        .map(FriendInfo::getUuid)
+                        .map(groupManager::getPlayerGroup)
+                        .filter(Objects::nonNull)
+                        .count();
+                replacements.put("%groups_friends%", String.valueOf(friendsInGroups));
+            }
         }
+
+        if (player == null || groupManager == null) {
+            return replaceAll(text, replacements);
+        }
+
         final Group group = groupManager.getPlayerGroup(player.getUniqueId());
-        if (group == null) {
-            return text.replace("%group_name%", "Aucun")
-                    .replace("%group_members%", "0")
-                    .replace("%group_max%", "0")
-                    .replace("%group_leader%", "Aucun");
+        if (group != null) {
+            replacements.put("%group_name%", Objects.requireNonNullElse(group.getDisplayName(), "Groupe"));
+            replacements.put("%group_leader%", resolveName(group.getLeaderUUID()));
+            replacements.put("%group_members%", String.valueOf(group.getSize()));
+            replacements.put("%group_max%", String.valueOf(group.getMaxSize()));
+            replacements.put("%group_slots_free%", String.valueOf(Math.max(0, group.getMaxSize() - group.getSize())));
+            replacements.put("%group_status%", group.isFull() ? "Complet" : "Ouvert");
+            replacements.put("%group_auto_accept%", "Invitations manuelles");
+            replacements.put("%group_preferred_mode%", "Toutes les files");
+            replacements.put("%group_visibility%", "Privé");
         }
-        final String leaderName = resolveName(group.getLeaderUUID());
-        final int memberCount = group.getMembers().size();
-        final int max = group.getMaxSize();
-        String replaced = text.replace("%group_name%", Objects.requireNonNullElse(group.getDisplayName(), "Aucun"))
-                .replace("%group_members%", String.valueOf(memberCount))
-                .replace("%group_max%", String.valueOf(max))
-                .replace("%group_leader%", leaderName);
-        return replaced;
+
+        replacements.put("%group_invitations%", String.valueOf(groupManager.countPendingInvitations(player.getUniqueId())));
+        replacements.put("%group_invites_sent%", String.valueOf(groupManager.countSentInvitations(player.getUniqueId())));
+        replacements.put("%groups_open%", String.valueOf(groupManager.countCachedOpenGroups()));
+
+        return replaceAll(text, replacements);
     }
 
     private String applyClanPlaceholders(final Player player, final String text) {
-        if (player == null) {
-            return text;
-        }
+        final Map<String, String> replacements = new HashMap<>();
+        replacements.put("%clan_name%", "Aucun");
+        replacements.put("%clan_tag%", "");
+        replacements.put("%clan_rank%", "Aucun");
+        replacements.put("%clan_members%", "0");
+        replacements.put("%clan_max%", "0");
+        replacements.put("%clan_points%", "0");
+        replacements.put("%clan_level%", "0");
+        replacements.put("%clan_online%", "0");
+        replacements.put("%clan_last_activity%", "Aucune activité");
+        replacements.put("%clan_permissions%", "Standard");
+        replacements.put("%clan_player_level%", "Membre");
+        replacements.put("%clan_available_perms%", String.valueOf(ClanPermission.values().length));
+        replacements.put("%clan_ranks_count%", "0");
+        replacements.put("%clan_coins%", "0");
+        replacements.put("%clan_contributions%", "0");
+        replacements.put("%clan_vault_access%", "Réservé");
+        replacements.put("%clan_war_status%", "Inactif");
+        replacements.put("%clan_war_wins%", "0");
+        replacements.put("%clan_war_losses%", "0");
+        replacements.put("%clan_war_ratio%", formatRatio(0, 0));
+        replacements.put("%clans_open_count%", "0");
+        replacements.put("%clans_invite_count%", "0");
+
         final ClanManager clanManager = plugin.getClanManager();
-        if (clanManager == null) {
-            return text;
+        if (player == null || clanManager == null) {
+            return replaceAll(text, replacements);
         }
+
+        replacements.put("%clans_open_count%", String.valueOf(clanManager.countCachedOpenClans()));
+        replacements.put("%clans_invite_count%", String.valueOf(clanManager.countPendingInvitations(player.getUniqueId())));
+
         final Clan clan = clanManager.getPlayerClan(player.getUniqueId());
         if (clan == null) {
-            return text.replace("%clan_name%", "Aucun")
-                    .replace("%clan_tag%", "")
-                    .replace("%clan_rank%", "Aucun")
-                    .replace("%clan_members%", "0")
-                    .replace("%clan_max%", "0")
-                    .replace("%clan_points%", "0")
-                    .replace("%clan_level%", "0");
+            return replaceAll(text, replacements);
         }
+
+        replacements.put("%clan_name%", clan.getName());
+        replacements.put("%clan_tag%", clan.getTag());
+        replacements.put("%clan_members%", String.valueOf(clan.getMembers().size()));
+        replacements.put("%clan_max%", String.valueOf(clan.getMaxMembers()));
+        replacements.put("%clan_points%", String.valueOf(clan.getPoints()));
+        replacements.put("%clan_level%", String.valueOf(clan.getLevel()));
+        replacements.put("%clan_ranks_count%", String.valueOf(clan.getRanks().size()));
+        replacements.put("%clan_coins%", String.valueOf(clan.getBankCoins()));
+
+        final long onlineCount = clan.getMembers().keySet().stream()
+                .map(Bukkit::getPlayer)
+                .filter(Objects::nonNull)
+                .filter(Player::isOnline)
+                .count();
+        replacements.put("%clan_online%", String.valueOf(onlineCount));
+
         final ClanMember member = clan.getMember(player.getUniqueId());
-        String replaced = text;
-        replaced = replaced.replace("%clan_name%", clan.getName());
-        replaced = replaced.replace("%clan_tag%", clan.getTag());
-        replaced = replaced.replace("%clan_rank%", member != null ? member.getRankName() : "Membre");
-        replaced = replaced.replace("%clan_members%", String.valueOf(clan.getMembers().size()));
-        replaced = replaced.replace("%clan_max%", String.valueOf(clan.getMaxMembers()));
-        replaced = replaced.replace("%clan_points%", String.valueOf(clan.getPoints()));
-        replaced = replaced.replace("%clan_level%", String.valueOf(clan.getLevel()));
-        return replaced;
+        if (member != null) {
+            replacements.put("%clan_rank%", member.getRankName());
+            replacements.put("%clan_player_level%", member.getRankName());
+            replacements.put("%clan_contributions%", String.valueOf(member.getTotalContributions()));
+            replacements.put("%clan_last_activity%", formatRelativeTime(member.getJoinedAt()));
+        }
+
+        final ClanRank rank = member != null ? clan.getRank(member.getRankName()) : null;
+        if (rank != null) {
+            final String permissions = rank.getPermissions().isEmpty()
+                    ? "Standard"
+                    : rank.getPermissions().stream()
+                    .map(this::formatPermissionName)
+                    .collect(Collectors.joining(", "));
+            replacements.put("%clan_permissions%", permissions);
+            replacements.put("%clan_available_perms%", String.valueOf(Math.max(0,
+                    ClanPermission.values().length - rank.getPermissions().size())));
+            replacements.put("%clan_player_level%", rank.getDisplayName());
+        }
+
+        final boolean vaultAccess = clan.hasPermission(player.getUniqueId(), ClanPermission.MANAGE_BANK);
+        replacements.put("%clan_vault_access%", vaultAccess ? "Autorisé" : "Réservé");
+
+        return replaceAll(text, replacements);
     }
 
     private String applyServerPlaceholders(final String text) {
@@ -141,6 +307,73 @@ public class SocialPlaceholderManager {
         replaced = replaced.replace("%server_online_custom%",
                 String.valueOf(velocityManager.getServerPlayerCount("custom")));
         return replaced;
+    }
+
+    private String replaceAll(final String text, final Map<String, String> replacements) {
+        if (text == null || text.isEmpty() || replacements.isEmpty()) {
+            return text;
+        }
+        String replaced = text;
+        for (Map.Entry<String, String> entry : replacements.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            replaced = replaced.replace(entry.getKey(), entry.getValue());
+        }
+        return replaced;
+    }
+
+    private String formatRelativeTime(final long timestamp) {
+        if (timestamp <= 0L) {
+            return "Inconnu";
+        }
+        Duration duration = Duration.between(Instant.ofEpochMilli(timestamp), Instant.now());
+        if (duration.isNegative()) {
+            duration = Duration.ZERO;
+        }
+        final long days = duration.toDays();
+        if (days > 0) {
+            return "il y a " + days + "j";
+        }
+        final long hours = duration.toHours();
+        if (hours > 0) {
+            return "il y a " + hours + "h";
+        }
+        final long minutes = duration.toMinutes();
+        if (minutes > 0) {
+            return "il y a " + minutes + "m";
+        }
+        final long seconds = duration.getSeconds();
+        if (seconds <= 5) {
+            return "à l'instant";
+        }
+        return "il y a " + seconds + "s";
+    }
+
+    private String formatAcceptMode(final AcceptMode mode) {
+        if (mode == null) {
+            return "Tous";
+        }
+        return switch (mode) {
+            case ALL -> "Tous";
+            case FRIENDS_OF_FRIENDS -> "Amis d'amis";
+            case NONE -> "Personne";
+        };
+    }
+
+    private String formatPermissionName(final ClanPermission permission) {
+        final String formatted = permission.name().toLowerCase(Locale.ROOT).replace('_', ' ');
+        return Character.toUpperCase(formatted.charAt(0)) + formatted.substring(1);
+    }
+
+    private String formatRatio(final int wins, final int losses) {
+        if (wins <= 0 && losses <= 0) {
+            return "0.0";
+        }
+        if (losses <= 0) {
+            return String.format(Locale.US, "%.2f", (double) wins);
+        }
+        return String.format(Locale.US, "%.2f", (double) wins / Math.max(1, losses));
     }
 
     private String resolveName(final UUID uuid) {

--- a/src/main/java/com/lobby/social/clans/ClanManager.java
+++ b/src/main/java/com/lobby/social/clans/ClanManager.java
@@ -17,6 +17,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -178,6 +179,31 @@ public class ClanManager {
             return true;
         }
         return loadClanForPlayer(uuid) != null;
+    }
+
+    public int countPendingInvitations(final UUID playerUUID) {
+        final String query = "SELECT COUNT(*) FROM clan_invitations WHERE invited_uuid = ? AND status = 'PENDING'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getInt(1);
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to count clan invitations for " + playerUUID, exception);
+        }
+        return 0;
+    }
+
+    public int countCachedOpenClans() {
+        return (int) clanCache.values().stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .filter(clan -> !clan.isFull())
+                .count();
     }
 
     private void cacheClan(final Clan clan) {

--- a/src/main/java/com/lobby/social/friends/FriendManager.java
+++ b/src/main/java/com/lobby/social/friends/FriendManager.java
@@ -211,6 +211,43 @@ public class FriendManager {
         return new ArrayList<>(requests);
     }
 
+    public int countSentRequests(final UUID playerUUID) {
+        final String query = "SELECT COUNT(*) FROM friends WHERE player_uuid = ? AND status = 'PENDING'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getInt(1);
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to count sent friend requests for " + playerUUID, exception);
+        }
+        return 0;
+    }
+
+    public long getOldestPendingRequestTimestamp(final UUID playerUUID) {
+        final String query = "SELECT MIN(created_at) AS oldest FROM friends WHERE friend_uuid = ? AND status = 'PENDING'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    final Timestamp timestamp = resultSet.getTimestamp("oldest");
+                    if (timestamp != null) {
+                        return timestamp.getTime();
+                    }
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to fetch oldest pending friend request for " + playerUUID, exception);
+        }
+        return 0L;
+    }
+
     public boolean areFriends(final UUID player1, final UUID player2) {
         final Set<UUID> friends = friendsCache.computeIfAbsent(player1, this::loadFriendsFromDatabase);
         return friends.contains(player2);
@@ -327,7 +364,7 @@ public class FriendManager {
         return false;
     }
 
-    private FriendSettings getFriendSettings(final UUID uuid) {
+    public FriendSettings getFriendSettings(final UUID uuid) {
         return settingsCache.computeIfAbsent(uuid, this::loadSettings);
     }
 

--- a/src/main/java/com/lobby/social/groups/GroupManager.java
+++ b/src/main/java/com/lobby/social/groups/GroupManager.java
@@ -178,6 +178,46 @@ public class GroupManager {
         return getPlayerGroup(uuid) != null;
     }
 
+    public int countPendingInvitations(final UUID playerUUID) {
+        final String query = "SELECT COUNT(*) FROM group_invitations WHERE invited_uuid = ? AND status = 'PENDING'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getInt(1);
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to count pending group invitations for " + playerUUID, exception);
+        }
+        return 0;
+    }
+
+    public int countSentInvitations(final UUID inviterUUID) {
+        final String query = "SELECT COUNT(*) FROM group_invitations WHERE inviter_uuid = ? AND status = 'PENDING'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, inviterUUID.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getInt(1);
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to count sent group invitations for " + inviterUUID, exception);
+        }
+        return 0;
+    }
+
+    public int countCachedOpenGroups() {
+        return (int) groupCache.values().stream()
+                .filter(group -> group != null && !group.isFull())
+                .count();
+    }
+
     private Group getGroupById(final int id) {
         final Group cached = groupCache.get(id);
         if (cached != null) {

--- a/src/main/resources/config/menus.yml
+++ b/src/main/resources/config/menus.yml
@@ -149,7 +149,7 @@ menus:
 
   profile_menu:
     title: "&bProfil de %player_name%"
-    size: 27
+    size: 45
     items:
       overview:
         slot: 11
@@ -178,8 +178,48 @@ menus:
           - "&7Personnalise ton expérience"
         actions:
           - "[COMMAND] settings open %player_name%"
+      clan_menu_entry:
+        slot: 28
+        material: PLAYER_HEAD
+        head: "hdb:8971"
+        name: "&cGestion de Clan"
+        lore:
+          - "&7Gérez votre clan et ses membres"
+          - "&8▸ &7Clan: &c%clan_name%"
+          - "&8▸ &7Rang: &6%clan_rank%"
+          - "&8▸ &7Membres: &a%clan_members%/%clan_max%"
+          - ""
+          - "&c▶ Cliquez pour ouvrir"
+        actions:
+          - "[MENU] clan_menu"
+      friends_menu_entry:
+        slot: 30
+        material: PLAYER_HEAD
+        head: "hdb:9945"
+        name: "&aGestion d'Amis"
+        lore:
+          - "&7Retrouvez vos amis rapidement"
+          - "&8▸ &7En ligne: &a%friends_online_count%/%friends_total%"
+          - "&8▸ &7Demandes: &e%friend_requests_received%"
+          - ""
+          - "&a▶ Cliquez pour ouvrir"
+        actions:
+          - "[MENU] friends_menu"
+      groups_menu_entry:
+        slot: 32
+        material: PLAYER_HEAD
+        head: "hdb:9723"
+        name: "&eGestion de Groupes"
+        lore:
+          - "&7Organisez vos sessions de jeu"
+          - "&8▸ &7Membres: &a%group_members%/%group_max%"
+          - "&8▸ &7Invitations: &e%group_invitations%"
+          - ""
+          - "&e▶ Cliquez pour ouvrir"
+        actions:
+          - "[MENU] groups_menu"
       back:
-        slot: 18
+        slot: 36
         material: ARROW
         name: "&aRetour"
         lore:
@@ -187,7 +227,7 @@ menus:
         actions:
           - "[MENU] main_menu"
       close:
-        slot: 26
+        slot: 44
         material: BARRIER
         name: "&cFermer"
         lore:
@@ -223,5 +263,934 @@ menus:
         name: "&cFermer"
         lore:
           - "&7Fermer les statistiques"
+        actions:
+          - "[CLOSE]"
+
+  clan_menu:
+    title: "&8» &c&lGestion de Clan"
+    size: 54
+    items:
+      decor_0:
+        slot: 0
+        material: RED_STAINED_GLASS_PANE
+        name: "&7"
+      decor_1:
+        slot: 1
+        material: RED_STAINED_GLASS_PANE
+        name: "&7"
+      decor_2:
+        slot: 2
+        material: RED_STAINED_GLASS_PANE
+        name: "&7"
+      decor_6:
+        slot: 6
+        material: RED_STAINED_GLASS_PANE
+        name: "&7"
+      decor_7:
+        slot: 7
+        material: RED_STAINED_GLASS_PANE
+        name: "&7"
+      decor_8:
+        slot: 8
+        material: RED_STAINED_GLASS_PANE
+        name: "&7"
+      decor_9:
+        slot: 9
+        material: RED_STAINED_GLASS_PANE
+        name: "&7"
+      decor_17:
+        slot: 17
+        material: RED_STAINED_GLASS_PANE
+        name: "&7"
+      decor_45:
+        slot: 45
+        material: RED_STAINED_GLASS_PANE
+        name: "&7"
+      decor_53:
+        slot: 53
+        material: RED_STAINED_GLASS_PANE
+        name: "&7"
+      clan_overview:
+        slot: 19
+        material: PLAYER_HEAD
+        head: "hdb:8971"
+        name: "&c&lMon Clan"
+        lore:
+          - "&7Informations sur votre clan actuel"
+          - "&r"
+          - "&8▸ &7Clan: &c%clan_name%"
+          - "&8▸ &7Rang: &6%clan_rank%"
+          - "&8▸ &7Membres: &a%clan_members%/%clan_max%"
+          - "&8▸ &7Points: &e%clan_points%"
+          - "&8▸ &7Niveau: &b%clan_level%"
+          - "&r"
+          - "&a▶ Cliquez pour voir les détails !"
+        actions:
+          - "[MENU] clan_info_menu"
+      clan_members:
+        slot: 21
+        material: PLAYER_HEAD
+        head: "hdb:9969"
+        name: "&e&lMembres du Clan"
+        lore:
+          - "&7Gérez les membres de votre clan"
+          - "&r"
+          - "&8▸ &7Membres connectés: &a%clan_online%/%clan_members%"
+          - "&8▸ &7Dernière activité: %clan_last_activity%"
+          - "&8▸ &7Permissions: %clan_permissions%"
+          - "&r"
+          - "&a▶ Cliquez pour gérer !"
+        actions:
+          - "[MENU] clan_members_menu"
+      clan_ranks:
+        slot: 23
+        material: PLAYER_HEAD
+        head: "hdb:1218"
+        name: "&d&lRangs et Permissions"
+        lore:
+          - "&7Configurez les rangs de votre clan"
+          - "&r"
+          - "&8▸ &7Votre niveau: &6%clan_player_level%"
+          - "&8▸ &7Permissions disponibles: %clan_available_perms%"
+          - "&8▸ &7Rangs configurés: &e%clan_ranks_count%"
+          - "&r"
+          - "&6⚠ Nécessite rang Officier+"
+        actions:
+          - "[MENU] clan_ranks_menu"
+      clan_vault:
+        slot: 25
+        material: PLAYER_HEAD
+        head: "hdb:35472"
+        name: "&a&lTrésor du Clan"
+        lore:
+          - "&7Gérez les ressources du clan"
+          - "&r"
+          - "&8▸ &7Coins du clan: &e%clan_coins%"
+          - "&8▸ &7Contributions mensuelles: &6%clan_contributions%"
+          - "&8▸ &7Accès coffre: %clan_vault_access%"
+          - "&r"
+          - "&a▶ Cliquez pour accéder !"
+        actions:
+          - "[MENU] clan_vault_menu"
+      clan_wars:
+        slot: 31
+        material: PLAYER_HEAD
+        head: "hdb:38878"
+        name: "&b&lGuerres de Clans"
+        lore:
+          - "&7Participez aux guerres épiques !"
+          - "&r"
+          - "&8▸ &7Guerre actuelle: %clan_war_status%"
+          - "&8▸ &7Victoires: &a%clan_war_wins%"
+          - "&8▸ &7Défaites: &c%clan_war_losses%"
+          - "&8▸ &7Ratio: &6%clan_war_ratio%"
+          - "&r"
+          - "&c⚔ Cliquez pour les guerres !"
+        actions:
+          - "[MENU] clan_wars_menu"
+      clan_create:
+        slot: 37
+        material: PLAYER_HEAD
+        head: "hdb:12654"
+        name: "&6&lCréer un Clan"
+        lore:
+          - "&7Créez votre propre clan !"
+          - "&r"
+          - "&8▸ &7Coût: &e10,000 coins"
+          - "&8▸ &7Membres max: &a20 joueurs"
+          - "&8▸ &7Avantages: Coffre, Guerres, Chat privé"
+          - "&r"
+          - "&a▶ Cliquez pour créer !"
+        actions:
+          - "[COMMAND] clan create"
+      clan_join:
+        slot: 43
+        material: PLAYER_HEAD
+        head: "hdb:23022"
+        name: "&e&lRejoindre un Clan"
+        lore:
+          - "&7Explorez les clans disponibles"
+          - "&r"
+          - "&8▸ &7Clans ouverts: &a%clans_open_count%"
+          - "&8▸ &7Clans avec invitations: &e%clans_invite_count%"
+          - "&8▸ &7Popularité: Top clans actifs"
+          - "&r"
+          - "&a▶ Cliquez pour explorer !"
+        actions:
+          - "[MENU] clan_browse_menu"
+      clan_back:
+        slot: 49
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
+        lore:
+          - "&7Retourner au menu principal"
+        actions:
+          - "[MENU] profil_menu"
+
+  friends_menu:
+    title: "&8» &a&lGestion d'Amis"
+    size: 54
+    items:
+      decor_0:
+        slot: 0
+        material: GREEN_STAINED_GLASS_PANE
+        name: "&7"
+      decor_1:
+        slot: 1
+        material: GREEN_STAINED_GLASS_PANE
+        name: "&7"
+      decor_2:
+        slot: 2
+        material: GREEN_STAINED_GLASS_PANE
+        name: "&7"
+      decor_6:
+        slot: 6
+        material: GREEN_STAINED_GLASS_PANE
+        name: "&7"
+      decor_7:
+        slot: 7
+        material: GREEN_STAINED_GLASS_PANE
+        name: "&7"
+      decor_8:
+        slot: 8
+        material: GREEN_STAINED_GLASS_PANE
+        name: "&7"
+      decor_9:
+        slot: 9
+        material: GREEN_STAINED_GLASS_PANE
+        name: "&7"
+      decor_17:
+        slot: 17
+        material: GREEN_STAINED_GLASS_PANE
+        name: "&7"
+      decor_45:
+        slot: 45
+        material: GREEN_STAINED_GLASS_PANE
+        name: "&7"
+      decor_53:
+        slot: 53
+        material: GREEN_STAINED_GLASS_PANE
+        name: "&7"
+      friends_online:
+        slot: 20
+        material: PLAYER_HEAD
+        head: "hdb:9945"
+        name: "&a&lAmis En Ligne"
+        lore:
+          - "&7Vos amis actuellement connectés"
+          - "&r"
+          - "&8▸ &7Amis en ligne: &a%friends_online_count%/%friends_total%"
+          - "&8▸ &7Serveurs populaires: %friends_popular_servers%"
+          - "&8▸ &7Activité récente: %friends_recent_activity%"
+          - "&r"
+          - "&a▶ Cliquez pour voir la liste !"
+        actions:
+          - "[MENU] friends_online_menu"
+      friend_requests:
+        slot: 22
+        material: PLAYER_HEAD
+        head: "hdb:1455"
+        name: "&e&lDemandes d'Amis"
+        lore:
+          - "&7Gérez vos demandes d'amitié"
+          - "&r"
+          - "&8▸ &7Demandes reçues: &e%friend_requests_received%"
+          - "&8▸ &7Demandes envoyées: &b%friend_requests_sent%"
+          - "&8▸ &7En attente depuis: %friend_requests_oldest%"
+          - "&r"
+          - "&e▶ Cliquez pour gérer !"
+        actions:
+          - "[MENU] friend_requests_menu"
+      friends_all:
+        slot: 24
+        material: PLAYER_HEAD
+        head: "hdb:13389"
+        name: "&b&lTous mes Amis"
+        lore:
+          - "&7Liste complète de vos amis"
+          - "&r"
+          - "&8▸ &7Total d'amis: &a%friends_total%"
+          - "&8▸ &7Amis favoris: &6%friends_favorites%"
+          - "&8▸ &7Dernière connexion: %friends_last_seen%"
+          - "&r"
+          - "&b▶ Cliquez pour parcourir !"
+        actions:
+          - "[MENU] friends_all_menu"
+      friend_add:
+        slot: 28
+        material: PLAYER_HEAD
+        head: "hdb:7439"
+        name: "&d&lAjouter un Ami"
+        lore:
+          - "&7Envoyez une demande d'amitié"
+          - "&r"
+          - "&8▸ &7Tapez le nom dans le chat"
+          - "&8▸ &7Limites: %friend_limits%"
+          - "&8▸ &7Statut: %friend_request_status%"
+          - "&r"
+          - "&d▶ Cliquez pour ajouter !"
+        actions:
+          - "[COMMAND] friend add"
+      friend_settings:
+        slot: 30
+        material: PLAYER_HEAD
+        head: "hdb:8537"
+        name: "&6&lParamètres d'Amis"
+        lore:
+          - "&7Configurez vos préférences"
+          - "&r"
+          - "&8▸ &7Demandes automatiques: %friend_auto_accept%"
+          - "&8▸ &7Notifications: %friend_notifications%"
+          - "&8▸ &7Visibilité: %friend_visibility%"
+          - "&r"
+          - "&6▶ Cliquez pour configurer !"
+        actions:
+          - "[MENU] friend_settings_menu"
+      friends_favorites:
+        slot: 32
+        material: PLAYER_HEAD
+        head: "hdb:35472"
+        name: "&c&lAmis Favoris"
+        lore:
+          - "&7Vos amis les plus proches"
+          - "&r"
+          - "&8▸ &7Favoris marqués: &6%friends_favorites_count%"
+          - "&8▸ &7Notifications prioritaires activées"
+          - "&8▸ &7Accès rapide aux invitations"
+          - "&r"
+          - "&c▶ Cliquez pour voir !"
+        actions:
+          - "[MENU] friends_favorites_menu"
+      friends_back:
+        slot: 49
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
+        lore:
+          - "&7Retourner au menu profil"
+        actions:
+          - "[MENU] profil_menu"
+
+  groups_menu:
+    title: "&8» &e&lGestion de Groupes"
+    size: 54
+    items:
+      decor_0:
+        slot: 0
+        material: YELLOW_STAINED_GLASS_PANE
+        name: "&7"
+      decor_1:
+        slot: 1
+        material: YELLOW_STAINED_GLASS_PANE
+        name: "&7"
+      decor_2:
+        slot: 2
+        material: YELLOW_STAINED_GLASS_PANE
+        name: "&7"
+      decor_6:
+        slot: 6
+        material: YELLOW_STAINED_GLASS_PANE
+        name: "&7"
+      decor_7:
+        slot: 7
+        material: YELLOW_STAINED_GLASS_PANE
+        name: "&7"
+      decor_8:
+        slot: 8
+        material: YELLOW_STAINED_GLASS_PANE
+        name: "&7"
+      decor_9:
+        slot: 9
+        material: YELLOW_STAINED_GLASS_PANE
+        name: "&7"
+      decor_17:
+        slot: 17
+        material: YELLOW_STAINED_GLASS_PANE
+        name: "&7"
+      decor_45:
+        slot: 45
+        material: YELLOW_STAINED_GLASS_PANE
+        name: "&7"
+      decor_53:
+        slot: 53
+        material: YELLOW_STAINED_GLASS_PANE
+        name: "&7"
+      group_current:
+        slot: 20
+        material: PLAYER_HEAD
+        head: "hdb:9723"
+        name: "&e&lMon Groupe Actuel"
+        lore:
+          - "&7Informations sur votre groupe"
+          - "&r"
+          - "&8▸ &7Groupe: %group_name%"
+          - "&8▸ &7Leader: &6%group_leader%"
+          - "&8▸ &7Membres: &a%group_members%/%group_max%"
+          - "&8▸ &7Mode de jeu: &b%group_gamemode%"
+          - "&8▸ &7Statut: %group_status%"
+          - "&r"
+          - "&e▶ Cliquez pour gérer !"
+        actions:
+          - "[MENU] group_manage_menu"
+      group_create:
+        slot: 22
+        material: PLAYER_HEAD
+        head: "hdb:38878"
+        name: "&a&lCréer un Groupe"
+        lore:
+          - "&7Créez un nouveau groupe de jeu"
+          - "&r"
+          - "&8▸ &7Taille max: &a8 joueurs"
+          - "&8▸ &7Modes supportés: Tous les jeux"
+          - "&8▸ &7Durée max: &e2 heures"
+          - "&8▸ &7Coût: &aGratuit"
+          - "&r"
+          - "&a▶ Cliquez pour créer !"
+        actions:
+          - "[COMMAND] group create"
+      group_join:
+        slot: 24
+        material: PLAYER_HEAD
+        head: "hdb:1218"
+        name: "&b&lRejoindre un Groupe"
+        lore:
+          - "&7Rejoignez un groupe existant"
+          - "&r"
+          - "&8▸ &7Groupes ouverts: &a%groups_open%"
+          - "&8▸ &7Groupes d'amis: &e%groups_friends%"
+          - "&8▸ &7Invitations reçues: &b%group_invitations%"
+          - "&r"
+          - "&b▶ Cliquez pour explorer !"
+        actions:
+          - "[MENU] group_browse_menu"
+      group_invite:
+        slot: 28
+        material: PLAYER_HEAD
+        head: "hdb:7439"
+        name: "&d&lInviter des Joueurs"
+        lore:
+          - "&7Invitez des amis dans votre groupe"
+          - "&r"
+          - "&8▸ &7Amis en ligne: &a%friends_online_count%"
+          - "&8▸ &7Places disponibles: &e%group_slots_free%"
+          - "&8▸ &7Invitations envoyées: &b%group_invites_sent%"
+          - "&r"
+          - "&d▶ Cliquez pour inviter !"
+        actions:
+          - "[MENU] group_invite_menu"
+      group_queue:
+        slot: 30
+        material: PLAYER_HEAD
+        head: "hdb:23022"
+        name: "&6&lFiles d'Attente"
+        lore:
+          - "&7Rejoignez une file d'attente"
+          - "&r"
+          - "&8▸ &7Files disponibles: %queue_available%"
+          - "&8▸ &7Temps d'attente moyen: &b%queue_wait_time%"
+          - "&8▸ &7Joueurs en file: &e%queue_players%"
+          - "&r"
+          - "&6▶ Cliquez pour rejoindre !"
+        actions:
+          - "[MENU] queue_menu"
+      group_settings:
+        slot: 32
+        material: PLAYER_HEAD
+        head: "hdb:8537"
+        name: "&c&lParamètres de Groupe"
+        lore:
+          - "&7Configurez vos préférences"
+          - "&r"
+          - "&8▸ &7Invitations automatiques: %group_auto_accept%"
+          - "&8▸ &7Mode préféré: %group_preferred_mode%"
+          - "&8▸ &7Visibilité: %group_visibility%"
+          - "&r"
+          - "&c▶ Cliquez pour configurer !"
+        actions:
+          - "[MENU] group_settings_menu"
+      group_back:
+        slot: 49
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
+        lore:
+          - "&7Retourner au menu profil"
+        actions:
+          - "[MENU] profil_menu"
+
+  clan_info_menu:
+    title: "&8» &c&lMon Clan"
+    size: 27
+    items:
+      details:
+        slot: 13
+        material: PLAYER_HEAD
+        head: "hdb:8971"
+        name: "&c&lDétails du Clan"
+        lore:
+          - "&7Nom: &c%clan_name%"
+          - "&7Tag: &f%clan_tag%"
+          - "&7Rang: &6%clan_rank%"
+          - "&7Niveau: &b%clan_level%"
+          - "&7Membres: &a%clan_members%/%clan_max%"
+          - "&7Points: &e%clan_points%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour à la gestion du clan"
+        actions:
+          - "[MENU] clan_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  clan_members_menu:
+    title: "&8» &c&lMembres du Clan"
+    size: 27
+    items:
+      summary:
+        slot: 13
+        material: BOOK
+        name: "&eListe des membres"
+        lore:
+          - "&7Membres totaux: &a%clan_members%"
+          - "&7Connectés: &a%clan_online%"
+          - "&7Dernière activité: %clan_last_activity%"
+          - "&7Permissions: %clan_permissions%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Revenir au menu clan"
+        actions:
+          - "[MENU] clan_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  clan_ranks_menu:
+    title: "&8» &d&lRangs de Clan"
+    size: 27
+    items:
+      overview:
+        slot: 13
+        material: PAPER
+        name: "&dAperçu des rangs"
+        lore:
+          - "&7Votre rang: &6%clan_player_level%"
+          - "&7Rangs configurés: &e%clan_ranks_count%"
+          - "&7Permissions restantes: %clan_available_perms%"
+          - "&7Accès coffre: %clan_vault_access%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Revenir au menu clan"
+        actions:
+          - "[MENU] clan_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  clan_vault_menu:
+    title: "&8» &a&lTrésor du Clan"
+    size: 27
+    items:
+      vault_info:
+        slot: 13
+        material: CHEST
+        name: "&aInformations du coffre"
+        lore:
+          - "&7Solde: &e%clan_coins%"
+          - "&7Contributions: &6%clan_contributions%"
+          - "&7Accès: %clan_vault_access%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Revenir au menu clan"
+        actions:
+          - "[MENU] clan_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  clan_wars_menu:
+    title: "&8» &b&lGuerres de Clans"
+    size: 27
+    items:
+      war_info:
+        slot: 13
+        material: IRON_SWORD
+        name: "&bStatistiques de guerre"
+        lore:
+          - "&7Statut: %clan_war_status%"
+          - "&7Victoires: &a%clan_war_wins%"
+          - "&7Défaites: &c%clan_war_losses%"
+          - "&7Ratio: &6%clan_war_ratio%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Revenir au menu clan"
+        actions:
+          - "[MENU] clan_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  clan_browse_menu:
+    title: "&8» &e&lExplorer les Clans"
+    size: 27
+    items:
+      listing:
+        slot: 13
+        material: COMPASS
+        name: "&eClans disponibles"
+        lore:
+          - "&7Clans ouverts: &a%clans_open_count%"
+          - "&7Invitations reçues: &e%clans_invite_count%"
+          - "&7Popularité: Top clans actifs"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Revenir au menu clan"
+        actions:
+          - "[MENU] clan_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  friends_online_menu:
+    title: "&8» &a&lAmis En Ligne"
+    size: 27
+    items:
+      overview:
+        slot: 13
+        material: PLAYER_HEAD
+        head: "%player_name%"
+        name: "&aVos amis connectés"
+        lore:
+          - "&7En ligne: &a%friends_online_count%/%friends_total%"
+          - "&7Serveurs: %friends_popular_servers%"
+          - "&7Dernière activité: %friends_recent_activity%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour à la gestion des amis"
+        actions:
+          - "[MENU] friends_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  friend_requests_menu:
+    title: "&8» &e&lDemandes d'Amis"
+    size: 27
+    items:
+      summary:
+        slot: 13
+        material: PAPER
+        name: "&eDemandes en attente"
+        lore:
+          - "&7Reçues: &e%friend_requests_received%"
+          - "&7Envoyées: &b%friend_requests_sent%"
+          - "&7Plus ancienne: %friend_requests_oldest%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour à la gestion des amis"
+        actions:
+          - "[MENU] friends_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  friends_all_menu:
+    title: "&8» &b&lTous mes Amis"
+    size: 27
+    items:
+      summary:
+        slot: 13
+        material: BOOK
+        name: "&bRésumé des amis"
+        lore:
+          - "&7Total: &a%friends_total%"
+          - "&7Favoris: &6%friends_favorites_count%"
+          - "&7Dernier connecté: %friends_last_seen%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour à la gestion des amis"
+        actions:
+          - "[MENU] friends_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  friend_settings_menu:
+    title: "&8» &6&lParamètres d'Amis"
+    size: 27
+    items:
+      settings_info:
+        slot: 13
+        material: REDSTONE_COMPARATOR
+        name: "&6Configuration actuelle"
+        lore:
+          - "&7Demandes automatiques: %friend_auto_accept%"
+          - "&7Notifications: %friend_notifications%"
+          - "&7Visibilité: %friend_visibility%"
+          - "&7Limite: %friend_limits%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour à la gestion des amis"
+        actions:
+          - "[MENU] friends_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  friends_favorites_menu:
+    title: "&8» &c&lAmis Favoris"
+    size: 27
+    items:
+      favorites_info:
+        slot: 13
+        material: PLAYER_HEAD
+        head: "%player_name%"
+        name: "&cFavoris"
+        lore:
+          - "&7Favoris marqués: &6%friends_favorites_count%"
+          - "&7Notifications prioritaires: %friend_notifications%"
+          - "&7Dernière activité: %friends_recent_activity%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour à la gestion des amis"
+        actions:
+          - "[MENU] friends_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  group_manage_menu:
+    title: "&8» &e&lMon Groupe"
+    size: 27
+    items:
+      group_info:
+        slot: 13
+        material: PLAYER_HEAD
+        head: "hdb:9723"
+        name: "&eDétails du groupe"
+        lore:
+          - "&7Nom: &f%group_name%"
+          - "&7Leader: &6%group_leader%"
+          - "&7Membres: &a%group_members%/%group_max%"
+          - "&7Statut: %group_status%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour à la gestion des groupes"
+        actions:
+          - "[MENU] groups_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  group_browse_menu:
+    title: "&8» &b&lExplorer les Groupes"
+    size: 27
+    items:
+      browse_info:
+        slot: 13
+        material: COMPASS
+        name: "&bGroupes disponibles"
+        lore:
+          - "&7Groupes ouverts: &a%groups_open%"
+          - "&7Groupes d'amis: &e%groups_friends%"
+          - "&7Invitations reçues: &b%group_invitations%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour à la gestion des groupes"
+        actions:
+          - "[MENU] groups_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  group_invite_menu:
+    title: "&8» &d&lInvitations de Groupe"
+    size: 27
+    items:
+      invite_info:
+        slot: 13
+        material: PAPER
+        name: "&dInvitations"
+        lore:
+          - "&7Amis en ligne: &a%friends_online_count%"
+          - "&7Invitations envoyées: &b%group_invites_sent%"
+          - "&7Invitations reçues: &e%group_invitations%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour à la gestion des groupes"
+        actions:
+          - "[MENU] groups_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  queue_menu:
+    title: "&8» &6&lFiles d'Attente"
+    size: 27
+    items:
+      queue_info:
+        slot: 13
+        material: CLOCK
+        name: "&6Statut des files"
+        lore:
+          - "&7Files disponibles: %queue_available%"
+          - "&7Temps d'attente: &b%queue_wait_time%"
+          - "&7Joueurs en file: &e%queue_players%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour à la gestion des groupes"
+        actions:
+          - "[MENU] groups_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  group_settings_menu:
+    title: "&8» &c&lParamètres de Groupe"
+    size: 27
+    items:
+      settings_info:
+        slot: 13
+        material: REDSTONE_COMPARATOR
+        name: "&cConfiguration"
+        lore:
+          - "&7Invitations automatiques: %group_auto_accept%"
+          - "&7Mode préféré: %group_preferred_mode%"
+          - "&7Visibilité: %group_visibility%"
+      back:
+        slot: 18
+        material: ARROW
+        name: "&aRetour"
+        lore:
+          - "&7Retour à la gestion des groupes"
+        actions:
+          - "[MENU] groups_menu"
+      close:
+        slot: 26
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
         actions:
           - "[CLOSE]"


### PR DESCRIPTION
## Summary
- expand the social placeholder manager to cover clan, friend, and group metrics used by the new menus
- expose helper queries in the clan, friend, and group managers for invitation counts and other UI data
- configure the clan, friends, and groups menus (plus supporting stubs) in `menus.yml` with themed layouts and actions

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach Maven Central in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ced91e5cc08329a63b9754ea3ae39d