### PR TITLE
Connect social menus to functional actions

### DIFF
--- a/src/main/resources/config/menus/clan_menu.yml
+++ b/src/main/resources/config/menus/clan_menu.yml
@@ -89,7 +89,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour voir les détails !"
       actions:
-        - "[MESSAGE] &cInformations du clan affichées !"
+        - "[MENU] clan_info_menu"
 
     clan_members:
       slot: 21
@@ -105,7 +105,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour gérer !"
       actions:
-        - "[MESSAGE] &eGestion des membres bientôt disponible !"
+        - "[MENU] clan_members_menu"
 
     clan_ranks:
       slot: 23
@@ -121,7 +121,7 @@ menu:
         - "&r"
         - "&6⚠ Nécessite rang Officier+"
       actions:
-        - "[MESSAGE] &dGestion des rangs bientôt disponible !"
+        - "[MENU] clan_ranks_menu"
 
     clan_treasury:
       slot: 25
@@ -137,7 +137,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour accéder !"
       actions:
-        - "[MESSAGE] &aTrésor du clan bientôt disponible !"
+        - "[MENU] clan_vault_menu"
 
     clan_wars:
       slot: 31
@@ -154,7 +154,7 @@ menu:
         - "&r"
         - "&c⚔ Cliquez pour les guerres !"
       actions:
-        - "[MESSAGE] &bGuerres de clans bientôt disponibles !"
+        - "[MENU] clan_wars_menu"
 
     clan_create:
       slot: 37
@@ -186,7 +186,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour explorer !"
       actions:
-        - "[MESSAGE] &eListe des clans bientôt disponible !"
+        - "[MENU] clan_browse_menu"
 
     back:
       slot: 49

--- a/src/main/resources/config/menus/friends_menu.yml
+++ b/src/main/resources/config/menus/friends_menu.yml
@@ -88,7 +88,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour voir la liste !"
       actions:
-        - "[MESSAGE] &aListe des amis en ligne bientôt disponible !"
+        - "[MENU] friends_online_menu"
 
     friend_requests:
       slot: 22
@@ -104,7 +104,7 @@ menu:
         - "&r"
         - "&e▶ Cliquez pour gérer !"
       actions:
-        - "[MESSAGE] &eGestion des demandes bientôt disponible !"
+        - "[MENU] friend_requests_menu"
 
     friends_all:
       slot: 24
@@ -120,7 +120,7 @@ menu:
         - "&r"
         - "&b▶ Cliquez pour parcourir !"
       actions:
-        - "[MESSAGE] &bListe complète des amis bientôt disponible !"
+        - "[MENU] friends_all_menu"
 
     friend_add:
       slot: 28
@@ -136,7 +136,7 @@ menu:
         - "&r"
         - "&d▶ Cliquez pour ajouter !"
       actions:
-        - "[MESSAGE] &dSystème d'ajout d'amis bientôt disponible !"
+        - "[COMMAND] friend add"
 
     friend_settings:
       slot: 30
@@ -152,7 +152,7 @@ menu:
         - "&r"
         - "&6▶ Cliquez pour configurer !"
       actions:
-        - "[MESSAGE] &6Paramètres d'amis bientôt disponibles !"
+        - "[MENU] friend_settings_menu"
 
     friends_favorites:
       slot: 32
@@ -168,7 +168,7 @@ menu:
         - "&r"
         - "&c▶ Cliquez pour voir !"
       actions:
-        - "[MESSAGE] &cGestion des favoris bientôt disponible !"
+        - "[MENU] friends_favorites_menu"
 
     back:
       slot: 49

--- a/src/main/resources/config/menus/groups_menu.yml
+++ b/src/main/resources/config/menus/groups_menu.yml
@@ -90,7 +90,7 @@ menu:
         - "&r"
         - "&e▶ Cliquez pour gérer !"
       actions:
-        - "[MESSAGE] &eGestion de groupe bientôt disponible !"
+        - "[MENU] group_manage_menu"
 
     group_create:
       slot: 22
@@ -107,7 +107,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour créer !"
       actions:
-        - "[MESSAGE] &aCréation de groupe bientôt disponible !"
+        - "[COMMAND] group create"
 
     group_join:
       slot: 24
@@ -123,7 +123,7 @@ menu:
         - "&r"
         - "&b▶ Cliquez pour explorer !"
       actions:
-        - "[MESSAGE] &bRecherche de groupes bientôt disponible !"
+        - "[MENU] group_browse_menu"
 
     group_invite:
       slot: 28
@@ -139,7 +139,7 @@ menu:
         - "&r"
         - "&d▶ Cliquez pour inviter !"
       actions:
-        - "[MESSAGE] &dSystème d'invitation bientôt disponible !"
+        - "[MENU] group_invite_menu"
 
     group_queue:
       slot: 30
@@ -155,7 +155,7 @@ menu:
         - "&r"
         - "&6▶ Cliquez pour rejoindre !"
       actions:
-        - "[MESSAGE] &6Files d'attente bientôt disponibles !"
+        - "[MENU] queue_menu"
 
     group_settings:
       slot: 32
@@ -171,7 +171,7 @@ menu:
         - "&r"
         - "&c▶ Cliquez pour configurer !"
       actions:
-        - "[MESSAGE] &cParamètres de groupe bientôt disponibles !"
+        - "[MENU] group_settings_menu"
 
     back:
       slot: 49


### PR DESCRIPTION
## Summary
- connect the top level friends menu buttons to the implemented friend sub-menus and chat command
- hook the group management menu entries up to their browse, invite, queue, and settings menus
- enable the clan management menu shortcuts to open the clan detail, roster, ranks, vault, wars, and browse menus

## Testing
- mvn -q -DskipTests package *(fails: Network is unreachable while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cfabf4a8308329ab31f31ca6d807ed