### PR TITLE
feat: enrich friend backend with favorites and settings

### DIFF
--- a/src/main/java/com/lobby/core/DatabaseManager.java
+++ b/src/main/java/com/lobby/core/DatabaseManager.java
@@ -814,6 +814,7 @@ public class DatabaseManager {
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
                         accepted_at TIMESTAMP NULL,
                         blocked_at TIMESTAMP NULL,
+                        is_favorite BOOLEAN DEFAULT FALSE NOT NULL,
                         UNIQUE KEY unique_friendship (player_uuid, friend_uuid),
                         KEY idx_friends_player_uuid (player_uuid),
                         KEY idx_friends_friend_uuid (friend_uuid),
@@ -835,6 +836,7 @@ public class DatabaseManager {
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     accepted_at TIMESTAMP NULL,
                     blocked_at TIMESTAMP NULL,
+                    is_favorite BOOLEAN DEFAULT 0,
                     UNIQUE (player_uuid, friend_uuid)
                 )
                 """;
@@ -846,6 +848,7 @@ public class DatabaseManager {
             executeSQL("CREATE INDEX IF NOT EXISTS idx_friends_created_at ON friends(created_at)");
         }
         addColumnIfNotExists("friends", "blocked_at", "TIMESTAMP NULL");
+        addColumnIfNotExists("friends", "is_favorite", "BOOLEAN DEFAULT FALSE NOT NULL");
     }
 
     private void createFriendSettingsTable() throws SQLException {
@@ -855,15 +858,21 @@ public class DatabaseManager {
                         player_uuid VARCHAR(36) PRIMARY KEY,
                         accept_requests ENUM('ALL','FRIENDS_OF_FRIENDS','NONE') DEFAULT 'ALL' NOT NULL,
                         show_online_status BOOLEAN DEFAULT TRUE NOT NULL,
+                        allow_notifications BOOLEAN DEFAULT TRUE NOT NULL,
                         receive_notifications BOOLEAN DEFAULT TRUE NOT NULL,
+                        auto_accept_favorites BOOLEAN DEFAULT FALSE NOT NULL,
                         auto_accept_friends BOOLEAN DEFAULT FALSE NOT NULL,
+                        max_friends INT DEFAULT 100 NOT NULL,
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                         INDEX idx_friend_settings_accept_requests (accept_requests)
                     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
                     """;
             executeSQL(sql);
+            addColumnIfNotExists("friend_settings", "allow_notifications", "BOOLEAN DEFAULT TRUE NOT NULL");
+            addColumnIfNotExists("friend_settings", "auto_accept_favorites", "BOOLEAN DEFAULT FALSE NOT NULL");
             addColumnIfNotExists("friend_settings", "auto_accept_friends", "BOOLEAN DEFAULT FALSE NOT NULL");
+            addColumnIfNotExists("friend_settings", "max_friends", "INT DEFAULT 100 NOT NULL");
             addColumnIfNotExists("friend_settings", "created_at", "TIMESTAMP DEFAULT CURRENT_TIMESTAMP");
             addColumnIfNotExists("friend_settings", "updated_at",
                     "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP");
@@ -875,8 +884,11 @@ public class DatabaseManager {
                     player_uuid VARCHAR(36) PRIMARY KEY,
                     accept_requests TEXT DEFAULT 'ALL',
                     show_online_status BOOLEAN DEFAULT 1,
+                    allow_notifications BOOLEAN DEFAULT 1,
                     receive_notifications BOOLEAN DEFAULT 1,
+                    auto_accept_favorites BOOLEAN DEFAULT 0,
                     auto_accept_friends BOOLEAN DEFAULT 0,
+                    max_friends INT DEFAULT 100,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
@@ -885,7 +897,10 @@ public class DatabaseManager {
         if (createIndexes) {
             executeSQL("CREATE INDEX IF NOT EXISTS idx_friend_settings_accept_requests ON friend_settings(accept_requests)");
         }
+        addColumnIfNotExists("friend_settings", "allow_notifications", "BOOLEAN DEFAULT 1");
+        addColumnIfNotExists("friend_settings", "auto_accept_favorites", "BOOLEAN DEFAULT 0");
         addColumnIfNotExists("friend_settings", "auto_accept_friends", "BOOLEAN DEFAULT 0");
+        addColumnIfNotExists("friend_settings", "max_friends", "INT DEFAULT 100");
         addColumnIfNotExists("friend_settings", "created_at", "TIMESTAMP DEFAULT CURRENT_TIMESTAMP");
         addColumnIfNotExists("friend_settings", "updated_at", "TIMESTAMP DEFAULT CURRENT_TIMESTAMP");
     }

--- a/src/main/java/com/lobby/social/SocialPlaceholderManager.java
+++ b/src/main/java/com/lobby/social/SocialPlaceholderManager.java
@@ -95,9 +95,18 @@ public class SocialPlaceholderManager {
 
         final List<FriendInfo> friends = friendManager.getFriendsList(player.getUniqueId());
         final long online = friends.stream().filter(FriendInfo::isOnline).count();
+        final long favoritesCount = friends.stream().filter(FriendInfo::isFavorite).count();
         replacements.put("%friends_total%", String.valueOf(friends.size()));
         replacements.put("%friends_online%", String.valueOf(online));
         replacements.put("%friends_online_count%", String.valueOf(online));
+        replacements.put("%friends_favorites_count%", String.valueOf(favoritesCount));
+        if (favoritesCount > 0) {
+            final String favoritesNames = friends.stream()
+                    .filter(FriendInfo::isFavorite)
+                    .map(FriendInfo::getName)
+                    .collect(Collectors.joining(", "));
+            replacements.put("%friends_favorites%", favoritesNames);
+        }
 
         final String popularServers = friends.stream()
                 .filter(FriendInfo::isOnline)
@@ -134,9 +143,14 @@ public class SocialPlaceholderManager {
         }
 
         final FriendSettings settings = friendManager.getFriendSettings(player.getUniqueId());
-        replacements.put("%friend_auto_accept%", formatAcceptMode(settings.getAcceptRequests()));
-        replacements.put("%friend_notifications%", settings.isReceiveNotifications() ? "Activées" : "Désactivées");
+        replacements.put("%friend_auto_accept%", settings.isAutoAcceptFavorites()
+                ? "Favoris auto"
+                : formatAcceptMode(settings.getAcceptRequests()));
+        replacements.put("%friend_notifications%", settings.isAllowNotifications() ? "Activées" : "Désactivées");
         replacements.put("%friend_visibility%", settings.isShowOnlineStatus() ? "Visible" : "Caché");
+        replacements.put("%friend_limits%", settings.getMaxFriends() <= 0
+                ? "Illimité"
+                : settings.getMaxFriends() + " slots");
 
         if (settings.getAcceptRequests() == AcceptMode.NONE) {
             replacements.put("%friend_request_status%", "Demandes désactivées");

--- a/src/main/java/com/lobby/social/friends/FriendInfo.java
+++ b/src/main/java/com/lobby/social/friends/FriendInfo.java
@@ -10,14 +10,22 @@ public class FriendInfo {
     private final String server;
     private final long friendsSince;
     private final long lastSeen;
+    private final boolean favorite;
 
-    public FriendInfo(final UUID uuid, final String name, final boolean online, final String server, final long friendsSince, final long lastSeen) {
+    public FriendInfo(final UUID uuid,
+                      final String name,
+                      final boolean online,
+                      final String server,
+                      final long friendsSince,
+                      final long lastSeen,
+                      final boolean favorite) {
         this.uuid = uuid;
         this.name = name;
         this.online = online;
         this.server = server;
         this.friendsSince = friendsSince;
         this.lastSeen = lastSeen;
+        this.favorite = favorite;
     }
 
     public UUID getUuid() {
@@ -42,5 +50,9 @@ public class FriendInfo {
 
     public long getLastSeen() {
         return lastSeen;
+    }
+
+    public boolean isFavorite() {
+        return favorite;
     }
 }

--- a/src/main/java/com/lobby/social/friends/FriendManager.java
+++ b/src/main/java/com/lobby/social/friends/FriendManager.java
@@ -14,6 +14,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.sql.ResultSetMetaData;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -29,6 +30,7 @@ public class FriendManager {
     private final LobbyPlugin plugin;
     private final DatabaseManager databaseManager;
     private final Map<UUID, Set<UUID>> friendsCache = new ConcurrentHashMap<>();
+    private final Map<UUID, Set<UUID>> favoritesCache = new ConcurrentHashMap<>();
     private final Map<UUID, Set<UUID>> pendingRequests = new ConcurrentHashMap<>();
     private final Map<UUID, FriendSettings> settingsCache = new ConcurrentHashMap<>();
 
@@ -39,6 +41,7 @@ public class FriendManager {
 
     public void reload() {
         friendsCache.clear();
+        favoritesCache.clear();
         pendingRequests.clear();
         settingsCache.clear();
     }
@@ -57,6 +60,12 @@ public class FriendManager {
 
         if (areFriends(sender.getUniqueId(), target.getUniqueId())) {
             sender.sendMessage("§cVous êtes déjà amis avec " + target.getName() + " !");
+            return;
+        }
+
+        if (isBlocked(sender.getUniqueId(), target.getUniqueId())
+                || isBlocked(target.getUniqueId(), sender.getUniqueId())) {
+            sender.sendMessage("§cImpossible d'envoyer une demande : relation bloquée.");
             return;
         }
 
@@ -83,6 +92,14 @@ public class FriendManager {
         target.sendMessage("§7Tapez §a/friend accept " + sender.getName() + " §7pour accepter");
         target.sendMessage("§7ou §c/friend deny " + sender.getName() + " §7pour refuser");
         target.playSound(target.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.0f);
+    }
+
+    public void onPlayerJoin(final UUID player) {
+        getFriendSettings(player);
+    }
+
+    public void onPlayerQuit(final UUID player) {
+        // Reserved for future cleanup hooks
     }
 
     public void acceptFriendRequest(final Player player, final String senderName) {
@@ -152,14 +169,8 @@ public class FriendManager {
             return;
         }
         removeFriendship(player.getUniqueId(), targetUUID);
-        friendsCache.computeIfPresent(player.getUniqueId(), (uuid, uuids) -> {
-            uuids.remove(targetUUID);
-            return uuids;
-        });
-        friendsCache.computeIfPresent(targetUUID, (uuid, uuids) -> {
-            uuids.remove(player.getUniqueId());
-            return uuids;
-        });
+        removeFromCaches(player.getUniqueId(), targetUUID);
+        removeFromCaches(targetUUID, player.getUniqueId());
         player.sendMessage("§cVous n'êtes plus ami avec §6" + targetName + "§c.");
         final Player targetPlayer = Bukkit.getPlayer(targetUUID);
         if (targetPlayer != null) {
@@ -174,15 +185,13 @@ public class FriendManager {
 
     public List<FriendInfo> getFriendsList(final UUID playerUUID) {
         final List<FriendInfo> friends = new ArrayList<>();
+        final String query = "SELECT friend_uuid, accepted_at, is_favorite FROM friends WHERE player_uuid = ? AND status = 'ACCEPTED'";
         try (Connection connection = databaseManager.getConnection();
-             PreparedStatement statement = connection.prepareStatement("SELECT player_uuid, friend_uuid, status, created_at, accepted_at FROM friends WHERE (player_uuid = ? OR friend_uuid = ?) AND status = 'ACCEPTED'")) {
+             PreparedStatement statement = connection.prepareStatement(query)) {
             statement.setString(1, playerUUID.toString());
-            statement.setString(2, playerUUID.toString());
             try (ResultSet resultSet = statement.executeQuery()) {
                 while (resultSet.next()) {
-                    final UUID playerOne = UUID.fromString(resultSet.getString("player_uuid"));
-                    final UUID playerTwo = UUID.fromString(resultSet.getString("friend_uuid"));
-                    final UUID friendUUID = playerOne.equals(playerUUID) ? playerTwo : playerOne;
+                    final UUID friendUUID = UUID.fromString(resultSet.getString("friend_uuid"));
                     final String name = getNameByUuid(friendUUID);
                     final Player friendPlayer = Bukkit.getPlayer(friendUUID);
                     final boolean online = friendPlayer != null && friendPlayer.isOnline();
@@ -197,7 +206,8 @@ public class FriendManager {
                     final Timestamp acceptedTimestamp = resultSet.getTimestamp("accepted_at");
                     final long acceptedAt = acceptedTimestamp != null ? acceptedTimestamp.getTime() : System.currentTimeMillis();
                     final long lastSeen = getLastSeen(friendUUID);
-                    friends.add(new FriendInfo(friendUUID, name, online, serverName, acceptedAt, lastSeen));
+                    final boolean favorite = resultSet.getBoolean("is_favorite");
+                    friends.add(new FriendInfo(friendUUID, name, online, serverName, acceptedAt, lastSeen, favorite));
                 }
             }
         } catch (final SQLException exception) {
@@ -266,27 +276,17 @@ public class FriendManager {
     }
 
     private void saveFriendRequest(final UUID senderUUID, final UUID targetUUID) {
-        final String selectQuery = "SELECT status FROM friends WHERE player_uuid = ? AND friend_uuid = ?";
-        final String insertQuery = "INSERT INTO friends (player_uuid, friend_uuid, status, created_at) VALUES (?, ?, 'PENDING', CURRENT_TIMESTAMP)";
-        final String updateQuery = "UPDATE friends SET status = 'PENDING', created_at = CURRENT_TIMESTAMP WHERE player_uuid = ? AND friend_uuid = ?";
-        try (Connection connection = databaseManager.getConnection(); PreparedStatement selectStatement = connection.prepareStatement(selectQuery)) {
-            selectStatement.setString(1, senderUUID.toString());
-            selectStatement.setString(2, targetUUID.toString());
-            try (ResultSet resultSet = selectStatement.executeQuery()) {
-                if (resultSet.next()) {
-                    try (PreparedStatement updateStatement = connection.prepareStatement(updateQuery)) {
-                        updateStatement.setString(1, senderUUID.toString());
-                        updateStatement.setString(2, targetUUID.toString());
-                        updateStatement.executeUpdate();
-                    }
-                } else {
-                    try (PreparedStatement insertStatement = connection.prepareStatement(insertQuery)) {
-                        insertStatement.setString(1, senderUUID.toString());
-                        insertStatement.setString(2, targetUUID.toString());
-                        insertStatement.executeUpdate();
-                    }
-                }
-            }
+        final String query;
+        if (databaseManager.getDatabaseType() == DatabaseManager.DatabaseType.MYSQL) {
+            query = "INSERT INTO friends (player_uuid, friend_uuid, status, created_at, accepted_at, blocked_at, is_favorite) VALUES (?, ?, 'PENDING', CURRENT_TIMESTAMP, NULL, NULL, FALSE) ON DUPLICATE KEY UPDATE status = 'PENDING', created_at = CURRENT_TIMESTAMP, accepted_at = NULL, blocked_at = NULL, is_favorite = FALSE";
+        } else {
+            query = "INSERT INTO friends (player_uuid, friend_uuid, status, created_at, accepted_at, blocked_at, is_favorite) VALUES (?, ?, 'PENDING', CURRENT_TIMESTAMP, NULL, NULL, 0) ON CONFLICT(player_uuid, friend_uuid) DO UPDATE SET status = 'PENDING', created_at = CURRENT_TIMESTAMP, accepted_at = NULL, blocked_at = NULL, is_favorite = 0";
+        }
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, senderUUID.toString());
+            statement.setString(2, targetUUID.toString());
+            statement.executeUpdate();
         } catch (final SQLException exception) {
             plugin.getLogger().log(Level.SEVERE, "Failed to save friend request", exception);
         }
@@ -294,13 +294,31 @@ public class FriendManager {
     }
 
     private void acceptFriendship(final UUID senderUUID, final UUID targetUUID) {
-        final String updateQuery = "UPDATE friends SET status = 'ACCEPTED', accepted_at = CURRENT_TIMESTAMP WHERE player_uuid = ? AND friend_uuid = ?";
-        try (Connection connection = databaseManager.getConnection(); PreparedStatement statement = connection.prepareStatement(updateQuery)) {
+        final String updateQuery = "UPDATE friends SET status = 'ACCEPTED', accepted_at = CURRENT_TIMESTAMP, blocked_at = NULL WHERE player_uuid = ? AND friend_uuid = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(updateQuery)) {
             statement.setString(1, senderUUID.toString());
             statement.setString(2, targetUUID.toString());
             statement.executeUpdate();
+            ensureReciprocalFriendship(connection, targetUUID, senderUUID);
         } catch (final SQLException exception) {
             plugin.getLogger().log(Level.SEVERE, "Failed to accept friendship", exception);
+        }
+    }
+
+    private void ensureReciprocalFriendship(final Connection connection,
+                                            final UUID ownerUUID,
+                                            final UUID friendUUID) throws SQLException {
+        final String query;
+        if (databaseManager.getDatabaseType() == DatabaseManager.DatabaseType.MYSQL) {
+            query = "INSERT INTO friends (player_uuid, friend_uuid, status, created_at, accepted_at, blocked_at, is_favorite) VALUES (?, ?, 'ACCEPTED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL, FALSE) ON DUPLICATE KEY UPDATE status = 'ACCEPTED', accepted_at = CURRENT_TIMESTAMP, blocked_at = NULL";
+        } else {
+            query = "INSERT INTO friends (player_uuid, friend_uuid, status, created_at, accepted_at, blocked_at, is_favorite) VALUES (?, ?, 'ACCEPTED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL, 0) ON CONFLICT(player_uuid, friend_uuid) DO UPDATE SET status = 'ACCEPTED', accepted_at = CURRENT_TIMESTAMP, blocked_at = NULL";
+        }
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, ownerUUID.toString());
+            statement.setString(2, friendUUID.toString());
+            statement.executeUpdate();
         }
     }
 
@@ -319,22 +337,42 @@ public class FriendManager {
 
     private Set<UUID> loadFriendsFromDatabase(final UUID playerUUID) {
         final Set<UUID> friends = new HashSet<>();
-        final String query = "SELECT player_uuid, friend_uuid FROM friends WHERE (player_uuid = ? OR friend_uuid = ?) AND status = 'ACCEPTED'";
-        try (Connection connection = databaseManager.getConnection(); PreparedStatement statement = connection.prepareStatement(query)) {
+        final Set<UUID> favorites = new HashSet<>();
+        final String query = "SELECT friend_uuid, is_favorite FROM friends WHERE player_uuid = ? AND status = 'ACCEPTED'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
             statement.setString(1, playerUUID.toString());
-            statement.setString(2, playerUUID.toString());
             try (ResultSet resultSet = statement.executeQuery()) {
                 while (resultSet.next()) {
-                    final UUID playerOne = UUID.fromString(resultSet.getString("player_uuid"));
-                    final UUID playerTwo = UUID.fromString(resultSet.getString("friend_uuid"));
-                    final UUID friendUUID = playerOne.equals(playerUUID) ? playerTwo : playerOne;
+                    final UUID friendUUID = UUID.fromString(resultSet.getString("friend_uuid"));
                     friends.add(friendUUID);
+                    if (resultSet.getBoolean("is_favorite")) {
+                        favorites.add(friendUUID);
+                    }
                 }
             }
         } catch (final SQLException exception) {
             plugin.getLogger().log(Level.SEVERE, "Failed to load friends for " + playerUUID, exception);
         }
+        favoritesCache.put(playerUUID, favorites);
         return friends;
+    }
+
+    private Set<UUID> loadFavoritesFromDatabase(final UUID playerUUID) {
+        final Set<UUID> favorites = new HashSet<>();
+        final String query = "SELECT friend_uuid FROM friends WHERE player_uuid = ? AND status = 'ACCEPTED' AND is_favorite = TRUE";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    favorites.add(UUID.fromString(resultSet.getString("friend_uuid")));
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to load favorite friends for " + playerUUID, exception);
+        }
+        return favorites;
     }
 
     private Set<UUID> loadPendingRequests(final UUID targetUUID) {
@@ -368,27 +406,57 @@ public class FriendManager {
         return settingsCache.computeIfAbsent(uuid, this::loadSettings);
     }
 
+    public void updateSettings(final UUID uuid, final FriendSettings settings) {
+        final String query;
+        if (databaseManager.getDatabaseType() == DatabaseManager.DatabaseType.MYSQL) {
+            query = "INSERT INTO friend_settings (player_uuid, accept_requests, show_online_status, allow_notifications, receive_notifications, auto_accept_favorites, auto_accept_friends, max_friends) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE accept_requests = VALUES(accept_requests), show_online_status = VALUES(show_online_status), allow_notifications = VALUES(allow_notifications), receive_notifications = VALUES(receive_notifications), auto_accept_favorites = VALUES(auto_accept_favorites), auto_accept_friends = VALUES(auto_accept_friends), max_friends = VALUES(max_friends)";
+        } else {
+            query = "INSERT INTO friend_settings (player_uuid, accept_requests, show_online_status, allow_notifications, receive_notifications, auto_accept_favorites, auto_accept_friends, max_friends) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(player_uuid) DO UPDATE SET accept_requests = excluded.accept_requests, show_online_status = excluded.show_online_status, allow_notifications = excluded.allow_notifications, receive_notifications = excluded.receive_notifications, auto_accept_favorites = excluded.auto_accept_favorites, auto_accept_friends = excluded.auto_accept_friends, max_friends = excluded.max_friends";
+        }
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, uuid.toString());
+            statement.setString(2, settings.getAcceptRequests().toDatabase());
+            statement.setBoolean(3, settings.isShowOnlineStatus());
+            statement.setBoolean(4, settings.isAllowNotifications());
+            statement.setBoolean(5, settings.isAllowNotifications());
+            statement.setBoolean(6, settings.isAutoAcceptFavorites());
+            statement.setBoolean(7, settings.isAutoAcceptFavorites());
+            statement.setInt(8, settings.getMaxFriends());
+            statement.executeUpdate();
+            settingsCache.put(uuid, settings);
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to update friend settings for " + uuid, exception);
+        }
+    }
+
     private FriendSettings loadSettings(final UUID uuid) {
-        final String query = "SELECT accept_requests, show_online_status, receive_notifications FROM friend_settings WHERE player_uuid = ?";
-        try (Connection connection = databaseManager.getConnection(); PreparedStatement statement = connection.prepareStatement(query)) {
+        final String query = "SELECT * FROM friend_settings WHERE player_uuid = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
             statement.setString(1, uuid.toString());
             try (ResultSet resultSet = statement.executeQuery()) {
                 if (resultSet.next()) {
+                    final ResultSetMetaData metaData = resultSet.getMetaData();
                     final AcceptMode acceptMode = AcceptMode.fromDatabase(resultSet.getString("accept_requests"));
-                    final boolean showOnline = resultSet.getBoolean("show_online_status");
-                    final boolean receiveNotifications = resultSet.getBoolean("receive_notifications");
-                    return new FriendSettings(acceptMode, showOnline, receiveNotifications);
+                    final boolean showOnline = getBoolean(resultSet, metaData, "show_online_status", true);
+                    final boolean allowNotifications = getBooleanWithFallback(resultSet, metaData,
+                            "allow_notifications", "receive_notifications", true);
+                    final boolean autoAcceptFavorites = getBooleanWithFallback(resultSet, metaData,
+                            "auto_accept_favorites", "auto_accept_friends", false);
+                    final int maxFriends = getIntWithDefault(resultSet, metaData, "max_friends", 100);
+                    return new FriendSettings(acceptMode, showOnline, allowNotifications, autoAcceptFavorites, maxFriends);
                 }
             }
             insertDefaultSettings(uuid, connection);
         } catch (final SQLException exception) {
             plugin.getLogger().log(Level.SEVERE, "Failed to load friend settings for " + uuid, exception);
         }
-        return new FriendSettings(AcceptMode.ALL, true, true);
+        return new FriendSettings(AcceptMode.ALL, true, true, false, 100);
     }
 
     private void insertDefaultSettings(final UUID uuid, final Connection connection) throws SQLException {
-        final String insertQuery = "INSERT INTO friend_settings (player_uuid, accept_requests, show_online_status, receive_notifications) VALUES (?, 'ALL', 1, 1)";
+        final String insertQuery = "INSERT INTO friend_settings (player_uuid, accept_requests, show_online_status, allow_notifications, receive_notifications, auto_accept_favorites, auto_accept_friends, max_friends) VALUES (?, 'ALL', 1, 1, 1, 0, 0, 100)";
         try (PreparedStatement statement = connection.prepareStatement(insertQuery)) {
             statement.setString(1, uuid.toString());
             statement.executeUpdate();
@@ -398,6 +466,189 @@ public class FriendManager {
     private void addToFriendsCache(final UUID source, final UUID friend) {
         friendsCache.computeIfAbsent(source, this::loadFriendsFromDatabase).add(friend);
     }
+
+    public List<UUID> getAllFriends(final UUID uuid) {
+        return new ArrayList<>(friendsCache.computeIfAbsent(uuid, this::loadFriendsFromDatabase));
+    }
+
+    public List<UUID> getOnlineFriends(final UUID uuid) {
+        final List<UUID> online = new ArrayList<>();
+        for (final UUID friendUUID : friendsCache.computeIfAbsent(uuid, this::loadFriendsFromDatabase)) {
+            final Player player = Bukkit.getPlayer(friendUUID);
+            if (player != null && player.isOnline()) {
+                online.add(friendUUID);
+            }
+        }
+        return online;
+    }
+
+    public List<UUID> getFavoriteFriends(final UUID uuid) {
+        return new ArrayList<>(favoritesCache.computeIfAbsent(uuid, this::loadFavoritesFromDatabase));
+    }
+
+    public boolean addToFavorites(final UUID playerUUID, final UUID friendUUID) {
+        if (!areFriends(playerUUID, friendUUID)) {
+            return false;
+        }
+        final String query = "UPDATE friends SET is_favorite = TRUE WHERE player_uuid = ? AND friend_uuid = ? AND status = 'ACCEPTED'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            statement.setString(2, friendUUID.toString());
+            if (statement.executeUpdate() > 0) {
+                favoritesCache.computeIfAbsent(playerUUID, this::loadFavoritesFromDatabase).add(friendUUID);
+                return true;
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to add favorite friend for " + playerUUID, exception);
+        }
+        return false;
+    }
+
+    public boolean removeFromFavorites(final UUID playerUUID, final UUID friendUUID) {
+        final String query = "UPDATE friends SET is_favorite = FALSE WHERE player_uuid = ? AND friend_uuid = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            statement.setString(2, friendUUID.toString());
+            if (statement.executeUpdate() > 0) {
+                favoritesCache.computeIfPresent(playerUUID, (uuid, set) -> {
+                    set.remove(friendUUID);
+                    return set;
+                });
+                return true;
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to remove favorite friend for " + playerUUID, exception);
+        }
+        return false;
+    }
+
+    public boolean blockPlayer(final UUID playerUUID, final UUID targetUUID) {
+        if (playerUUID.equals(targetUUID)) {
+            return false;
+        }
+        removeFriendship(playerUUID, targetUUID);
+        removeFromCaches(playerUUID, targetUUID);
+        removeFromCaches(targetUUID, playerUUID);
+        removePendingRequest(playerUUID, targetUUID);
+        removePendingRequest(targetUUID, playerUUID);
+
+        final String query;
+        if (databaseManager.getDatabaseType() == DatabaseManager.DatabaseType.MYSQL) {
+            query = "INSERT INTO friends (player_uuid, friend_uuid, status, created_at, blocked_at, accepted_at, is_favorite) VALUES (?, ?, 'BLOCKED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL, FALSE) ON DUPLICATE KEY UPDATE status = 'BLOCKED', blocked_at = CURRENT_TIMESTAMP, accepted_at = NULL, is_favorite = FALSE";
+        } else {
+            query = "INSERT INTO friends (player_uuid, friend_uuid, status, created_at, blocked_at, accepted_at, is_favorite) VALUES (?, ?, 'BLOCKED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL, 0) ON CONFLICT(player_uuid, friend_uuid) DO UPDATE SET status = 'BLOCKED', blocked_at = CURRENT_TIMESTAMP, accepted_at = NULL, is_favorite = 0";
+        }
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            statement.setString(2, targetUUID.toString());
+            statement.executeUpdate();
+            return true;
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to block player " + targetUUID + " for " + playerUUID, exception);
+        }
+        return false;
+    }
+
+    public boolean unblockPlayer(final UUID playerUUID, final UUID targetUUID) {
+        final String query = "DELETE FROM friends WHERE player_uuid = ? AND friend_uuid = ? AND status = 'BLOCKED'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            statement.setString(2, targetUUID.toString());
+            return statement.executeUpdate() > 0;
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to unblock player " + targetUUID + " for " + playerUUID, exception);
+        }
+        return false;
+    }
+
+    public boolean isBlocked(final UUID playerUUID, final UUID targetUUID) {
+        final String query = "SELECT 1 FROM friends WHERE player_uuid = ? AND friend_uuid = ? AND status = 'BLOCKED'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            statement.setString(2, targetUUID.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to check block status between " + playerUUID + " and " + targetUUID, exception);
+        }
+        return false;
+    }
+
+    public List<FriendRequest> getPendingRequestsDetailed(final UUID playerUUID) {
+        final List<FriendRequest> requests = new ArrayList<>();
+        final String query = "SELECT player_uuid, friend_uuid, status, created_at FROM friends WHERE friend_uuid = ? AND status = 'PENDING'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    final UUID sender = UUID.fromString(resultSet.getString("player_uuid"));
+                    final UUID target = UUID.fromString(resultSet.getString("friend_uuid"));
+                    final Timestamp timestamp = resultSet.getTimestamp("created_at");
+                    final FriendRequestStatus status = FriendRequestStatus.fromDatabase(resultSet.getString("status"));
+                    requests.add(new FriendRequest(sender, target,
+                            timestamp != null ? timestamp.getTime() : System.currentTimeMillis(), status));
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to load detailed pending requests for " + playerUUID, exception);
+        }
+        return requests;
+    }
+
+    public List<FriendRequest> getSentRequestsDetailed(final UUID playerUUID) {
+        final List<FriendRequest> requests = new ArrayList<>();
+        final String query = "SELECT player_uuid, friend_uuid, status, created_at FROM friends WHERE player_uuid = ? AND status = 'PENDING'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    final UUID sender = UUID.fromString(resultSet.getString("player_uuid"));
+                    final UUID target = UUID.fromString(resultSet.getString("friend_uuid"));
+                    final Timestamp timestamp = resultSet.getTimestamp("created_at");
+                    final FriendRequestStatus status = FriendRequestStatus.fromDatabase(resultSet.getString("status"));
+                    requests.add(new FriendRequest(sender, target,
+                            timestamp != null ? timestamp.getTime() : System.currentTimeMillis(), status));
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to load detailed sent requests for " + playerUUID, exception);
+        }
+        return requests;
+    }
+
+    public List<UUID> getSentRequests(final UUID playerUUID) {
+        final List<UUID> requests = new ArrayList<>();
+        final String query = "SELECT friend_uuid FROM friends WHERE player_uuid = ? AND status = 'PENDING'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUUID.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    requests.add(UUID.fromString(resultSet.getString("friend_uuid")));
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to load sent requests for " + playerUUID, exception);
+        }
+        return requests;
+    }
+
 
     private UUID getUuidByName(final String name) {
         if (name == null || name.isEmpty()) {
@@ -419,6 +670,57 @@ public class FriendManager {
             plugin.getLogger().log(Level.SEVERE, "Failed to fetch UUID for name " + name, exception);
         }
         return null;
+    }
+
+    private boolean getBoolean(final ResultSet resultSet, final ResultSetMetaData metaData,
+                               final String column, final boolean defaultValue) throws SQLException {
+        if (!hasColumn(metaData, column)) {
+            return defaultValue;
+        }
+        final boolean value = resultSet.getBoolean(column);
+        return resultSet.wasNull() ? defaultValue : value;
+    }
+
+    private boolean getBooleanWithFallback(final ResultSet resultSet, final ResultSetMetaData metaData,
+                                           final String primaryColumn, final String fallbackColumn,
+                                           final boolean defaultValue) throws SQLException {
+        if (primaryColumn != null && hasColumn(metaData, primaryColumn)) {
+            return getBoolean(resultSet, metaData, primaryColumn, defaultValue);
+        }
+        if (fallbackColumn != null && hasColumn(metaData, fallbackColumn)) {
+            return getBoolean(resultSet, metaData, fallbackColumn, defaultValue);
+        }
+        return defaultValue;
+    }
+
+    private int getIntWithDefault(final ResultSet resultSet, final ResultSetMetaData metaData,
+                                  final String column, final int defaultValue) throws SQLException {
+        if (!hasColumn(metaData, column)) {
+            return defaultValue;
+        }
+        final int value = resultSet.getInt(column);
+        return resultSet.wasNull() ? defaultValue : value;
+    }
+
+    private boolean hasColumn(final ResultSetMetaData metaData, final String column) throws SQLException {
+        final int count = metaData.getColumnCount();
+        for (int index = 1; index <= count; index++) {
+            if (column.equalsIgnoreCase(metaData.getColumnName(index))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void removeFromCaches(final UUID owner, final UUID target) {
+        friendsCache.computeIfPresent(owner, (uuid, set) -> {
+            set.remove(target);
+            return set;
+        });
+        favoritesCache.computeIfPresent(owner, (uuid, set) -> {
+            set.remove(target);
+            return set;
+        });
     }
 
     private String getNameByUuid(final UUID uuid) {

--- a/src/main/java/com/lobby/social/friends/FriendRequest.java
+++ b/src/main/java/com/lobby/social/friends/FriendRequest.java
@@ -1,0 +1,38 @@
+package com.lobby.social.friends;
+
+import java.util.UUID;
+
+public class FriendRequest {
+
+    private final UUID sender;
+    private final UUID target;
+    private final long timestamp;
+    private FriendRequestStatus status;
+
+    public FriendRequest(final UUID sender, final UUID target, final long timestamp, final FriendRequestStatus status) {
+        this.sender = sender;
+        this.target = target;
+        this.timestamp = timestamp;
+        this.status = status;
+    }
+
+    public UUID getSender() {
+        return sender;
+    }
+
+    public UUID getTarget() {
+        return target;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public FriendRequestStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(final FriendRequestStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/lobby/social/friends/FriendRequestStatus.java
+++ b/src/main/java/com/lobby/social/friends/FriendRequestStatus.java
@@ -1,0 +1,20 @@
+package com.lobby.social.friends;
+
+public enum FriendRequestStatus {
+    PENDING,
+    ACCEPTED,
+    DECLINED,
+    EXPIRED,
+    BLOCKED;
+
+    public static FriendRequestStatus fromDatabase(final String value) {
+        if (value == null || value.isEmpty()) {
+            return PENDING;
+        }
+        try {
+            return FriendRequestStatus.valueOf(value.toUpperCase());
+        } catch (final IllegalArgumentException exception) {
+            return PENDING;
+        }
+    }
+}

--- a/src/main/java/com/lobby/social/friends/FriendSettings.java
+++ b/src/main/java/com/lobby/social/friends/FriendSettings.java
@@ -4,12 +4,20 @@ public class FriendSettings {
 
     private final AcceptMode acceptRequests;
     private final boolean showOnlineStatus;
-    private final boolean receiveNotifications;
+    private final boolean allowNotifications;
+    private final boolean autoAcceptFavorites;
+    private final int maxFriends;
 
-    public FriendSettings(final AcceptMode acceptRequests, final boolean showOnlineStatus, final boolean receiveNotifications) {
+    public FriendSettings(final AcceptMode acceptRequests,
+                          final boolean showOnlineStatus,
+                          final boolean allowNotifications,
+                          final boolean autoAcceptFavorites,
+                          final int maxFriends) {
         this.acceptRequests = acceptRequests;
         this.showOnlineStatus = showOnlineStatus;
-        this.receiveNotifications = receiveNotifications;
+        this.allowNotifications = allowNotifications;
+        this.autoAcceptFavorites = autoAcceptFavorites;
+        this.maxFriends = maxFriends;
     }
 
     public AcceptMode getAcceptRequests() {
@@ -20,7 +28,15 @@ public class FriendSettings {
         return showOnlineStatus;
     }
 
-    public boolean isReceiveNotifications() {
-        return receiveNotifications;
+    public boolean isAllowNotifications() {
+        return allowNotifications;
+    }
+
+    public boolean isAutoAcceptFavorites() {
+        return autoAcceptFavorites;
+    }
+
+    public int getMaxFriends() {
+        return maxFriends;
     }
 }


### PR DESCRIPTION
## Summary
- expand friend database schema to store favorite flags and richer friend settings controls
- extend FriendManager with favorite management, blocking, and detailed request utilities plus bidirectional friendship handling
- expose new friend request data structures and update placeholders to report favorites and new settings values

## Testing
- `mvn -q -DskipTests compile` *(fails: network unreachable when downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cef1c631f48329bc87a59826e8ab34