### PR TITLE
Implement clan deletion flow and refresh social menus

### DIFF
--- a/src/main/java/com/lobby/commands/ClanCommand.java
+++ b/src/main/java/com/lobby/commands/ClanCommand.java
@@ -1,5 +1,8 @@
 package com.lobby.commands;
 
+import com.lobby.LobbyPlugin;
+import com.lobby.npcs.ActionProcessor;
+import com.lobby.social.clans.Clan;
 import com.lobby.social.clans.ClanManager;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -42,6 +45,9 @@ public class ClanCommand implements CommandExecutor, TabCompleter {
                 }
                 clanManager.createClan(player, args[1], args[2]);
                 return true;
+            case "delete":
+                handleDelete(player);
+                return true;
             case "invite":
                 if (args.length < 2) {
                     player.sendMessage(ChatColor.RED + "Usage: /" + label + " invite <joueur> [message]");
@@ -74,6 +80,7 @@ public class ClanCommand implements CommandExecutor, TabCompleter {
     private void sendUsage(final Player player, final String label) {
         player.sendMessage(ChatColor.YELLOW + "Utilisation de /" + label + ":");
         player.sendMessage(ChatColor.GOLD + "/" + label + " create <nom> <tag> " + ChatColor.WHITE + "- Créer un clan");
+        player.sendMessage(ChatColor.GOLD + "/" + label + " delete " + ChatColor.WHITE + "- Supprimer votre clan");
         player.sendMessage(ChatColor.GOLD + "/" + label + " invite <joueur> [message] " + ChatColor.WHITE + "- Inviter un joueur");
         player.sendMessage(ChatColor.GOLD + "/" + label + " accept <clan> " + ChatColor.WHITE + "- Accepter une invitation");
         player.sendMessage(ChatColor.GOLD + "/" + label + " deny <clan> " + ChatColor.WHITE + "- Refuser une invitation");
@@ -83,11 +90,29 @@ public class ClanCommand implements CommandExecutor, TabCompleter {
     public List<String> onTabComplete(final CommandSender sender, final Command command, final String alias, final String[] args) {
         if (args.length == 1) {
             final List<String> subCommands = new ArrayList<>();
-            Collections.addAll(subCommands, "create", "invite", "accept", "deny");
+            Collections.addAll(subCommands, "create", "delete", "invite", "accept", "deny");
             final String prefix = args[0].toLowerCase(Locale.ROOT);
             subCommands.removeIf(value -> !value.startsWith(prefix));
             return subCommands;
         }
         return Collections.emptyList();
+    }
+
+    private void handleDelete(final Player player) {
+        final Clan playerClan = clanManager.getPlayerClan(player.getUniqueId());
+        if (playerClan == null) {
+            player.sendMessage(ChatColor.RED + "Vous n'êtes dans aucun clan!");
+            return;
+        }
+        if (!playerClan.isLeader(player.getUniqueId())) {
+            player.sendMessage(ChatColor.RED + "Seul le leader peut supprimer le clan!");
+            return;
+        }
+
+        ActionProcessor.openClanDeleteConfirmation(player);
+        if (LobbyPlugin.getInstance() == null || LobbyPlugin.getInstance().getNpcManager() == null
+                || LobbyPlugin.getInstance().getNpcManager().getActionProcessor() == null) {
+            player.sendMessage(ChatColor.RED + "Impossible d'afficher la confirmation de suppression pour le moment.");
+        }
     }
 }

--- a/src/main/java/com/lobby/commands/FriendCommand.java
+++ b/src/main/java/com/lobby/commands/FriendCommand.java
@@ -1,7 +1,9 @@
 package com.lobby.commands;
 
+import com.lobby.social.friends.AcceptMode;
 import com.lobby.social.friends.FriendInfo;
 import com.lobby.social.friends.FriendManager;
+import com.lobby.social.friends.FriendSettings;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -48,6 +50,9 @@ public class FriendCommand implements CommandExecutor, TabCompleter {
                 if (friendManager.sendFriendRequest(player, args[1])) {
                     player.sendMessage("§aDemande envoyée à §6" + args[1] + "§a !");
                 }
+                return true;
+            case "settings":
+                handleSettingsCommand(player, label, args);
                 return true;
             case "accept":
                 if (args.length < 2) {
@@ -111,6 +116,7 @@ public class FriendCommand implements CommandExecutor, TabCompleter {
         player.sendMessage(ChatColor.GOLD + "/" + label + " deny <joueur> " + ChatColor.WHITE + "- Refuser une demande");
         player.sendMessage(ChatColor.GOLD + "/" + label + " remove <joueur> " + ChatColor.WHITE + "- Supprimer un ami");
         player.sendMessage(ChatColor.GOLD + "/" + label + " list " + ChatColor.WHITE + "- Liste des amis");
+        player.sendMessage(ChatColor.GOLD + "/" + label + " settings toggle <option> " + ChatColor.WHITE + "- Configurer vos préférences");
     }
 
     @Override
@@ -122,8 +128,15 @@ public class FriendCommand implements CommandExecutor, TabCompleter {
             completions.add("deny");
             completions.add("remove");
             completions.add("list");
+            completions.add("settings");
             completions.removeIf(value -> !value.startsWith(args[0].toLowerCase(Locale.ROOT)));
             return completions;
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("settings")) {
+            return filterByPrefix(List.of("toggle"), args[1]);
+        }
+        if (args.length == 3 && args[0].equalsIgnoreCase("settings") && args[1].equalsIgnoreCase("toggle")) {
+            return filterByPrefix(List.of("requests", "notifications", "visibility", "favorites"), args[2]);
         }
         if (!(sender instanceof Player)) {
             return Collections.emptyList();
@@ -151,5 +164,69 @@ public class FriendCommand implements CommandExecutor, TabCompleter {
             }
         }
         return filtered;
+    }
+
+    private void handleSettingsCommand(final Player player, final String label, final String[] args) {
+        if (args.length < 3 || !args[1].equalsIgnoreCase("toggle")) {
+            sendSettingsUsage(player, label);
+            return;
+        }
+
+        final FriendSettings current = friendManager.getFriendSettings(player.getUniqueId());
+        final String option = args[2].toLowerCase(Locale.ROOT);
+        FriendSettings updated;
+        String feedback;
+        switch (option) {
+            case "requests":
+                final AcceptMode nextMode = cycleAcceptMode(current.getAcceptRequests());
+                updated = new FriendSettings(nextMode, current.isShowOnlineStatus(), current.isAllowNotifications(),
+                        current.isAutoAcceptFavorites(), current.getMaxFriends());
+                feedback = ChatColor.GREEN + "Demandes d'amis: " + describeAcceptMode(nextMode);
+                break;
+            case "notifications":
+                final boolean allowNotifications = !current.isAllowNotifications();
+                updated = new FriendSettings(current.getAcceptRequests(), current.isShowOnlineStatus(), allowNotifications,
+                        current.isAutoAcceptFavorites(), current.getMaxFriends());
+                feedback = ChatColor.GREEN + "Notifications: " + (allowNotifications ? "Activées" : "Désactivées");
+                break;
+            case "visibility":
+                final boolean showStatus = !current.isShowOnlineStatus();
+                updated = new FriendSettings(current.getAcceptRequests(), showStatus, current.isAllowNotifications(),
+                        current.isAutoAcceptFavorites(), current.getMaxFriends());
+                feedback = ChatColor.GREEN + "Visibilité: " + (showStatus ? "Visible" : "Caché");
+                break;
+            case "favorites":
+                final boolean autoFavorites = !current.isAutoAcceptFavorites();
+                updated = new FriendSettings(current.getAcceptRequests(), current.isShowOnlineStatus(),
+                        current.isAllowNotifications(), autoFavorites, current.getMaxFriends());
+                feedback = ChatColor.GREEN + "Acceptation auto favoris: " + (autoFavorites ? "Activée" : "Désactivée");
+                break;
+            default:
+                sendSettingsUsage(player, label);
+                return;
+        }
+
+        friendManager.updateSettings(player.getUniqueId(), updated);
+        player.sendMessage(feedback);
+    }
+
+    private void sendSettingsUsage(final Player player, final String label) {
+        player.sendMessage(ChatColor.YELLOW + "Usage: /" + label + " settings toggle <requests|notifications|visibility|favorites>");
+    }
+
+    private AcceptMode cycleAcceptMode(final AcceptMode current) {
+        return switch (current) {
+            case ALL -> AcceptMode.FRIENDS_OF_FRIENDS;
+            case FRIENDS_OF_FRIENDS -> AcceptMode.NONE;
+            case NONE -> AcceptMode.ALL;
+        };
+    }
+
+    private String describeAcceptMode(final AcceptMode mode) {
+        return switch (mode) {
+            case ALL -> "Tous";
+            case FRIENDS_OF_FRIENDS -> "Amis d'amis";
+            case NONE -> "Aucun";
+        };
     }
 }

--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -3,6 +3,8 @@ package com.lobby.npcs;
 import com.lobby.LobbyPlugin;
 import com.lobby.menus.MenuManager;
 import com.lobby.social.ChatInputManager;
+import com.lobby.social.clans.Clan;
+import com.lobby.social.clans.ClanManager;
 import com.lobby.social.menus.ClanMenus;
 import com.lobby.social.menus.FriendsMenus;
 import com.lobby.utils.LogUtils;
@@ -78,6 +80,10 @@ public class ActionProcessor {
         }
         if (trimmed.equalsIgnoreCase("[CLAN_INVITE]")) {
             ChatInputManager.startClanInviteFlow(player);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CLAN_DELETE_CONFIRM]")) {
+            handleClanDeleteConfirmation(player);
             return;
         }
         if (startsWithIgnoreCase(trimmed, "[SOUND]")) {
@@ -161,6 +167,81 @@ public class ActionProcessor {
             final String coordinates = processed.substring(10).trim();
             handleTeleport(coordinates, player, npc);
         }
+    }
+
+    public static void openClanDeleteConfirmation(final Player player) {
+        final LobbyPlugin plugin = LobbyPlugin.getInstance();
+        if (plugin == null) {
+            return;
+        }
+        final var npcManager = plugin.getNpcManager();
+        if (npcManager == null) {
+            return;
+        }
+        final ActionProcessor processor = npcManager.getActionProcessor();
+        if (processor == null) {
+            return;
+        }
+        processor.handleClanDeleteConfirmation(player);
+    }
+
+    private void handleClanDeleteConfirmation(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final ClanManager clanManager = plugin.getClanManager();
+        if (clanManager == null) {
+            return;
+        }
+        final Clan clan = clanManager.getPlayerClan(player.getUniqueId());
+        if (clan == null) {
+            player.sendMessage("§cVous n'êtes dans aucun clan.");
+            return;
+        }
+        if (!clan.isLeader(player.getUniqueId())) {
+            player.sendMessage("§cSeul le leader peut supprimer le clan.");
+            return;
+        }
+
+        player.closeInventory();
+        player.sendMessage("§c§l⚠ SUPPRESSION DE CLAN ⚠");
+        player.sendMessage("§7Vous êtes sur le point de supprimer définitivement votre clan.");
+        player.sendMessage("§7Cette action est §cIRRÉVERSIBLE§7 !");
+        player.sendMessage("§r");
+        player.sendMessage("§7Conséquences :");
+        player.sendMessage("§8▸ §7Tous les membres seront expulsés");
+        player.sendMessage("§8▸ §7Le trésor du clan sera perdu");
+        player.sendMessage("§8▸ §7Toutes les données seront supprimées");
+        player.sendMessage("§r");
+        player.sendMessage("§7Tapez §c'SUPPRIMER'§7 pour confirmer");
+        player.sendMessage("§7Tapez §a'annuler'§7 pour annuler");
+
+        final var menuManager = plugin.getMenuManager();
+        ChatInputManager.startInputFlow(player, inputRaw -> {
+            final String input = inputRaw.trim();
+            if (input.equalsIgnoreCase("SUPPRIMER")) {
+                final boolean success = clanManager.deleteClan(player.getUniqueId());
+                if (success) {
+                    player.sendMessage("§c§lClan supprimé avec succès !");
+                    player.sendMessage("§7Toutes les données ont été effacées.");
+                } else {
+                    player.sendMessage("§cErreur lors de la suppression du clan.");
+                }
+            } else if (input.equalsIgnoreCase("annuler")) {
+                player.sendMessage("§aSuppression annulée.");
+            } else {
+                player.sendMessage("§cCommande non reconnue - Suppression annulée.");
+            }
+
+            if (menuManager != null) {
+                Bukkit.getScheduler().runTaskLater(plugin, () -> menuManager.openMenu(player, "clan_menu"), 40L);
+            }
+        }, () -> {
+            player.sendMessage("§cTemps écoulé - Suppression annulée.");
+            if (menuManager != null) {
+                menuManager.openMenu(player, "clan_menu");
+            }
+        });
     }
 
     private void parseAmountAndApply(final String raw, final java.util.function.LongConsumer consumer) {

--- a/src/main/java/com/lobby/social/SocialPlaceholderManager.java
+++ b/src/main/java/com/lobby/social/SocialPlaceholderManager.java
@@ -83,6 +83,7 @@ public class SocialPlaceholderManager {
         replacements.put("%friend_auto_accept%", "Tous");
         replacements.put("%friend_notifications%", "Activées");
         replacements.put("%friend_visibility%", "Visible");
+        replacements.put("%friend_auto_favorites%", "Désactivée");
 
         if (player == null) {
             return replaceAll(text, replacements);
@@ -148,6 +149,7 @@ public class SocialPlaceholderManager {
                 : formatAcceptMode(settings.getAcceptRequests()));
         replacements.put("%friend_notifications%", settings.isAllowNotifications() ? "Activées" : "Désactivées");
         replacements.put("%friend_visibility%", settings.isShowOnlineStatus() ? "Visible" : "Caché");
+        replacements.put("%friend_auto_favorites%", settings.isAutoAcceptFavorites() ? "Activée" : "Désactivée");
         replacements.put("%friend_limits%", settings.getMaxFriends() <= 0
                 ? "Illimité"
                 : settings.getMaxFriends() + " slots");

--- a/src/main/java/com/lobby/social/clans/ClanManager.java
+++ b/src/main/java/com/lobby/social/clans/ClanManager.java
@@ -288,6 +288,65 @@ public class ClanManager {
         return true;
     }
 
+    public boolean deleteClan(final UUID leaderUuid) {
+        if (leaderUuid == null) {
+            return false;
+        }
+
+        final Clan clan = getPlayerClan(leaderUuid);
+        if (clan == null || !clan.isLeader(leaderUuid)) {
+            return false;
+        }
+
+        Connection connection = null;
+        try {
+            connection = databaseManager.getConnection();
+            connection.setAutoCommit(false);
+
+            deleteEntries(connection, "DELETE FROM clan_members WHERE clan_id = ?", clan.getId());
+            deleteEntries(connection, "DELETE FROM clan_ranks WHERE clan_id = ?", clan.getId());
+            deleteEntries(connection, "DELETE FROM clan_invitations WHERE clan_id = ?", clan.getId());
+            deleteEntries(connection, "DELETE FROM clan_transactions WHERE clan_id = ?", clan.getId());
+            deleteEntries(connection, "DELETE FROM clans WHERE id = ?", clan.getId());
+
+            connection.commit();
+
+            removeClanFromCache(clan);
+            notifyAllClanMembers(clan, "§cLe clan a été supprimé par le leader");
+            return true;
+        } catch (final SQLException exception) {
+            if (connection != null) {
+                try {
+                    connection.rollback();
+                } catch (final SQLException rollbackException) {
+                    plugin.getLogger().log(Level.SEVERE, "Failed to rollback clan deletion", rollbackException);
+                }
+            }
+            plugin.getLogger().log(Level.SEVERE, "Failed to delete clan", exception);
+            return false;
+        } finally {
+            if (connection != null) {
+                try {
+                    connection.setAutoCommit(true);
+                } catch (final SQLException exception) {
+                    plugin.getLogger().log(Level.SEVERE, "Failed to reset auto-commit after clan deletion", exception);
+                }
+                try {
+                    connection.close();
+                } catch (final SQLException exception) {
+                    plugin.getLogger().log(Level.SEVERE, "Failed to close connection after clan deletion", exception);
+                }
+            }
+        }
+    }
+
+    private void deleteEntries(final Connection connection, final String query, final int clanId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setInt(1, clanId);
+            statement.executeUpdate();
+        }
+    }
+
     private void cacheClan(final Clan clan) {
         clanCache.put(clan.getName().toLowerCase(Locale.ROOT), clan);
         clanCache.put(clan.getTag().toLowerCase(Locale.ROOT), clan);
@@ -295,6 +354,17 @@ public class ClanManager {
         for (final UUID member : clan.getMembers().keySet()) {
             playerClanCache.put(member, clan.getName().toLowerCase(Locale.ROOT));
         }
+    }
+
+    private void removeClanFromCache(final Clan clan) {
+        if (clan == null) {
+            return;
+        }
+        clanCache.entrySet().removeIf(entry -> entry.getValue() == clan || (entry.getValue() != null
+                && entry.getValue().getId() == clan.getId()));
+        clanCacheById.remove(clan.getId());
+        playerClanCache.entrySet().removeIf(entry -> entry.getValue() != null
+                && entry.getValue().equalsIgnoreCase(clan.getName()));
     }
 
     private void updateClanBank(final Clan clan) {
@@ -342,6 +412,23 @@ public class ClanManager {
             statement.executeUpdate();
         } catch (final SQLException exception) {
             plugin.getLogger().log(Level.SEVERE, "Failed to log clan transaction", exception);
+        }
+    }
+
+    private void notifyAllClanMembers(final Clan clan, final String message) {
+        if (clan == null || message == null || message.isBlank()) {
+            return;
+        }
+        for (final ClanMember member : clan.getMembers().values()) {
+            final Player player = Bukkit.getPlayer(member.getUuid());
+            if (player != null) {
+                player.sendMessage(message);
+            }
+        }
+        final Player leader = Bukkit.getPlayer(clan.getLeaderUUID());
+        if (leader != null && clan.getMembers().values().stream()
+                .noneMatch(member -> member.getUuid().equals(leader.getUniqueId()))) {
+            leader.sendMessage(message);
         }
     }
 

--- a/src/main/resources/config/menus.yml
+++ b/src/main/resources/config/menus.yml
@@ -403,6 +403,23 @@ menus:
           - "&a▶ Cliquez pour créer !"
         actions:
           - "[COMMAND] clan create"
+      clan_delete:
+        slot: 35
+        material: PLAYER_HEAD
+        head: "hdb:60776"
+        name: "&c&lSupprimer le Clan"
+        lore:
+          - "&7Supprimez définitivement votre clan."
+          - "&7Cette action est irréversible !"
+          - "&r"
+          - "&8▸ &7Membres expulsés"
+          - "&8▸ &7Trésor perdu"
+          - "&8▸ &7Données effacées"
+          - "&r"
+          - "&c⚠ Nécessite confirmation"
+          - "&c▶ Cliquez pour supprimer !"
+        actions:
+          - "[CLAN_DELETE_CONFIRM]"
       clan_join:
         slot: 43
         material: PLAYER_HEAD
@@ -550,7 +567,7 @@ menus:
       friends_favorites:
         slot: 32
         material: PLAYER_HEAD
-        head: "hdb:35472"
+        head: "hdb:12654"
         name: "&c&lAmis Favoris"
         lore:
           - "&7Vos amis les plus proches"
@@ -989,28 +1006,90 @@ menus:
           - "[CLOSE]"
 
   friend_settings_menu:
-    title: "&8» &6&lParamètres d'Amis"
-    size: 27
+    title: "&8» &dParamètres d'Amis"
+    size: 45
     items:
-      settings_info:
+      accept_requests:
+        slot: 11
+        material: PLAYER_HEAD
+        head: "hdb:3581"
+        name: "&a&lDemandes d'Amis"
+        lore:
+          - "&7Gérez qui peut vous envoyer"
+          - "&7des demandes d'amitié."
+          - "&r"
+          - "&8▸ &7Statut: %friend_auto_accept%"
+          - "&r"
+          - "&a▶ Cliquez pour modifier!"
+        actions:
+          - "[PLAYER_COMMAND] friend settings toggle requests"
+      notifications:
         slot: 13
-        material: REDSTONE_COMPARATOR
-        name: "&6Configuration actuelle"
+        material: PLAYER_HEAD
+        head: "hdb:1455"
+        name: "&e&lNotifications"
         lore:
-          - "&7Demandes automatiques: %friend_auto_accept%"
-          - "&7Notifications: %friend_notifications%"
-          - "&7Visibilité: %friend_visibility%"
-          - "&7Limite: %friend_limits%"
+          - "&7Activez/désactivez les notifications"
+          - "&7d'amis en ligne."
+          - "&r"
+          - "&8▸ &7Statut: %friend_notifications%"
+          - "&r"
+          - "&e▶ Cliquez pour basculer!"
+        actions:
+          - "[PLAYER_COMMAND] friend settings toggle notifications"
+      visibility:
+        slot: 15
+        material: PLAYER_HEAD
+        head: "hdb:8537"
+        name: "&b&lVisibilité"
+        lore:
+          - "&7Contrôlez qui peut voir votre"
+          - "&7statut en ligne."
+          - "&r"
+          - "&8▸ &7Mode: %friend_visibility%"
+          - "&r"
+          - "&b▶ Cliquez pour changer!"
+        actions:
+          - "[PLAYER_COMMAND] friend settings toggle visibility"
+      auto_accept_favorites:
+        slot: 22
+        material: PLAYER_HEAD
+        head: "hdb:12654"
+        name: "&6&lAcceptation Auto Favoris"
+        lore:
+          - "&7Acceptez automatiquement les"
+          - "&7demandes de vos amis favoris."
+          - "&r"
+          - "&8▸ &7Statut: %friend_auto_favorites%"
+          - "&r"
+          - "&6▶ Cliquez pour basculer!"
+        actions:
+          - "[PLAYER_COMMAND] friend settings toggle favorites"
+      private_messages:
+        slot: 24
+        material: PLAYER_HEAD
+        head: "hdb:2736"
+        name: "&d&lMessages Privés"
+        lore:
+          - "&7Autorisez les messages privés"
+          - "&7de vos amis."
+          - "&r"
+          - "&8▸ &7Statut: &eFonctionnalité à venir"
+          - "&r"
+          - "&d▶ Revenez bientôt!"
+        actions:
+          - "[NONE]"
       back:
-        slot: 18
-        material: ARROW
-        name: "&aRetour"
+        slot: 40
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
-          - "&7Retour à la gestion des amis"
+          - "&7Retourner au menu des amis"
         actions:
           - "[MENU] friends_menu"
       close:
-        slot: 26
+        slot: 44
         material: BARRIER
         name: "&cFermer"
         lore:
@@ -1167,27 +1246,90 @@ menus:
           - "[CLOSE]"
 
   group_settings_menu:
-    title: "&8» &c&lParamètres de Groupe"
-    size: 27
+    title: "&8» &eParamètres de Groupe"
+    size: 45
     items:
-      settings_info:
+      auto_accept:
+        slot: 11
+        material: PLAYER_HEAD
+        head: "hdb:13389"
+        name: "&a&lAcceptation Automatique"
+        lore:
+          - "&7Acceptez automatiquement les"
+          - "&7invitations de groupe d'amis."
+          - "&r"
+          - "&8▸ &7Statut: %group_auto_accept%"
+          - "&r"
+          - "&a▶ Bientôt disponible"
+        actions:
+          - "[NONE]"
+      preferred_gamemode:
         slot: 13
-        material: REDSTONE_COMPARATOR
-        name: "&cConfiguration"
+        material: PLAYER_HEAD
+        head: "hdb:38878"
+        name: "&b&lMode de Jeu Préféré"
         lore:
-          - "&7Invitations automatiques: %group_auto_accept%"
-          - "&7Mode préféré: %group_preferred_mode%"
-          - "&7Visibilité: %group_visibility%"
+          - "&7Définissez votre mode de jeu"
+          - "&7préféré pour les groupes."
+          - "&r"
+          - "&8▸ &7Mode actuel: %group_preferred_mode%"
+          - "&r"
+          - "&b▶ Fonctionnalité à venir"
+        actions:
+          - "[NONE]"
+      visibility:
+        slot: 15
+        material: PLAYER_HEAD
+        head: "hdb:7439"
+        name: "&d&lVisibilité du Groupe"
+        lore:
+          - "&7Contrôlez si vos groupes"
+          - "&7sont publics ou privés."
+          - "&r"
+          - "&8▸ &7Mode: %group_visibility%"
+          - "&r"
+          - "&d▶ Bientôt disponible"
+        actions:
+          - "[NONE]"
+      max_invites:
+        slot: 22
+        material: PLAYER_HEAD
+        head: "hdb:9969"
+        name: "&6&lLimite d'Invitations"
+        lore:
+          - "&7Nombre maximum d'invitations"
+          - "&7simultanées que vous pouvez avoir."
+          - "&r"
+          - "&8▸ &7Limite actuelle: %group_max%"
+          - "&r"
+          - "&6▶ Paramétrage prochainement"
+        actions:
+          - "[NONE]"
+      notifications:
+        slot: 24
+        material: PLAYER_HEAD
+        head: "hdb:1455"
+        name: "&c&lNotifications de Groupe"
+        lore:
+          - "&7Recevez des notifications pour"
+          - "&7les invitations et événements."
+          - "&r"
+          - "&8▸ &7Statut: %group_status%"
+          - "&r"
+          - "&c▶ Gestion à venir"
+        actions:
+          - "[NONE]"
       back:
-        slot: 18
-        material: ARROW
-        name: "&aRetour"
+        slot: 40
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
-          - "&7Retour à la gestion des groupes"
+          - "&7Retourner au menu des groupes"
         actions:
           - "[MENU] groups_menu"
       close:
-        slot: 26
+        slot: 44
         material: BARRIER
         name: "&cFermer"
         lore:

--- a/src/main/resources/config/menus/clan_menu.yml
+++ b/src/main/resources/config/menus/clan_menu.yml
@@ -172,6 +172,24 @@ menu:
       actions:
         - "[COMMAND] clan create"
 
+    clan_delete:
+      slot: 35
+      material: "PLAYER_HEAD"
+      head: "hdb:60776"
+      name: "&c&lSupprimer le Clan"
+      lore:
+        - "&7Supprimez définitivement votre clan."
+        - "&7Cette action est irréversible !"
+        - "&r"
+        - "&8▸ &7Membres expulsés"
+        - "&8▸ &7Trésor perdu"
+        - "&8▸ &7Données effacées"
+        - "&r"
+        - "&c⚠ Nécessite confirmation"
+        - "&c▶ Cliquez pour supprimer !"
+      actions:
+        - "[CLAN_DELETE_CONFIRM]"
+
     clan_join:
       slot: 43
       material: "PLAYER_HEAD"

--- a/src/main/resources/config/menus/friends_menu.yml
+++ b/src/main/resources/config/menus/friends_menu.yml
@@ -157,7 +157,7 @@ menu:
     friends_favorites:
       slot: 32
       material: "PLAYER_HEAD"
-      head: "hdb:35472"
+      head: "hdb:12654"
       name: "&c&lAmis Favoris"
       lore:
         - "&7Vos amis les plus proches"


### PR DESCRIPTION
## Summary
- add a transactional clan deletion routine that clears database records, updates caches, and notifies online members
- expose the clan deletion confirmation flow through the menu action processor and the `/clan delete` sub-command
- expand friend settings support with toggle commands, placeholders, and refreshed menu configurations that leverage HeadDatabase icons across social menus

## Testing
- `mvn -q -DskipTests package` *(fails: repository unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc444b2448329a34c960039fe7853