### PR TITLE
Add missing Locale import in GroupManager

### DIFF
--- a/src/main/java/com/lobby/social/groups/GroupManager.java
+++ b/src/main/java/com/lobby/social/groups/GroupManager.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;


### PR DESCRIPTION
## Summary
- add the missing `java.util.Locale` import to GroupManager to fix compilation

## Testing
- mvn clean compile *(fails: network is unreachable when downloading Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbfba47e4832990a65277237421b3