### PR TITLE
Ensure friends table adds missing is_favorite column

### DIFF
--- a/src/main/java/com/lobby/core/DatabaseManager.java
+++ b/src/main/java/com/lobby/core/DatabaseManager.java
@@ -824,6 +824,7 @@ public class DatabaseManager {
                     """;
             executeSQL(sql);
             addColumnIfNotExists("friends", "blocked_at", "TIMESTAMP NULL");
+            addColumnIfNotExists("friends", "is_favorite", "BOOLEAN DEFAULT FALSE NOT NULL");
             return;
         }
 


### PR DESCRIPTION
## Summary
- ensure MySQL deployments add the is_favorite column when migrating the friends table

## Testing
- `mvn -q -DskipTests package` *(fails: network is unreachable when downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cef94340cc83298ce0a228e7e04fc0