### PR TITLE
Implement social menus and chat input flows

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -24,7 +24,9 @@ import com.lobby.lobby.listeners.LobbyPlayerListener;
 import com.lobby.lobby.listeners.LobbyProtectionListener;
 import com.lobby.servers.ServerManager;
 import com.lobby.shop.ShopManager;
+import com.lobby.social.ChatInputManager;
 import com.lobby.social.SocialPlaceholderManager;
+import com.lobby.social.menus.MenuClickHandler;
 import com.lobby.social.clans.ClanManager;
 import com.lobby.social.friends.FriendManager;
 import com.lobby.social.groups.GroupManager;
@@ -55,6 +57,7 @@ public final class LobbyPlugin extends JavaPlugin {
     private ClanManager clanManager;
     private VelocityManager velocityManager;
     private SocialPlaceholderManager socialPlaceholderManager;
+    private ChatInputManager chatInputManager;
 
     public static LobbyPlugin getInstance() {
         return instance;
@@ -98,6 +101,7 @@ public final class LobbyPlugin extends JavaPlugin {
         shopManager = new ShopManager(this);
         shopManager.initialize();
         shopCommands = new ShopCommands(this, shopManager);
+        chatInputManager = new ChatInputManager(this);
 
         registerCommands();
 
@@ -106,6 +110,7 @@ public final class LobbyPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new LobbyItemListener(lobbyManager, lobbyManager.getItemManager()), this);
         getServer().getPluginManager().registerEvents(new LobbyProtectionListener(lobbyManager), this);
         getServer().getPluginManager().registerEvents(new NPCInteractionHandler(npcManager), this);
+        getServer().getPluginManager().registerEvents(new MenuClickHandler(this), this);
 
         LogUtils.info(this, "LobbyCore activé !");
     }

--- a/src/main/java/com/lobby/commands/FriendCommand.java
+++ b/src/main/java/com/lobby/commands/FriendCommand.java
@@ -45,7 +45,9 @@ public class FriendCommand implements CommandExecutor, TabCompleter {
                     player.sendMessage(ChatColor.RED + "Usage: /" + label + " add <joueur>");
                     return true;
                 }
-                friendManager.sendFriendRequest(player, args[1]);
+                if (friendManager.sendFriendRequest(player, args[1])) {
+                    player.sendMessage("§aDemande envoyée à §6" + args[1] + "§a !");
+                }
                 return true;
             case "accept":
                 if (args.length < 2) {

--- a/src/main/java/com/lobby/core/DatabaseManager.java
+++ b/src/main/java/com/lobby/core/DatabaseManager.java
@@ -801,6 +801,7 @@ public class DatabaseManager {
         createClanMembersTable();
         createClanRanksTable();
         createClanInvitationsTable();
+        createClanTransactionsTable();
     }
 
     private void createFriendsTable() throws SQLException {
@@ -959,6 +960,11 @@ public class DatabaseManager {
                 "inviter_uuid", "players", "uuid", "CASCADE");
         addForeignKeyIfNotExists("clan_invitations", "fk_clan_invitations_invited",
                 "invited_uuid", "players", "uuid", "CASCADE");
+
+        addForeignKeyIfNotExists("clan_transactions", "fk_clan_transactions_clan",
+                "clan_id", "clans", "id", "CASCADE");
+        addForeignKeyIfNotExists("clan_transactions", "fk_clan_transactions_player",
+                "player_uuid", "players", "uuid", "CASCADE");
 
         addForeignKeyIfNotExists("shop_items", "fk_shop_items_category",
                 "category_id", "shop_categories", "id", "CASCADE");
@@ -1231,7 +1237,7 @@ public class DatabaseManager {
         final String[] requiredTables = {
                 "players", "friend_settings", "friends",
                 "groups_table", "group_members", "group_invitations",
-                "clans", "clan_members", "clan_ranks", "clan_invitations",
+                "clans", "clan_members", "clan_ranks", "clan_invitations", "clan_transactions",
                 "shop_categories", "shop_items", "transactions"
         };
 
@@ -1690,6 +1696,45 @@ public class DatabaseManager {
         }
         addColumnIfNotExists("clan_invitations", "message", "TEXT");
         addColumnIfNotExists("clan_invitations", "expires_at", "TIMESTAMP NOT NULL");
+    }
+
+    private void createClanTransactionsTable() throws SQLException {
+        if (databaseType == DatabaseType.MYSQL) {
+            final String sql = """
+                    CREATE TABLE IF NOT EXISTS clan_transactions (
+                        id INT AUTO_INCREMENT PRIMARY KEY,
+                        clan_id INT NOT NULL,
+                        player_uuid VARCHAR(36) NOT NULL,
+                        transaction_type VARCHAR(16) NOT NULL,
+                        amount BIGINT NOT NULL,
+                        balance_after BIGINT NOT NULL,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                        INDEX idx_clan_transactions_clan_id (clan_id),
+                        INDEX idx_clan_transactions_player_uuid (player_uuid),
+                        INDEX idx_clan_transactions_type (transaction_type)
+                    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+                    """;
+            executeSQL(sql);
+            return;
+        }
+
+        final String sql = """
+                CREATE TABLE IF NOT EXISTS clan_transactions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    clan_id INTEGER NOT NULL,
+                    player_uuid VARCHAR(36) NOT NULL,
+                    transaction_type TEXT NOT NULL,
+                    amount BIGINT NOT NULL,
+                    balance_after BIGINT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """;
+        executeSQL(sql);
+        if (createIndexes) {
+            executeSQL("CREATE INDEX IF NOT EXISTS idx_clan_transactions_clan_id ON clan_transactions(clan_id)");
+            executeSQL("CREATE INDEX IF NOT EXISTS idx_clan_transactions_player_uuid ON clan_transactions(player_uuid)");
+            executeSQL("CREATE INDEX IF NOT EXISTS idx_clan_transactions_type ON clan_transactions(transaction_type)");
+        }
     }
 
     public enum DatabaseType {

--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -2,6 +2,9 @@ package com.lobby.npcs;
 
 import com.lobby.LobbyPlugin;
 import com.lobby.menus.MenuManager;
+import com.lobby.social.ChatInputManager;
+import com.lobby.social.menus.ClanMenus;
+import com.lobby.social.menus.FriendsMenus;
 import com.lobby.utils.LogUtils;
 import com.lobby.utils.MessageUtils;
 import com.lobby.utils.PlaceholderUtils;
@@ -47,6 +50,34 @@ public class ActionProcessor {
         if (startsWithIgnoreCase(trimmed, "[MESSAGE]")) {
             final String message = processed.substring(9).trim();
             MessageUtils.sendPrefixedMessage(player, message);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[FRIENDS_ONLINE]")) {
+            FriendsMenus.openFriendsOnlineMenu(player);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[FRIEND_REQUESTS]")) {
+            FriendsMenus.openFriendRequestsMenu(player);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[FRIEND_ADD]")) {
+            ChatInputManager.startFriendAddFlow(player);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[GROUP_CREATE]")) {
+            ChatInputManager.startGroupCreateFlow(player);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CLAN_MEMBERS]")) {
+            ClanMenus.openClanMembersMenu(player);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CLAN_VAULT]")) {
+            ClanMenus.openClanVaultMenu(player);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CLAN_INVITE]")) {
+            ChatInputManager.startClanInviteFlow(player);
             return;
         }
         if (startsWithIgnoreCase(trimmed, "[SOUND]")) {

--- a/src/main/java/com/lobby/social/ChatInputManager.java
+++ b/src/main/java/com/lobby/social/ChatInputManager.java
@@ -1,0 +1,225 @@
+package com.lobby.social;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.menus.MenuManager;
+import com.lobby.social.clans.ClanManager;
+import com.lobby.social.groups.GroupManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+public final class ChatInputManager implements Listener {
+
+    private static ChatInputManager instance;
+
+    private final LobbyPlugin plugin;
+    private final Map<UUID, InputSession> waitingInputs = new ConcurrentHashMap<>();
+
+    public ChatInputManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        instance = this;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    public static ChatInputManager getInstance() {
+        if (instance == null) {
+            throw new IllegalStateException("ChatInputManager has not been initialized");
+        }
+        return instance;
+    }
+
+    public static void startFriendAddFlow(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final ChatInputManager manager = getInstance();
+        player.closeInventory();
+        player.sendMessage("§e§l» Ajouter un ami");
+        player.sendMessage("§7Tapez le nom du joueur à ajouter:");
+        player.sendMessage("§7Tapez §ccancel §7pour annuler");
+
+        final MenuManager menuManager = manager.plugin.getMenuManager();
+        startInputFlow(player, inputRaw -> {
+            final String input = inputRaw.trim();
+            if (input.equalsIgnoreCase("cancel")) {
+                player.sendMessage("§cAjout annulé");
+                if (menuManager != null) {
+                    menuManager.openMenu(player, "friends_menu");
+                }
+                return;
+            }
+            if (manager.plugin.getFriendManager().sendFriendRequest(player, input)) {
+                player.sendMessage("§aDemande envoyée à §6" + input + "§a !");
+            } else {
+                player.sendMessage("§cImpossible d'envoyer la demande");
+            }
+            if (menuManager != null) {
+                menuManager.openMenu(player, "friends_menu");
+            }
+        }, () -> {
+            if (menuManager != null) {
+                menuManager.openMenu(player, "friends_menu");
+            }
+        });
+    }
+
+    public static void startGroupCreateFlow(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final ChatInputManager manager = getInstance();
+        player.closeInventory();
+        player.sendMessage("§e§l» Créer un groupe");
+        player.sendMessage("§7Tapez le nom de votre groupe:");
+        player.sendMessage("§7Tapez §ccancel §7pour annuler");
+
+        final MenuManager menuManager = manager.plugin.getMenuManager();
+        startInputFlow(player, inputRaw -> {
+            final String input = inputRaw.trim();
+            if (input.equalsIgnoreCase("cancel")) {
+                player.sendMessage("§cCréation annulée");
+                if (menuManager != null) {
+                    menuManager.openMenu(player, "groups_menu");
+                }
+                return;
+            }
+            if (input.isEmpty()) {
+                player.sendMessage("§cLe nom du groupe ne peut pas être vide");
+                if (menuManager != null) {
+                    menuManager.openMenu(player, "groups_menu");
+                }
+                return;
+            }
+            final GroupManager groupManager = manager.plugin.getGroupManager();
+            if (groupManager.createGroup(player, input, false)) {
+                player.sendMessage("§aGroupe '" + input + "' créé!");
+            } else {
+                player.sendMessage("§cErreur lors de la création");
+            }
+            if (menuManager != null) {
+                menuManager.openMenu(player, "groups_menu");
+            }
+        }, () -> {
+            if (menuManager != null) {
+                menuManager.openMenu(player, "groups_menu");
+            }
+        });
+    }
+
+    public static void startClanInviteFlow(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final ChatInputManager manager = getInstance();
+        player.closeInventory();
+        player.sendMessage("§e§l» Inviter au clan");
+        player.sendMessage("§7Tapez le nom du joueur à inviter:");
+        player.sendMessage("§7Tapez §ccancel §7pour annuler");
+
+        final MenuManager menuManager = manager.plugin.getMenuManager();
+        startInputFlow(player, inputRaw -> {
+            final String input = inputRaw.trim();
+            if (input.equalsIgnoreCase("cancel")) {
+                player.sendMessage("§cInvitation annulée");
+                if (menuManager != null) {
+                    menuManager.openMenu(player, "clan_menu");
+                }
+                return;
+            }
+            final ClanManager clanManager = manager.plugin.getClanManager();
+            final boolean success = clanManager.inviteToClan(player, input, "");
+            if (!success) {
+                player.sendMessage("§cImpossible d'inviter ce joueur");
+            }
+            if (menuManager != null) {
+                menuManager.openMenu(player, "clan_menu");
+            }
+        }, () -> {
+            if (menuManager != null) {
+                menuManager.openMenu(player, "clan_menu");
+            }
+        });
+    }
+
+    public static void startInputFlow(final Player player, final Consumer<String> onInput) {
+        startInputFlow(player, onInput, () -> {
+        });
+    }
+
+    public static void startInputFlow(final Player player, final Consumer<String> onInput, final Runnable onTimeout) {
+        if (player == null || onInput == null) {
+            return;
+        }
+        final ChatInputManager manager = getInstance();
+        manager.startSession(player, onInput, onTimeout != null ? onTimeout : () -> {
+        });
+    }
+
+    @EventHandler
+    public void onPlayerChat(final AsyncPlayerChatEvent event) {
+        final Player player = event.getPlayer();
+        final InputSession session = waitingInputs.remove(player.getUniqueId());
+        if (session == null) {
+            return;
+        }
+        event.setCancelled(true);
+        session.cancelTimeout();
+        Bukkit.getScheduler().runTask(plugin, () -> session.accept(event.getMessage()));
+    }
+
+    @EventHandler
+    public void onPlayerQuit(final PlayerQuitEvent event) {
+        final InputSession session = waitingInputs.remove(event.getPlayer().getUniqueId());
+        if (session != null) {
+            session.cancelTimeout();
+        }
+    }
+
+    private void startSession(final Player player, final Consumer<String> onInput, final Runnable onTimeout) {
+        final UUID uuid = player.getUniqueId();
+        final InputSession previous = waitingInputs.remove(uuid);
+        if (previous != null) {
+            previous.cancelTimeout();
+        }
+        final InputSession session = new InputSession(onInput);
+        waitingInputs.put(uuid, session);
+        session.scheduleTimeout(plugin, () -> {
+            if (waitingInputs.remove(uuid, session)) {
+                Bukkit.getScheduler().runTask(plugin, onTimeout);
+            }
+        });
+    }
+
+    private static final class InputSession {
+        private final Consumer<String> onInput;
+        private BukkitTask timeoutTask;
+
+        private InputSession(final Consumer<String> onInput) {
+            this.onInput = onInput;
+        }
+
+        private void scheduleTimeout(final LobbyPlugin plugin, final Runnable timeoutCallback) {
+            timeoutTask = Bukkit.getScheduler().runTaskLater(plugin, timeoutCallback, 600L);
+        }
+
+        private void cancelTimeout() {
+            if (timeoutTask != null) {
+                timeoutTask.cancel();
+                timeoutTask = null;
+            }
+        }
+
+        private void accept(final String message) {
+            onInput.accept(message);
+        }
+    }
+}

--- a/src/main/java/com/lobby/social/clans/ClanManager.java
+++ b/src/main/java/com/lobby/social/clans/ClanManager.java
@@ -13,6 +13,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Locale;
@@ -22,6 +23,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
+import java.util.List;
 
 public class ClanManager {
 
@@ -29,6 +31,7 @@ public class ClanManager {
     private final DatabaseManager databaseManager;
     private final EconomyManager economyManager;
     private final Map<String, Clan> clanCache = new HashMap<>();
+    private final Map<Integer, Clan> clanCacheById = new HashMap<>();
     private final Map<UUID, String> playerClanCache = new HashMap<>();
 
     public ClanManager(final LobbyPlugin plugin) {
@@ -39,6 +42,7 @@ public class ClanManager {
 
     public void reload() {
         clanCache.clear();
+        clanCacheById.clear();
         playerClanCache.clear();
     }
 
@@ -83,15 +87,15 @@ public class ClanManager {
         leader.sendMessage("§7Vous êtes maintenant le leader du clan.");
     }
 
-    public void inviteToClan(final Player inviter, final String targetName, final String message) {
+    public boolean inviteToClan(final Player inviter, final String targetName, final String message) {
         final Clan clan = getPlayerClan(inviter.getUniqueId());
         if (clan == null) {
             inviter.sendMessage("§cVous n'êtes dans aucun clan !");
-            return;
+            return false;
         }
         if (!clan.hasPermission(inviter.getUniqueId(), ClanPermission.INVITE)) {
             inviter.sendMessage("§cVous n'avez pas la permission d'inviter des joueurs !");
-            return;
+            return false;
         }
         UUID targetUUID = null;
         Player targetPlayer = Bukkit.getPlayerExact(targetName);
@@ -102,11 +106,11 @@ public class ClanManager {
         }
         if (targetUUID == null) {
             inviter.sendMessage("§cJoueur introuvable.");
-            return;
+            return false;
         }
         if (hasPlayerClan(targetUUID)) {
             inviter.sendMessage("§c" + targetName + " est déjà dans un clan !");
-            return;
+            return false;
         }
         final ClanInvitation invitation = saveInvitation(clan.getId(), inviter.getUniqueId(), targetUUID, message);
         inviter.sendMessage("§aInvitation envoyée à §6" + targetName + "§a !");
@@ -119,6 +123,7 @@ public class ClanManager {
             targetPlayer.playSound(targetPlayer.getLocation(), Sound.UI_TOAST_IN, 1.0f, 1.0f);
         }
         scheduleInvitationExpiration(invitation);
+        return true;
     }
 
     public void acceptInvitation(final Player player, final String clanName) {
@@ -206,11 +211,159 @@ public class ClanManager {
                 .count();
     }
 
+    public Clan getClanById(final int clanId) {
+        if (clanId <= 0) {
+            return null;
+        }
+        final Clan cached = clanCacheById.get(clanId);
+        if (cached != null) {
+            return cached;
+        }
+        final Clan clan = loadClanById(clanId);
+        if (clan != null) {
+            cacheClan(clan);
+        }
+        return clan;
+    }
+
+    public List<ClanMember> getClanMembers(final int clanId) {
+        final Clan clan = getClanById(clanId);
+        if (clan == null) {
+            return List.of();
+        }
+        return new ArrayList<>(clan.getMembers().values());
+    }
+
+    public boolean hasPermission(final int clanId, final UUID playerUuid, final String permissionKey) {
+        final Clan clan = getClanById(clanId);
+        if (clan == null || playerUuid == null || permissionKey == null || permissionKey.isBlank()) {
+            return false;
+        }
+        final ClanPermission permission = resolvePermission(permissionKey);
+        if (permission == null) {
+            return false;
+        }
+        return clan.hasPermission(playerUuid, permission);
+    }
+
+    public boolean depositCoins(final Player player, final long amount) {
+        if (player == null || amount <= 0) {
+            return false;
+        }
+        final Clan clan = getPlayerClan(player.getUniqueId());
+        if (clan == null) {
+            return false;
+        }
+        if (!economyManager.hasCoins(player.getUniqueId(), amount)) {
+            return false;
+        }
+
+        economyManager.removeCoins(player.getUniqueId(), amount, "Clan deposit");
+        clan.deposit(amount);
+        updateClanBank(clan);
+        updateMemberContribution(clan, player.getUniqueId(), amount);
+        logClanTransaction(clan.getId(), player.getUniqueId(), "DEPOSIT", amount, clan.getBankCoins());
+        return true;
+    }
+
+    public boolean withdrawCoins(final Player player, final long amount) {
+        if (player == null || amount <= 0) {
+            return false;
+        }
+        final Clan clan = getPlayerClan(player.getUniqueId());
+        if (clan == null) {
+            return false;
+        }
+        if (!clan.hasPermission(player.getUniqueId(), ClanPermission.MANAGE_BANK)) {
+            return false;
+        }
+        if (clan.getBankCoins() < amount) {
+            return false;
+        }
+
+        clan.withdraw(amount);
+        updateClanBank(clan);
+        economyManager.addCoins(player.getUniqueId(), amount, "Clan withdraw");
+        logClanTransaction(clan.getId(), player.getUniqueId(), "WITHDRAW", amount, clan.getBankCoins());
+        return true;
+    }
+
     private void cacheClan(final Clan clan) {
         clanCache.put(clan.getName().toLowerCase(Locale.ROOT), clan);
         clanCache.put(clan.getTag().toLowerCase(Locale.ROOT), clan);
+        clanCacheById.put(clan.getId(), clan);
         for (final UUID member : clan.getMembers().keySet()) {
             playerClanCache.put(member, clan.getName().toLowerCase(Locale.ROOT));
+        }
+    }
+
+    private void updateClanBank(final Clan clan) {
+        final String query = "UPDATE clans SET bank_coins = ? WHERE id = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setLong(1, clan.getBankCoins());
+            statement.setInt(2, clan.getId());
+            statement.executeUpdate();
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to update clan bank", exception);
+        }
+    }
+
+    private void updateMemberContribution(final Clan clan, final UUID memberUuid, final long amount) {
+        if (clan == null || memberUuid == null || amount <= 0) {
+            return;
+        }
+        final ClanMember member = clan.getMember(memberUuid);
+        if (member != null) {
+            member.addContribution(amount);
+        }
+        final String query = "UPDATE clan_members SET total_contributions = total_contributions + ? WHERE clan_id = ? AND player_uuid = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setLong(1, amount);
+            statement.setInt(2, clan.getId());
+            statement.setString(3, memberUuid.toString());
+            statement.executeUpdate();
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to update clan member contributions", exception);
+        }
+    }
+
+    private void logClanTransaction(final int clanId, final UUID playerUuid, final String type, final long amount,
+                                    final long balanceAfter) {
+        final String query = "INSERT INTO clan_transactions (clan_id, player_uuid, transaction_type, amount, balance_after, created_at) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setInt(1, clanId);
+            statement.setString(2, playerUuid.toString());
+            statement.setString(3, type);
+            statement.setLong(4, amount);
+            statement.setLong(5, balanceAfter);
+            statement.executeUpdate();
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to log clan transaction", exception);
+        }
+    }
+
+    private ClanPermission resolvePermission(final String permissionKey) {
+        final String key = permissionKey.toLowerCase(Locale.ROOT);
+        switch (key) {
+            case "clan.invite":
+                return ClanPermission.INVITE;
+            case "clan.withdraw":
+                return ClanPermission.MANAGE_BANK;
+            case "clan.kick":
+                return ClanPermission.KICK;
+            case "clan.promote":
+                return ClanPermission.PROMOTE;
+            case "clan.demote":
+                return ClanPermission.DEMOTE;
+            case "clan.manage_ranks":
+                return ClanPermission.MANAGE_RANKS;
+            case "clan.disband":
+                return ClanPermission.DISBAND;
+            default:
+                return null;
         }
     }
 
@@ -545,6 +698,33 @@ public class ClanManager {
             }
         } catch (final SQLException exception) {
             plugin.getLogger().log(Level.SEVERE, "Failed to fetch clan invitation", exception);
+        }
+        return null;
+    }
+
+    private Clan loadClanById(final int clanId) {
+        final String query = "SELECT id, name, tag, leader_uuid, description, max_members, points, level, bank_coins FROM clans WHERE id = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setInt(1, clanId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    final String clanName = resultSet.getString("name");
+                    final String tag = resultSet.getString("tag");
+                    final UUID leaderUUID = UUID.fromString(resultSet.getString("leader_uuid"));
+                    final Clan clan = new Clan(clanId, clanName, tag, leaderUUID);
+                    clan.setDescription(resultSet.getString("description"));
+                    clan.setMaxMembers(resultSet.getInt("max_members"));
+                    clan.addPoints(resultSet.getInt("points"));
+                    clan.setLevel(resultSet.getInt("level"));
+                    clan.setBankCoins(resultSet.getLong("bank_coins"));
+                    loadClanRanks(clan, connection);
+                    loadClanMembers(clan, connection);
+                    return clan;
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to load clan by id", exception);
         }
         return null;
     }

--- a/src/main/java/com/lobby/social/friends/FriendManager.java
+++ b/src/main/java/com/lobby/social/friends/FriendManager.java
@@ -46,52 +46,51 @@ public class FriendManager {
         settingsCache.clear();
     }
 
-    public void sendFriendRequest(final Player sender, final String targetName) {
+    public boolean sendFriendRequest(final Player sender, final String targetName) {
         final Player target = Bukkit.getPlayerExact(targetName);
         if (target == null) {
             sender.sendMessage("§cJoueur introuvable ou hors ligne.");
-            return;
+            return false;
         }
 
         if (sender.getUniqueId().equals(target.getUniqueId())) {
             sender.sendMessage("§cVous ne pouvez pas vous ajouter vous-même !");
-            return;
+            return false;
         }
 
         if (areFriends(sender.getUniqueId(), target.getUniqueId())) {
             sender.sendMessage("§cVous êtes déjà amis avec " + target.getName() + " !");
-            return;
+            return false;
         }
 
         if (isBlocked(sender.getUniqueId(), target.getUniqueId())
                 || isBlocked(target.getUniqueId(), sender.getUniqueId())) {
             sender.sendMessage("§cImpossible d'envoyer une demande : relation bloquée.");
-            return;
+            return false;
         }
 
         if (hasPendingRequest(sender.getUniqueId(), target.getUniqueId())) {
             sender.sendMessage("§cVous avez déjà envoyé une demande d'ami à " + target.getName() + " !");
-            return;
+            return false;
         }
 
         final FriendSettings settings = getFriendSettings(target.getUniqueId());
         if (settings.getAcceptRequests() == AcceptMode.NONE) {
             sender.sendMessage("§c" + target.getName() + " n'accepte pas les demandes d'amis.");
-            return;
+            return false;
         }
 
         if (settings.getAcceptRequests() == AcceptMode.FRIENDS_OF_FRIENDS && !hasMutualFriend(sender.getUniqueId(), target.getUniqueId())) {
             sender.sendMessage("§cVous devez avoir des amis en commun avec " + target.getName() + " pour envoyer une demande.");
-            return;
+            return false;
         }
 
         saveFriendRequest(sender.getUniqueId(), target.getUniqueId());
-
-        sender.sendMessage("§aDemande d'ami envoyée à §6" + target.getName() + "§a !");
         target.sendMessage("§e" + sender.getName() + " §avous a envoyé une demande d'ami !");
         target.sendMessage("§7Tapez §a/friend accept " + sender.getName() + " §7pour accepter");
         target.sendMessage("§7ou §c/friend deny " + sender.getName() + " §7pour refuser");
         target.playSound(target.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.0f);
+        return true;
     }
 
     public void onPlayerJoin(final UUID player) {
@@ -104,58 +103,86 @@ public class FriendManager {
 
     public void acceptFriendRequest(final Player player, final String senderName) {
         final UUID senderUUID = getUuidByName(senderName);
-        if (senderUUID == null) {
+        acceptFriendRequest(player, senderUUID, senderName);
+    }
+
+    public void acceptFriendRequest(final Player player, final UUID senderUuid) {
+        final String senderName = resolveName(senderUuid);
+        acceptFriendRequest(player, senderUuid, senderName);
+    }
+
+    public void denyFriendRequest(final Player player, final String senderName) {
+        final UUID senderUUID = getUuidByName(senderName);
+        denyFriendRequest(player, senderUUID, senderName);
+    }
+
+    public void denyFriendRequest(final Player player, final UUID senderUuid) {
+        final String senderName = resolveName(senderUuid);
+        denyFriendRequest(player, senderUuid, senderName);
+    }
+
+    private void acceptFriendRequest(final Player player, final UUID senderUuid, final String senderName) {
+        if (senderUuid == null) {
             player.sendMessage("§cJoueur introuvable.");
             return;
         }
-
-        if (!hasPendingRequest(senderUUID, player.getUniqueId())) {
+        if (!hasPendingRequest(senderUuid, player.getUniqueId())) {
             player.sendMessage("§cAucune demande d'ami de " + senderName + " trouvée.");
             return;
         }
 
-        acceptFriendship(senderUUID, player.getUniqueId());
+        acceptFriendship(senderUuid, player.getUniqueId());
 
-        addToFriendsCache(senderUUID, player.getUniqueId());
-        addToFriendsCache(player.getUniqueId(), senderUUID);
+        addToFriendsCache(senderUuid, player.getUniqueId());
+        addToFriendsCache(player.getUniqueId(), senderUuid);
 
-        removePendingRequest(senderUUID, player.getUniqueId());
+        removePendingRequest(senderUuid, player.getUniqueId());
 
         player.sendMessage("§aVous êtes maintenant ami avec §6" + senderName + "§a !");
 
-        final Player senderPlayer = Bukkit.getPlayer(senderUUID);
+        final Player senderPlayer = Bukkit.getPlayer(senderUuid);
         if (senderPlayer != null) {
             senderPlayer.sendMessage("§6" + player.getName() + " §aa accepté votre demande d'ami !");
             senderPlayer.playSound(senderPlayer.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1.0f, 1.0f);
         }
         final VelocityManager velocityManager = plugin.getVelocityManager();
         if (velocityManager != null) {
-            velocityManager.broadcastFriendUpdate(player.getUniqueId(), "ACCEPT", senderUUID);
-            velocityManager.broadcastFriendUpdate(senderUUID, "ACCEPT", player.getUniqueId());
+            velocityManager.broadcastFriendUpdate(player.getUniqueId(), "ACCEPT", senderUuid);
+            velocityManager.broadcastFriendUpdate(senderUuid, "ACCEPT", player.getUniqueId());
         }
     }
 
-    public void denyFriendRequest(final Player player, final String senderName) {
-        final UUID senderUUID = getUuidByName(senderName);
-        if (senderUUID == null) {
+    private void denyFriendRequest(final Player player, final UUID senderUuid, final String senderName) {
+        if (senderUuid == null) {
             player.sendMessage("§cJoueur introuvable.");
             return;
         }
-
-        if (!hasPendingRequest(senderUUID, player.getUniqueId())) {
+        if (!hasPendingRequest(senderUuid, player.getUniqueId())) {
             player.sendMessage("§cAucune demande d'ami de " + senderName + " trouvée.");
             return;
         }
 
-        removeFriendship(senderUUID, player.getUniqueId());
-        removePendingRequest(senderUUID, player.getUniqueId());
+        removeFriendship(senderUuid, player.getUniqueId());
+        removePendingRequest(senderUuid, player.getUniqueId());
 
         player.sendMessage("§cVous avez refusé la demande d'ami de §6" + senderName + "§c.");
 
-        final Player senderPlayer = Bukkit.getPlayer(senderUUID);
+        final Player senderPlayer = Bukkit.getPlayer(senderUuid);
         if (senderPlayer != null) {
             senderPlayer.sendMessage("§c" + player.getName() + " a refusé votre demande d'ami.");
         }
+    }
+
+    private String resolveName(final UUID uuid) {
+        if (uuid == null) {
+            return "";
+        }
+        final Player online = Bukkit.getPlayer(uuid);
+        if (online != null) {
+            return online.getName();
+        }
+        final String name = Bukkit.getOfflinePlayer(uuid).getName();
+        return name != null ? name : uuid.toString();
     }
 
     public void removeFriend(final Player player, final String targetName) {

--- a/src/main/java/com/lobby/social/groups/GroupManager.java
+++ b/src/main/java/com/lobby/social/groups/GroupManager.java
@@ -35,23 +35,56 @@ public class GroupManager {
     }
 
     public void createGroup(final Player leader) {
+        createGroup(leader, null, true);
+    }
+
+    public boolean createGroup(final Player leader, final String groupName, final boolean showTips) {
+        if (leader == null) {
+            return false;
+        }
         if (hasGroup(leader.getUniqueId())) {
             leader.sendMessage("§cVous êtes déjà dans un groupe !");
-            return;
+            return false;
         }
+
+        final String trimmedName = groupName != null ? groupName.trim() : "";
+        if (!trimmedName.isEmpty()) {
+            if (trimmedName.length() < 3 || trimmedName.length() > 20) {
+                leader.sendMessage("§cLe nom du groupe doit faire entre 3 et 20 caractères.");
+                return false;
+            }
+            if (isGroupNameTaken(trimmedName)) {
+                leader.sendMessage("§cCe nom de groupe est déjà utilisé.");
+                return false;
+            }
+        }
+
         final Group group = new Group(leader.getUniqueId());
+        if (!trimmedName.isEmpty()) {
+            group.setName(trimmedName);
+        }
+
         final int groupId = saveGroupToDatabase(group);
         if (groupId <= 0) {
             leader.sendMessage("§cImpossible de créer le groupe pour le moment.");
-            return;
+            return false;
         }
+
         group.setId(groupId);
         saveMember(groupId, leader.getUniqueId(), "LEADER");
         group.addMember(leader.getUniqueId());
         cacheGroup(group);
         playerGroups.put(leader.getUniqueId(), group);
-        leader.sendMessage("§aGroupe créé avec succès !");
-        leader.sendMessage("§7Utilisez §e/group invite <joueur> §7pour inviter des amis.");
+
+        if (showTips) {
+            if (trimmedName.isEmpty()) {
+                leader.sendMessage("§aGroupe créé avec succès !");
+            } else {
+                leader.sendMessage("§aGroupe '" + trimmedName + "' créé !");
+            }
+            leader.sendMessage("§7Utilisez §e/group invite <joueur> §7pour inviter des amis.");
+        }
+        return true;
     }
 
     public void inviteToGroup(final Player inviter, final String targetName) {
@@ -253,6 +286,20 @@ public class GroupManager {
             plugin.getLogger().log(Level.SEVERE, "Failed to create group", exception);
         }
         return -1;
+    }
+
+    private boolean isGroupNameTaken(final String name) {
+        final String query = "SELECT 1 FROM groups_table WHERE LOWER(name) = ? AND disbanded_at IS NULL";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, name.toLowerCase(Locale.ROOT));
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to check group name availability", exception);
+        }
+        return false;
     }
 
     private void saveMember(final int groupId, final UUID uuid, final String role) {

--- a/src/main/java/com/lobby/social/menus/ClanMenus.java
+++ b/src/main/java/com/lobby/social/menus/ClanMenus.java
@@ -1,0 +1,188 @@
+package com.lobby.social.menus;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.social.clans.Clan;
+import com.lobby.social.clans.ClanManager;
+import com.lobby.social.clans.ClanMember;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class ClanMenus {
+
+    public static final String CLAN_MEMBERS_TITLE = "§8» §eMembres du Clan";
+    public static final String CLAN_VAULT_TITLE = "§8» §6Trésor du Clan";
+    public static final int INVITE_SLOT = 46;
+    public static final int DEPOSIT_SLOT = 20;
+    public static final int WITHDRAW_SLOT = 24;
+
+    private ClanMenus() {
+    }
+
+    public static void openClanMembersMenu(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final LobbyPlugin plugin = LobbyPlugin.getInstance();
+        final ClanManager clanManager = plugin.getClanManager();
+        final Clan clan = clanManager.getPlayerClan(player.getUniqueId());
+        if (clan == null) {
+            player.sendMessage("§cVous n'êtes dans aucun clan!");
+            return;
+        }
+
+        final Inventory menu = Bukkit.createInventory(null, 54, CLAN_MEMBERS_TITLE);
+        setupRedBorders(menu);
+
+        final List<ClanMember> members = clanManager.getClanMembers(clan.getId());
+        int slot = 10;
+        for (ClanMember member : members) {
+            if (slot >= 44) {
+                break;
+            }
+            final ItemStack item = createClanMemberItem(member);
+            menu.setItem(slot, item);
+            slot = nextContentSlot(slot);
+        }
+
+        if (clanManager.hasPermission(clan.getId(), player.getUniqueId(), "clan.invite")) {
+            menu.setItem(INVITE_SLOT, createInviteItem());
+        }
+
+        addBackButton(menu, 49);
+        player.openInventory(menu);
+    }
+
+    public static void openClanVaultMenu(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final LobbyPlugin plugin = LobbyPlugin.getInstance();
+        final ClanManager clanManager = plugin.getClanManager();
+        final Clan clan = clanManager.getPlayerClan(player.getUniqueId());
+        if (clan == null) {
+            player.sendMessage("§cVous n'êtes dans aucun clan!");
+            return;
+        }
+
+        final Inventory menu = Bukkit.createInventory(null, 54, CLAN_VAULT_TITLE);
+        setupRedBorders(menu);
+
+        final ItemStack vaultInfo = new ItemStack(Material.CHEST);
+        final ItemMeta infoMeta = vaultInfo.getItemMeta();
+        if (infoMeta != null) {
+            infoMeta.setDisplayName("§6§lTrésor du Clan");
+            infoMeta.setLore(Arrays.asList(
+                    "§7Coins actuels: §e" + clan.getBankCoins(),
+                    "§7Niveau du clan: §b" + clan.getLevel()
+            ));
+            vaultInfo.setItemMeta(infoMeta);
+        }
+        menu.setItem(13, vaultInfo);
+
+        final ItemStack depositItem = new ItemStack(Material.GOLD_INGOT);
+        final ItemMeta depositMeta = depositItem.getItemMeta();
+        if (depositMeta != null) {
+            depositMeta.setDisplayName("§a§lDéposer des Coins");
+            depositMeta.setLore(Arrays.asList(
+                    "§7Déposez vos coins dans le trésor",
+                    "§r",
+                    "§a▶ Cliquez pour déposer!"
+            ));
+            depositItem.setItemMeta(depositMeta);
+        }
+        menu.setItem(DEPOSIT_SLOT, depositItem);
+
+        if (clanManager.hasPermission(clan.getId(), player.getUniqueId(), "clan.withdraw")) {
+            final ItemStack withdrawItem = new ItemStack(Material.DIAMOND);
+            final ItemMeta withdrawMeta = withdrawItem.getItemMeta();
+            if (withdrawMeta != null) {
+                withdrawMeta.setDisplayName("§c§lRetirer des Coins");
+                withdrawMeta.setLore(Arrays.asList(
+                        "§7Retirez des coins du trésor",
+                        "§r",
+                        "§c▶ Cliquez pour retirer!"
+                ));
+                withdrawItem.setItemMeta(withdrawMeta);
+            }
+            menu.setItem(WITHDRAW_SLOT, withdrawItem);
+        }
+
+        addBackButton(menu, 49);
+        player.openInventory(menu);
+    }
+
+    private static ItemStack createClanMemberItem(final ClanMember member) {
+        final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(member.getUuid());
+        final String name = offlinePlayer.getName() != null ? offlinePlayer.getName() : member.getUuid().toString();
+        final ItemStack item = new ItemStack(Material.PLAYER_HEAD);
+        final SkullMeta meta = (SkullMeta) item.getItemMeta();
+        if (meta != null) {
+            meta.setOwningPlayer(offlinePlayer);
+            meta.setDisplayName("§e" + name);
+            meta.setLore(Arrays.asList(
+                    "§7Rang: §f" + member.getRankName(),
+                    "§7Contributions: §b" + member.getTotalContributions()
+            ));
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private static ItemStack createInviteItem() {
+        final ItemStack inviteItem = new ItemStack(Material.PLAYER_HEAD);
+        final ItemMeta meta = inviteItem.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName("§a§lInviter un Joueur");
+            meta.setLore(Arrays.asList(
+                    "§7Invitez un nouveau membre",
+                    "§r",
+                    "§a▶ Cliquez pour inviter!"
+            ));
+            inviteItem.setItemMeta(meta);
+        }
+        return inviteItem;
+    }
+
+    private static void addBackButton(final Inventory menu, final int slot) {
+        final ItemStack back = new ItemStack(Material.ARROW);
+        final ItemMeta meta = back.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName("§c§lRetour");
+            meta.setLore(Arrays.asList(
+                    "§7Retourner au menu précédent"
+            ));
+            back.setItemMeta(meta);
+        }
+        menu.setItem(slot, back);
+    }
+
+    private static void setupRedBorders(final Inventory inventory) {
+        final int[] borderSlots = {0, 1, 2, 6, 7, 8, 9, 17, 45, 53};
+        final ItemStack pane = new ItemStack(Material.RED_STAINED_GLASS_PANE);
+        final ItemMeta meta = pane.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName("§7");
+            pane.setItemMeta(meta);
+        }
+        for (int slot : borderSlots) {
+            inventory.setItem(slot, pane.clone());
+        }
+    }
+
+    private static int nextContentSlot(final int currentSlot) {
+        int slot = currentSlot + 1;
+        if ((slot + 1) % 9 == 0) {
+            slot += 2;
+        }
+        return slot;
+    }
+}

--- a/src/main/java/com/lobby/social/menus/FriendsMenus.java
+++ b/src/main/java/com/lobby/social/menus/FriendsMenus.java
@@ -1,0 +1,208 @@
+package com.lobby.social.menus;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.social.friends.FriendManager;
+import com.lobby.social.friends.FriendRequest;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class FriendsMenus {
+
+    private static final Map<UUID, Map<Integer, FriendRequest>> REQUEST_SLOTS = new ConcurrentHashMap<>();
+    public static final String FRIENDS_ONLINE_TITLE = "§8» §aAmis En Ligne";
+    public static final String FRIEND_REQUESTS_TITLE = "§8» §eDemandes d'Amis";
+
+    private FriendsMenus() {
+    }
+
+    public static void openFriendsOnlineMenu(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final LobbyPlugin plugin = LobbyPlugin.getInstance();
+        final FriendManager friendManager = plugin.getFriendManager();
+        final List<UUID> onlineFriends = friendManager.getOnlineFriends(player.getUniqueId());
+
+        final Inventory menu = Bukkit.createInventory(null, 54, FRIENDS_ONLINE_TITLE);
+        setupGreenBorders(menu);
+
+        if (onlineFriends.isEmpty()) {
+            final ItemStack noFriends = new ItemStack(Material.BARRIER);
+            final ItemMeta meta = noFriends.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName("§cAucun ami en ligne");
+                meta.setLore(Arrays.asList(
+                        "§7Vos amis ne sont pas connectés",
+                        "§r",
+                        "§eInvitez d'autres joueurs !"
+                ));
+                noFriends.setItemMeta(meta);
+            }
+            menu.setItem(22, noFriends);
+        } else {
+            int slot = 10;
+            for (UUID friendUuid : onlineFriends) {
+                if (slot >= 44) {
+                    break;
+                }
+                final ItemStack friendItem = createOnlineFriendItem(friendUuid);
+                menu.setItem(slot, friendItem);
+                slot = nextContentSlot(slot);
+            }
+        }
+
+        addBackButton(menu, 49);
+        player.openInventory(menu);
+    }
+
+    public static void openFriendRequestsMenu(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final LobbyPlugin plugin = LobbyPlugin.getInstance();
+        final FriendManager friendManager = plugin.getFriendManager();
+        final List<FriendRequest> requests = new ArrayList<>(friendManager.getPendingRequestsDetailed(player.getUniqueId()));
+
+        final Inventory menu = Bukkit.createInventory(null, 54, FRIEND_REQUESTS_TITLE);
+        setupGreenBorders(menu);
+
+        final Map<Integer, FriendRequest> slotMap = new HashMap<>();
+        if (requests.isEmpty()) {
+            final ItemStack none = new ItemStack(Material.BARRIER);
+            final ItemMeta meta = none.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName("§cAucune demande d'ami");
+                meta.setLore(Collections.singletonList("§7Vous n'avez aucune demande en attente"));
+                none.setItemMeta(meta);
+            }
+            menu.setItem(22, none);
+        } else {
+            int slot = 10;
+            for (FriendRequest request : requests) {
+                if (slot >= 44) {
+                    break;
+                }
+                final ItemStack requestItem = createFriendRequestItem(request);
+                menu.setItem(slot, requestItem);
+                slotMap.put(slot, request);
+                slot = nextContentSlot(slot);
+            }
+        }
+        REQUEST_SLOTS.put(player.getUniqueId(), slotMap);
+
+        addBackButton(menu, 49);
+        player.openInventory(menu);
+    }
+
+    public static FriendRequest getRequestAt(final Player player, final int slot) {
+        final Map<Integer, FriendRequest> map = REQUEST_SLOTS.get(player.getUniqueId());
+        if (map == null) {
+            return null;
+        }
+        return map.get(slot);
+    }
+
+    public static void clearRequestCache(final UUID playerUuid) {
+        if (playerUuid != null) {
+            REQUEST_SLOTS.remove(playerUuid);
+        }
+    }
+
+    private static ItemStack createOnlineFriendItem(final UUID friendUuid) {
+        final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(friendUuid);
+        final String name = offlinePlayer.getName() != null ? offlinePlayer.getName() : "Joueur";
+        final ItemStack item = new ItemStack(Material.PLAYER_HEAD);
+        if (item.getItemMeta() instanceof SkullMeta meta) {
+            meta.setOwningPlayer(offlinePlayer);
+            meta.setDisplayName("§a" + name);
+            meta.setLore(Arrays.asList(
+                    "§7Statut: §aEn ligne",
+                    "§7Bon jeu ensemble !"
+            ));
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private static ItemStack createFriendRequestItem(final FriendRequest request) {
+        final OfflinePlayer sender = Bukkit.getOfflinePlayer(request.getSender());
+        final String senderName = sender.getName() != null ? sender.getName() : "Inconnu";
+        final ItemStack item = new ItemStack(Material.PLAYER_HEAD);
+        if (item.getItemMeta() instanceof SkullMeta meta) {
+            meta.setOwningPlayer(sender);
+            meta.setDisplayName("§eDemande de §6" + senderName);
+            final List<String> lore = new ArrayList<>();
+            lore.add("§7Clique gauche: §aAccepter");
+            lore.add("§7Clique droit: §cRefuser");
+            lore.add("§r");
+            lore.add("§7Reçue il y a §f" + formatElapsed(request.getTimestamp()));
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private static void addBackButton(final Inventory menu, final int slot) {
+        final ItemStack back = new ItemStack(Material.ARROW);
+        final ItemMeta meta = back.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName("§c§lRetour");
+            meta.setLore(Collections.singletonList("§7Retourner au menu précédent"));
+            back.setItemMeta(meta);
+        }
+        menu.setItem(slot, back);
+    }
+
+    private static void setupGreenBorders(final Inventory inventory) {
+        final int[] borderSlots = {0, 1, 2, 6, 7, 8, 9, 17, 45, 53};
+        final ItemStack pane = new ItemStack(Material.GREEN_STAINED_GLASS_PANE);
+        final ItemMeta meta = pane.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName("§7");
+            pane.setItemMeta(meta);
+        }
+        for (int slot : borderSlots) {
+            inventory.setItem(slot, pane.clone());
+        }
+    }
+
+    private static int nextContentSlot(final int currentSlot) {
+        int slot = currentSlot + 1;
+        if ((slot + 1) % 9 == 0) {
+            slot += 2;
+        }
+        return slot;
+    }
+
+    private static String formatElapsed(final long timestamp) {
+        final long elapsedSeconds = Math.max(0L, (System.currentTimeMillis() - timestamp) / 1000L);
+        final long minutes = elapsedSeconds / 60L;
+        if (minutes <= 0) {
+            return "quelques secondes";
+        }
+        if (minutes < 60) {
+            return minutes + " minute" + (minutes > 1 ? "s" : "");
+        }
+        final long hours = minutes / 60;
+        if (hours < 24) {
+            return hours + " heure" + (hours > 1 ? "s" : "");
+        }
+        final long days = hours / 24;
+        return days + " jour" + (days > 1 ? "s" : "");
+    }
+}

--- a/src/main/java/com/lobby/social/menus/MenuClickHandler.java
+++ b/src/main/java/com/lobby/social/menus/MenuClickHandler.java
@@ -1,0 +1,179 @@
+package com.lobby.social.menus;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.menus.MenuManager;
+import com.lobby.social.ChatInputManager;
+import com.lobby.social.clans.ClanManager;
+import com.lobby.social.friends.FriendManager;
+import com.lobby.social.friends.FriendRequest;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+
+import java.util.Objects;
+
+public final class MenuClickHandler implements Listener {
+
+    private final LobbyPlugin plugin;
+    private final MenuManager menuManager;
+    private final FriendManager friendManager;
+    private final ClanManager clanManager;
+
+    public MenuClickHandler(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        this.menuManager = plugin.getMenuManager();
+        this.friendManager = plugin.getFriendManager();
+        this.clanManager = plugin.getClanManager();
+    }
+
+    @EventHandler
+    public void onInventoryClick(final InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        final Inventory inventory = event.getView().getTopInventory();
+        if (!Objects.equals(inventory, event.getClickedInventory())) {
+            return;
+        }
+        final String title = event.getView().getTitle();
+        if (isFriendsMenuTitle(title)) {
+            event.setCancelled(true);
+            handleFriendsMenuClick(player, title, event.getSlot(), event.getClick());
+            return;
+        }
+        if (isClanMenuTitle(title)) {
+            event.setCancelled(true);
+            handleClanMenuClick(player, title, event.getSlot());
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(final InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player player)) {
+            return;
+        }
+        final String title = event.getView().getTitle();
+        if (isFriendsMenuTitle(title)) {
+            FriendsMenus.clearRequestCache(player.getUniqueId());
+        }
+    }
+
+    private void handleFriendsMenuClick(final Player player, final String title, final int slot, final ClickType clickType) {
+        if (slot < 0) {
+            return;
+        }
+        if (slot == 49) {
+            openMenu(player, "friends_menu");
+            return;
+        }
+        if (FriendsMenus.FRIEND_REQUESTS_TITLE.equals(title)) {
+            final FriendRequest request = FriendsMenus.getRequestAt(player, slot);
+            if (request == null) {
+                return;
+            }
+            if (clickType == ClickType.RIGHT) {
+                friendManager.denyFriendRequest(player, request.getSender());
+            } else {
+                friendManager.acceptFriendRequest(player, request.getSender());
+            }
+            FriendsMenus.openFriendRequestsMenu(player);
+        }
+    }
+
+    private void handleClanMenuClick(final Player player, final String title, final int slot) {
+        if (slot < 0) {
+            return;
+        }
+        if (slot == 49) {
+            openMenu(player, "clan_menu");
+            return;
+        }
+        if (ClanMenus.CLAN_MEMBERS_TITLE.equals(title)) {
+            if (slot == ClanMenus.INVITE_SLOT) {
+                ChatInputManager.startClanInviteFlow(player);
+            }
+            return;
+        }
+        if (ClanMenus.CLAN_VAULT_TITLE.equals(title)) {
+            if (slot == ClanMenus.DEPOSIT_SLOT) {
+                startDepositFlow(player);
+            } else if (slot == ClanMenus.WITHDRAW_SLOT) {
+                startWithdrawFlow(player);
+            }
+        }
+    }
+
+    private void startDepositFlow(final Player player) {
+        player.closeInventory();
+        player.sendMessage("§e§l» Déposer des Coins");
+        player.sendMessage("§7Tapez le montant à déposer:");
+        player.sendMessage("§7Tapez §ccancel §7pour annuler");
+
+        ChatInputManager.startInputFlow(player, inputRaw -> {
+            final String input = inputRaw.trim();
+            if (input.equalsIgnoreCase("cancel")) {
+                ClanMenus.openClanVaultMenu(player);
+                return;
+            }
+            try {
+                final long amount = Long.parseLong(input);
+                if (amount <= 0) {
+                    player.sendMessage("§cMontant invalide!");
+                } else if (clanManager.depositCoins(player, amount)) {
+                    player.sendMessage("§aDépôt effectué!");
+                } else {
+                    player.sendMessage("§cErreur: Fonds insuffisants");
+                }
+            } catch (NumberFormatException exception) {
+                player.sendMessage("§cMontant invalide!");
+            }
+            ClanMenus.openClanVaultMenu(player);
+        }, () -> ClanMenus.openClanVaultMenu(player));
+    }
+
+    private void startWithdrawFlow(final Player player) {
+        player.closeInventory();
+        player.sendMessage("§e§l» Retirer des Coins");
+        player.sendMessage("§7Tapez le montant à retirer:");
+        player.sendMessage("§7Tapez §ccancel §7pour annuler");
+
+        ChatInputManager.startInputFlow(player, inputRaw -> {
+            final String input = inputRaw.trim();
+            if (input.equalsIgnoreCase("cancel")) {
+                ClanMenus.openClanVaultMenu(player);
+                return;
+            }
+            try {
+                final long amount = Long.parseLong(input);
+                if (amount <= 0) {
+                    player.sendMessage("§cMontant invalide!");
+                } else if (clanManager.withdrawCoins(player, amount)) {
+                    player.sendMessage("§aRetrait effectué!");
+                } else {
+                    player.sendMessage("§cImpossible de retirer ce montant");
+                }
+            } catch (NumberFormatException exception) {
+                player.sendMessage("§cMontant invalide!");
+            }
+            ClanMenus.openClanVaultMenu(player);
+        }, () -> ClanMenus.openClanVaultMenu(player));
+    }
+
+    private void openMenu(final Player player, final String menuId) {
+        if (menuManager != null) {
+            menuManager.openMenu(player, menuId);
+        }
+    }
+
+    private boolean isFriendsMenuTitle(final String title) {
+        return FriendsMenus.FRIENDS_ONLINE_TITLE.equals(title) || FriendsMenus.FRIEND_REQUESTS_TITLE.equals(title);
+    }
+
+    private boolean isClanMenuTitle(final String title) {
+        return ClanMenus.CLAN_MEMBERS_TITLE.equals(title) || ClanMenus.CLAN_VAULT_TITLE.equals(title);
+    }
+}

--- a/src/main/resources/config/menus.yml
+++ b/src/main/resources/config/menus.yml
@@ -341,7 +341,7 @@ menus:
           - "&r"
           - "&a▶ Cliquez pour gérer !"
         actions:
-          - "[MENU] clan_members_menu"
+          - "[CLAN_MEMBERS]"
       clan_ranks:
         slot: 23
         material: PLAYER_HEAD
@@ -371,7 +371,7 @@ menus:
           - "&r"
           - "&a▶ Cliquez pour accéder !"
         actions:
-          - "[MENU] clan_vault_menu"
+          - "[CLAN_VAULT]"
       clan_wars:
         slot: 31
         material: PLAYER_HEAD
@@ -486,7 +486,7 @@ menus:
           - "&r"
           - "&a▶ Cliquez pour voir la liste !"
         actions:
-          - "[MENU] friends_online_menu"
+          - "[FRIENDS_ONLINE]"
       friend_requests:
         slot: 22
         material: PLAYER_HEAD
@@ -501,7 +501,7 @@ menus:
           - "&r"
           - "&e▶ Cliquez pour gérer !"
         actions:
-          - "[MENU] friend_requests_menu"
+          - "[FRIEND_REQUESTS]"
       friends_all:
         slot: 24
         material: PLAYER_HEAD
@@ -531,7 +531,7 @@ menus:
           - "&r"
           - "&d▶ Cliquez pour ajouter !"
         actions:
-          - "[COMMAND] friend add"
+          - "[FRIEND_ADD]"
       friend_settings:
         slot: 30
         material: PLAYER_HEAD
@@ -648,7 +648,7 @@ menus:
           - "&r"
           - "&a▶ Cliquez pour créer !"
         actions:
-          - "[COMMAND] group create"
+          - "[GROUP_CREATE]"
       group_join:
         slot: 24
         material: PLAYER_HEAD

--- a/src/main/resources/config/menus/clan_menu.yml
+++ b/src/main/resources/config/menus/clan_menu.yml
@@ -105,7 +105,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour gérer !"
       actions:
-        - "[MENU] clan_members_menu"
+        - "[CLAN_MEMBERS]"
 
     clan_ranks:
       slot: 23
@@ -137,7 +137,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour accéder !"
       actions:
-        - "[MENU] clan_vault_menu"
+        - "[CLAN_VAULT]"
 
     clan_wars:
       slot: 31

--- a/src/main/resources/config/menus/friends_menu.yml
+++ b/src/main/resources/config/menus/friends_menu.yml
@@ -88,7 +88,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour voir la liste !"
       actions:
-        - "[MENU] friends_online_menu"
+        - "[FRIENDS_ONLINE]"
 
     friend_requests:
       slot: 22
@@ -104,7 +104,7 @@ menu:
         - "&r"
         - "&e▶ Cliquez pour gérer !"
       actions:
-        - "[MENU] friend_requests_menu"
+        - "[FRIEND_REQUESTS]"
 
     friends_all:
       slot: 24
@@ -136,7 +136,7 @@ menu:
         - "&r"
         - "&d▶ Cliquez pour ajouter !"
       actions:
-        - "[COMMAND] friend add"
+        - "[FRIEND_ADD]"
 
     friend_settings:
       slot: 30

--- a/src/main/resources/config/menus/groups_menu.yml
+++ b/src/main/resources/config/menus/groups_menu.yml
@@ -107,7 +107,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour créer !"
       actions:
-        - "[COMMAND] group create"
+        - "[GROUP_CREATE]"
 
     group_join:
       slot: 24


### PR DESCRIPTION
## Summary
- hook new social action tokens in the NPC action processor and wire dedicated chat input flows and menu listeners for friends, groups, and clans
- add dynamic friends and clan inventories, plus clan bank deposit/withdraw handling with transaction logging and supporting database schema
- expand friend and group managers for menu-driven flows and update menu configurations to use the new actions

## Testing
- `mvn package` *(fails: unable to reach repo.maven.apache.org to download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb9137ef88329b843197bcef5ba0d