### PR TITLE
Implement social permissions menus and placeholders

### DIFF
--- a/src/main/java/com/lobby/commands/FriendCommand.java
+++ b/src/main/java/com/lobby/commands/FriendCommand.java
@@ -177,10 +177,8 @@ public class FriendCommand implements CommandExecutor, TabCompleter {
         String feedback;
         switch (option) {
             case "requests":
-                final boolean requestsEnabled = friendManager.toggleRequestAcceptance(player.getUniqueId());
-                feedback = requestsEnabled
-                        ? ChatColor.GREEN + "Requêtes d'amis activées"
-                        : ChatColor.RED + "Requêtes d'amis désactivées";
+                final String requestMode = friendManager.cycleRequestAcceptance(player.getUniqueId());
+                feedback = ChatColor.GREEN + "Demandes d'amis: " + ChatColor.WHITE + requestMode;
                 break;
             case "notifications":
                 final boolean notificationsEnabled = friendManager.toggleNotifications(player.getUniqueId());
@@ -189,10 +187,8 @@ public class FriendCommand implements CommandExecutor, TabCompleter {
                         : ChatColor.RED + "Notifications désactivées";
                 break;
             case "visibility":
-                final boolean visibilityEnabled = friendManager.toggleVisibility(player.getUniqueId());
-                feedback = visibilityEnabled
-                        ? ChatColor.GREEN + "Visibilité activée"
-                        : ChatColor.RED + "Visibilité masquée";
+                final String visibilityMode = friendManager.cycleFriendVisibility(player.getUniqueId());
+                feedback = ChatColor.GREEN + "Visibilité: " + ChatColor.WHITE + visibilityMode;
                 break;
             case "favorites":
                 final boolean autoFavorites = friendManager.toggleAutoAcceptFavorites(player.getUniqueId());

--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -67,6 +67,8 @@ public class ConfiguredMenu implements Menu {
             }
         }
 
+        applyBorders(player);
+
         final ConfigurationSection itemsSection = menuSection.getConfigurationSection("items");
         if (itemsSection != null) {
             for (String key : itemsSection.getKeys(false)) {
@@ -231,6 +233,76 @@ public class ConfiguredMenu implements Menu {
             return null;
         }
         return processed;
+    }
+
+    private void applyBorders(final Player player) {
+        if (inventory == null) {
+            return;
+        }
+        final List<Map<?, ?>> borders = menuSection.getMapList("borders");
+        if (borders == null || borders.isEmpty()) {
+            return;
+        }
+        for (Map<?, ?> definition : borders) {
+            if (definition == null || definition.isEmpty()) {
+                continue;
+            }
+            final ItemStack borderItem = createBorderItem(player, definition);
+            if (borderItem == null) {
+                continue;
+            }
+            final List<Integer> slots = parseSlots(definition.get("slots"));
+            for (Integer slot : slots) {
+                if (slot == null) {
+                    continue;
+                }
+                final int index = slot;
+                if (index >= 0 && index < inventory.getSize()) {
+                    inventory.setItem(index, borderItem.clone());
+                }
+            }
+        }
+    }
+
+    private ItemStack createBorderItem(final Player player, final Map<?, ?> definition) {
+        final Object materialObject = definition.getOrDefault("material", "BLACK_STAINED_GLASS_PANE");
+        final String materialName = materialObject != null ? materialObject.toString() : "BLACK_STAINED_GLASS_PANE";
+        final Material material = Material.matchMaterial(materialName);
+        if (material == null) {
+            LogUtils.warning(plugin, "Invalid border material '" + materialName + "' in menu '" + menuId + "'.");
+            return null;
+        }
+        final ItemStack itemStack = new ItemStack(material);
+        final ItemMeta meta = itemStack.getItemMeta();
+        if (meta != null) {
+            final Object nameObject = definition.get("name");
+            final String name = nameObject != null
+                    ? MessageUtils.colorize(PlaceholderUtils.applyPlaceholders(plugin, nameObject.toString(), player))
+                    : " ";
+            meta.setDisplayName((name == null || name.isBlank()) ? " " : name);
+            meta.addItemFlags(ItemFlag.values());
+            itemStack.setItemMeta(meta);
+        }
+        return itemStack;
+    }
+
+    private List<Integer> parseSlots(final Object value) {
+        if (value instanceof List<?> list) {
+            final List<Integer> slots = new ArrayList<>();
+            for (Object element : list) {
+                if (element instanceof Number number) {
+                    slots.add(number.intValue());
+                } else if (element instanceof String string) {
+                    try {
+                        slots.add(Integer.parseInt(string.trim()));
+                    } catch (final NumberFormatException ignored) {
+                        // Ignore invalid entries
+                    }
+                }
+            }
+            return slots;
+        }
+        return List.of();
     }
 
     private void storeActions(final int slot, final ConfigurationSection itemSection) {

--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -22,6 +22,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 
 public class ActionProcessor {
 
@@ -66,8 +67,36 @@ public class ActionProcessor {
             ChatInputManager.startFriendAddFlow(player);
             return;
         }
+        if (trimmed.equalsIgnoreCase("[TOGGLE_FRIEND_NOTIFICATIONS]")) {
+            toggleAndRefresh(player, "friend_notifications", "friend_settings_menu");
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CYCLE_FRIEND_REQUESTS]")) {
+            cycleAndRefresh(player, "friend_requests", "friend_settings_menu");
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CYCLE_FRIEND_VISIBILITY]")) {
+            cycleAndRefresh(player, "friend_visibility", "friend_settings_menu");
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[TOGGLE_FRIEND_AUTO_FAVORITES]")) {
+            toggleAndRefresh(player, "friend_auto_favorites", "friend_settings_menu");
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[TOGGLE_FRIEND_MESSAGES]")) {
+            toggleAndRefresh(player, "friend_messages", "friend_settings_menu");
+            return;
+        }
         if (trimmed.equalsIgnoreCase("[GROUP_CREATE]")) {
             ChatInputManager.startGroupCreateFlow(player);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[TOGGLE_GROUP_AUTO_ACCEPT]")) {
+            toggleAndRefresh(player, "group_auto_accept", "group_settings_menu");
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CYCLE_GROUP_VISIBILITY]")) {
+            cycleAndRefresh(player, "group_visibility", "group_settings_menu");
             return;
         }
         if (trimmed.equalsIgnoreCase("[CLAN_MEMBERS]")) {
@@ -76,6 +105,16 @@ public class ActionProcessor {
         }
         if (trimmed.equalsIgnoreCase("[CLAN_VAULT]")) {
             ClanMenus.openClanVaultMenu(player);
+            return;
+        }
+        if (startsWithIgnoreCase(trimmed, "[TOGGLE_MEMBER_PERMISSION]")) {
+            final String value = processed.substring("[TOGGLE_MEMBER_PERMISSION]".length()).trim();
+            toggleMemberPermission(player, value);
+            return;
+        }
+        if (startsWithIgnoreCase(trimmed, "[APPLY_MEMBER_PERMISSION_PRESET]")) {
+            final String value = processed.substring("[APPLY_MEMBER_PERMISSION_PRESET]".length()).trim();
+            applyMemberPreset(player, value);
             return;
         }
         if (trimmed.equalsIgnoreCase("[CLAN_INVITE]")) {
@@ -242,6 +281,244 @@ public class ActionProcessor {
                 menuManager.openMenu(player, "clan_menu");
             }
         });
+    }
+
+    private void toggleAndRefresh(final Player player, final String key, final String menuId) {
+        if (player == null || key == null) {
+            return;
+        }
+        switch (key) {
+            case "friend_notifications" -> {
+                final var friendManager = plugin.getFriendManager();
+                if (friendManager == null) {
+                    return;
+                }
+                final boolean enabled = friendManager.toggleNotifications(player.getUniqueId());
+                player.sendMessage(enabled
+                        ? "§aNotifications d'amis activées"
+                        : "§cNotifications d'amis désactivées");
+                reopenMenu(player, menuId);
+            }
+            case "friend_auto_favorites" -> {
+                final var friendManager = plugin.getFriendManager();
+                if (friendManager == null) {
+                    return;
+                }
+                final boolean enabled = friendManager.toggleAutoAcceptFavorites(player.getUniqueId());
+                player.sendMessage(enabled
+                        ? "§aAcceptation auto des favoris activée"
+                        : "§cAcceptation auto des favoris désactivée");
+                reopenMenu(player, menuId);
+            }
+            case "friend_messages" -> {
+                final var friendManager = plugin.getFriendManager();
+                if (friendManager == null) {
+                    return;
+                }
+                final boolean enabled = friendManager.togglePrivateMessages(player.getUniqueId());
+                player.sendMessage(enabled
+                        ? "§aMessages privés autorisés"
+                        : "§cMessages privés désactivés");
+                reopenMenu(player, menuId);
+            }
+            case "group_auto_accept" -> {
+                final var groupManager = plugin.getGroupManager();
+                if (groupManager == null) {
+                    return;
+                }
+                final boolean enabled = groupManager.toggleAutoAccept(player.getUniqueId());
+                player.sendMessage(enabled
+                        ? "§aInvitations automatiques activées"
+                        : "§cInvitations automatiques désactivées");
+                reopenMenu(player, menuId);
+            }
+            default -> {
+            }
+        }
+    }
+
+    private void cycleAndRefresh(final Player player, final String key, final String menuId) {
+        if (player == null || key == null) {
+            return;
+        }
+        switch (key) {
+            case "friend_requests" -> {
+                final var friendManager = plugin.getFriendManager();
+                if (friendManager == null) {
+                    return;
+                }
+                final String mode = friendManager.cycleRequestAcceptance(player.getUniqueId());
+                player.sendMessage("§aDemandes d'amis: §f" + mode);
+                reopenMenu(player, menuId);
+            }
+            case "friend_visibility" -> {
+                final var friendManager = plugin.getFriendManager();
+                if (friendManager == null) {
+                    return;
+                }
+                final String visibility = friendManager.cycleFriendVisibility(player.getUniqueId());
+                player.sendMessage("§aVisibilité: §f" + visibility);
+                reopenMenu(player, menuId);
+            }
+            case "group_visibility" -> {
+                final var groupManager = plugin.getGroupManager();
+                if (groupManager == null) {
+                    return;
+                }
+                final String visibility = groupManager.cycleGroupVisibility(player.getUniqueId());
+                player.sendMessage("§aVisibilité du groupe: §f" + visibility);
+                reopenMenu(player, menuId);
+            }
+            default -> {
+            }
+        }
+    }
+
+    private void toggleMemberPermission(final Player player, final String actionValue) {
+        if (player == null || actionValue == null || actionValue.isBlank()) {
+            return;
+        }
+        final String[] parts = actionValue.split("\\|");
+        if (parts.length < 2) {
+            player.sendMessage("§cAction de permission invalide.");
+            return;
+        }
+        final UUID memberUuid = parseUuid(parts[0]);
+        if (memberUuid == null) {
+            player.sendMessage("§cMembre introuvable.");
+            return;
+        }
+        final String permissionKey = parts[1].trim();
+        if (permissionKey.isEmpty()) {
+            player.sendMessage("§cPermission invalide.");
+            return;
+        }
+        final String menuId = parts.length > 2 && !parts[2].trim().isEmpty()
+                ? parts[2].trim()
+                : "clan_member_permissions_menu";
+        final ClanManager clanManager = plugin.getClanManager();
+        if (clanManager == null) {
+            return;
+        }
+        final boolean enabled = clanManager.toggleMemberPermission(player.getUniqueId(), memberUuid, permissionKey);
+        final String name = formatPermissionName(permissionKey);
+        player.sendMessage(enabled
+                ? "§aPermission activée: §f" + name
+                : "§cPermission désactivée: §f" + name);
+        reopenMenu(player, menuId);
+    }
+
+    private void applyMemberPreset(final Player player, final String actionValue) {
+        if (player == null || actionValue == null || actionValue.isBlank()) {
+            return;
+        }
+        final String[] parts = actionValue.split("\\|");
+        if (parts.length < 2) {
+            player.sendMessage("§cPreset de permissions invalide.");
+            return;
+        }
+        final UUID memberUuid = parseUuid(parts[0]);
+        if (memberUuid == null) {
+            player.sendMessage("§cMembre introuvable.");
+            return;
+        }
+        final String presetKey = parts[1].trim();
+        if (presetKey.isEmpty()) {
+            player.sendMessage("§cPreset invalide.");
+            return;
+        }
+        final String menuId = parts.length > 2 && !parts[2].trim().isEmpty()
+                ? parts[2].trim()
+                : "clan_member_permissions_menu";
+        final ClanManager clanManager = plugin.getClanManager();
+        if (clanManager == null) {
+            return;
+        }
+        final boolean success = clanManager.applyPermissionPreset(player.getUniqueId(), memberUuid, presetKey);
+        final String name = formatPresetName(presetKey);
+        player.sendMessage(success
+                ? "§aPreset appliqué: §f" + name
+                : "§cImpossible d'appliquer le preset: §f" + name);
+        reopenMenu(player, menuId);
+    }
+
+    private void reopenMenu(final Player player, final String menuId) {
+        if (player == null || menuId == null || menuId.isBlank()) {
+            return;
+        }
+        final MenuManager menuManager = plugin.getMenuManager();
+        if (menuManager == null) {
+            return;
+        }
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            if (player.isOnline()) {
+                menuManager.openMenu(player, menuId);
+            }
+        });
+    }
+
+    private UUID parseUuid(final String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(value.trim());
+        } catch (final IllegalArgumentException exception) {
+            return null;
+        }
+    }
+
+    private String formatPermissionName(final String permissionKey) {
+        if (permissionKey == null || permissionKey.isBlank()) {
+            return "Permission";
+        }
+        final String normalized = permissionKey.toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "clan.invite" -> "Invitations";
+            case "clan.kick" -> "Exclusions";
+            case "clan.promote" -> "Promotions";
+            case "clan.demote" -> "Rétrogradations";
+            case "clan.manage_ranks" -> "Gestion des rangs";
+            case "clan.withdraw", "clan.manage_bank" -> "Banque";
+            case "clan.disband" -> "Dissolution";
+            default -> {
+                final String raw = permissionKey.contains(".")
+                        ? permissionKey.substring(permissionKey.indexOf('.') + 1)
+                        : permissionKey;
+                final String lower = raw.replace('_', ' ').toLowerCase(Locale.ROOT);
+                yield Character.toUpperCase(lower.charAt(0)) + lower.substring(1);
+            }
+        };
+    }
+
+    private String formatPresetName(final String presetKey) {
+        if (presetKey == null || presetKey.isBlank()) {
+            return "Preset";
+        }
+        final String normalized = presetKey.toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "default", "aucun", "none" -> "Défaut";
+            case "moderateur", "moderator", "mod" -> "Modérateur";
+            case "officier", "officer" -> "Officier";
+            case "gestion", "manager" -> "Gestion";
+            case "banquier", "banker" -> "Banquier";
+            case "admin", "toutes", "all" -> "Administrateur";
+            default -> {
+                final String cleaned = normalized.replace('-', ' ').replace('_', ' ');
+                final String[] parts = cleaned.split(" ");
+                final StringBuilder builder = new StringBuilder();
+                for (String part : parts) {
+                    if (part.isEmpty()) {
+                        continue;
+                    }
+                    builder.append(Character.toUpperCase(part.charAt(0)))
+                            .append(part.substring(1));
+                    builder.append(' ');
+                }
+                final String result = builder.toString().trim();
+                yield result.isEmpty() ? presetKey : result;
+            }
+        };
     }
 
     private void parseAmountAndApply(final String raw, final java.util.function.LongConsumer consumer) {

--- a/src/main/java/com/lobby/social/SocialPlaceholderManager.java
+++ b/src/main/java/com/lobby/social/SocialPlaceholderManager.java
@@ -13,6 +13,8 @@ import com.lobby.social.friends.FriendManager;
 import com.lobby.social.friends.FriendSettings;
 import com.lobby.social.groups.Group;
 import com.lobby.social.groups.GroupManager;
+import com.lobby.social.groups.GroupSettings;
+import com.lobby.social.groups.GroupVisibility;
 import com.lobby.velocity.VelocityManager;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -28,11 +30,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class SocialPlaceholderManager {
 
     private final LobbyPlugin plugin;
+    private final Map<UUID, UUID> clanPermissionTargets = new ConcurrentHashMap<>();
 
     public SocialPlaceholderManager(final LobbyPlugin plugin) {
         this.plugin = plugin;
@@ -44,11 +48,29 @@ public class SocialPlaceholderManager {
         }
         String replaced = text;
         replaced = applyEconomyPlaceholders(player, replaced);
+        replaced = applyStatisticPlaceholders(player, replaced);
         replaced = applyFriendPlaceholders(player, replaced);
         replaced = applyGroupPlaceholders(player, replaced);
         replaced = applyClanPlaceholders(player, replaced);
         replaced = applyServerPlaceholders(replaced);
         return replaced;
+    }
+
+    private String applyStatisticPlaceholders(final Player player, final String text) {
+        final Map<String, String> replacements = new HashMap<>();
+        replacements.put("%stats_pvp_wins%", "0");
+        replacements.put("%stats_pvp_losses%", "0");
+        replacements.put("%stats_pvp_ratio%", "0.0");
+        replacements.put("%stats_bedwars_wins%", "0");
+        replacements.put("%stats_skywars_wins%", "0");
+        replacements.put("%stats_arcade_score%", "0");
+        replacements.put("%stats_achievements_unlocked%", "0");
+        replacements.put("%stats_achievements_remaining%", "0");
+        replacements.put("%player_language%", "Français");
+        replacements.put("%daily_reward_cooldown%", "Disponible");
+        replacements.put("%daily_reward_name%", "Mystery Box");
+        replacements.put("%daily_reward_streak%", "0 jour");
+        return replaceAll(text, replacements);
     }
 
     private String applyEconomyPlaceholders(final Player player, final String text) {
@@ -241,6 +263,10 @@ public class SocialPlaceholderManager {
             return replaceAll(text, replacements);
         }
 
+        final GroupSettings groupSettings = groupManager.getGroupSettings(player.getUniqueId());
+        replacements.put("%group_auto_accept%", groupSettings.isAutoAcceptInvites() ? "Automatique" : "Manuel");
+        replacements.put("%group_visibility%", formatGroupVisibility(groupSettings.getVisibility()));
+
         final Group group = groupManager.getPlayerGroup(player.getUniqueId());
         if (group != null) {
             replacements.put("%group_name%", Objects.requireNonNullElse(group.getDisplayName(), "Groupe"));
@@ -249,9 +275,7 @@ public class SocialPlaceholderManager {
             replacements.put("%group_max%", String.valueOf(group.getMaxSize()));
             replacements.put("%group_slots_free%", String.valueOf(Math.max(0, group.getMaxSize() - group.getSize())));
             replacements.put("%group_status%", group.isFull() ? "Complet" : "Ouvert");
-            replacements.put("%group_auto_accept%", "Invitations manuelles");
             replacements.put("%group_preferred_mode%", "Toutes les files");
-            replacements.put("%group_visibility%", "Privé");
         }
 
         replacements.put("%group_invitations%", String.valueOf(groupManager.countPendingInvitations(player.getUniqueId())));
@@ -285,6 +309,17 @@ public class SocialPlaceholderManager {
         replacements.put("%clan_war_ratio%", formatRatio(0, 0));
         replacements.put("%clans_open_count%", "0");
         replacements.put("%clans_invite_count%", "0");
+        replacements.put("%clan_target_uuid%", "");
+        replacements.put("%clan_target_name%", "Aucun membre");
+        replacements.put("%clan_target_rank%", "Aucun");
+        replacements.put("%clan_target_permissions%", "Aucune");
+        replacements.put("%clan_permission_invite_status%", "§cDésactivée");
+        replacements.put("%clan_permission_kick_status%", "§cDésactivée");
+        replacements.put("%clan_permission_promote_status%", "§cDésactivée");
+        replacements.put("%clan_permission_demote_status%", "§cDésactivée");
+        replacements.put("%clan_permission_manage_ranks_status%", "§cDésactivée");
+        replacements.put("%clan_permission_withdraw_status%", "§cDésactivée");
+        replacements.put("%clan_permission_disband_status%", "§cDésactivée");
 
         final ClanManager clanManager = plugin.getClanManager();
         if (player == null || clanManager == null) {
@@ -339,7 +374,53 @@ public class SocialPlaceholderManager {
         final boolean vaultAccess = clan.hasPermission(player.getUniqueId(), ClanPermission.MANAGE_BANK);
         replacements.put("%clan_vault_access%", vaultAccess ? "Autorisé" : "Réservé");
 
+        final UUID targetUuid = clanPermissionTargets.get(player.getUniqueId());
+        if (targetUuid != null) {
+            final ClanMember target = clan.getMember(targetUuid);
+            if (target != null) {
+                final String targetName = resolveName(targetUuid);
+                replacements.put("%clan_target_uuid%", targetUuid.toString());
+                replacements.put("%clan_target_name%", targetName);
+                replacements.put("%clan_target_rank%", target.getRankName());
+                final List<String> permissionList = clanManager.getMemberPermissions(targetUuid);
+                replacements.put("%clan_target_permissions%", permissionList.isEmpty()
+                        ? "Aucune"
+                        : String.join(", ", permissionList));
+                replacements.put("%clan_permission_invite_status%", formatPermissionStatus(
+                        clan.hasPermission(targetUuid, ClanPermission.INVITE)));
+                replacements.put("%clan_permission_kick_status%", formatPermissionStatus(
+                        clan.hasPermission(targetUuid, ClanPermission.KICK)));
+                replacements.put("%clan_permission_promote_status%", formatPermissionStatus(
+                        clan.hasPermission(targetUuid, ClanPermission.PROMOTE)));
+                replacements.put("%clan_permission_demote_status%", formatPermissionStatus(
+                        clan.hasPermission(targetUuid, ClanPermission.DEMOTE)));
+                replacements.put("%clan_permission_manage_ranks_status%", formatPermissionStatus(
+                        clan.hasPermission(targetUuid, ClanPermission.MANAGE_RANKS)));
+                replacements.put("%clan_permission_withdraw_status%", formatPermissionStatus(
+                        clan.hasPermission(targetUuid, ClanPermission.MANAGE_BANK)));
+                replacements.put("%clan_permission_disband_status%", formatPermissionStatus(
+                        clan.hasPermission(targetUuid, ClanPermission.DISBAND)));
+            }
+        }
+
         return replaceAll(text, replacements);
+    }
+
+    public void setClanPermissionTarget(final UUID viewer, final UUID target) {
+        if (viewer == null) {
+            return;
+        }
+        if (target == null) {
+            clanPermissionTargets.remove(viewer);
+        } else {
+            clanPermissionTargets.put(viewer, target);
+        }
+    }
+
+    public void clearClanPermissionTarget(final UUID viewer) {
+        if (viewer != null) {
+            clanPermissionTargets.remove(viewer);
+        }
     }
 
     private String applyServerPlaceholders(final String text) {
@@ -431,6 +512,17 @@ public class SocialPlaceholderManager {
         return Character.toUpperCase(formatted.charAt(0)) + formatted.substring(1);
     }
 
+    private String formatGroupVisibility(final GroupVisibility visibility) {
+        if (visibility == null) {
+            return "Public";
+        }
+        return switch (visibility) {
+            case PUBLIC -> "Public";
+            case FRIENDS_ONLY -> "Amis uniquement";
+            case INVITE_ONLY -> "Sur invitation";
+        };
+    }
+
     private String formatRatio(final int wins, final int losses) {
         if (wins <= 0 && losses <= 0) {
             return "0.0";
@@ -439,6 +531,10 @@ public class SocialPlaceholderManager {
             return String.format(Locale.US, "%.2f", (double) wins);
         }
         return String.format(Locale.US, "%.2f", (double) wins / Math.max(1, losses));
+    }
+
+    private String formatPermissionStatus(final boolean enabled) {
+        return enabled ? "§aActivée" : "§cDésactivée";
     }
 
     private String resolveName(final UUID uuid) {

--- a/src/main/java/com/lobby/social/clans/Clan.java
+++ b/src/main/java/com/lobby/social/clans/Clan.java
@@ -139,6 +139,10 @@ public class Clan {
         if (member == null) {
             return false;
         }
+        final var customPermissions = member.getPermissions();
+        if (!customPermissions.isEmpty()) {
+            return customPermissions.contains(permission);
+        }
         final ClanRank rank = ranks.get(member.getRankName());
         return rank != null && rank.hasPermission(permission);
     }

--- a/src/main/java/com/lobby/social/clans/ClanManager.java
+++ b/src/main/java/com/lobby/social/clans/ClanManager.java
@@ -236,6 +236,93 @@ public class ClanManager {
         return new ArrayList<>(clan.getMembers().values());
     }
 
+    public boolean toggleMemberPermission(final UUID managerUuid, final UUID memberUuid, final String permissionKey) {
+        if (managerUuid == null || memberUuid == null || permissionKey == null || permissionKey.isBlank()) {
+            return false;
+        }
+        final Clan clan = getPlayerClan(managerUuid);
+        final Clan targetClan = getPlayerClan(memberUuid);
+        if (clan == null || targetClan == null || clan.getId() != targetClan.getId()) {
+            return false;
+        }
+        if (!clan.hasPermission(managerUuid, ClanPermission.MANAGE_RANKS)) {
+            return false;
+        }
+        if (clan.isLeader(memberUuid)) {
+            return false;
+        }
+        final ClanMember member = clan.getMember(memberUuid);
+        if (member == null) {
+            return false;
+        }
+        final ClanPermission permission = resolvePermission(permissionKey);
+        if (permission == null) {
+            return false;
+        }
+        final boolean hadPermission = member.getPermissions().contains(permission);
+        member.togglePermission(permission);
+        final Set<ClanPermission> updated = member.getPermissions().isEmpty()
+                ? EnumSet.noneOf(ClanPermission.class)
+                : EnumSet.copyOf(member.getPermissions());
+        final boolean stored = storeMemberPermissions(clan.getId(), memberUuid, updated);
+        if (!stored) {
+            if (member.getPermissions().contains(permission) != hadPermission) {
+                member.togglePermission(permission);
+            }
+            return hadPermission;
+        }
+        return member.getPermissions().contains(permission);
+    }
+
+    public boolean applyPermissionPreset(final UUID managerUuid, final UUID memberUuid, final String presetKey) {
+        if (managerUuid == null || memberUuid == null || presetKey == null || presetKey.isBlank()) {
+            return false;
+        }
+        final Clan clan = getPlayerClan(managerUuid);
+        final Clan targetClan = getPlayerClan(memberUuid);
+        if (clan == null || targetClan == null || clan.getId() != targetClan.getId()) {
+            return false;
+        }
+        if (!clan.hasPermission(managerUuid, ClanPermission.MANAGE_RANKS)) {
+            return false;
+        }
+        if (clan.isLeader(memberUuid)) {
+            return false;
+        }
+        final ClanMember member = clan.getMember(memberUuid);
+        if (member == null) {
+            return false;
+        }
+        final Set<ClanPermission> preset = resolvePreset(presetKey);
+        member.setPermissions(preset);
+        return storeMemberPermissions(clan.getId(), memberUuid, preset);
+    }
+
+    public List<String> getMemberPermissions(final UUID memberUuid) {
+        if (memberUuid == null) {
+            return List.of();
+        }
+        final Clan clan = getPlayerClan(memberUuid);
+        if (clan == null) {
+            return List.of();
+        }
+        final ClanMember member = clan.getMember(memberUuid);
+        if (member == null) {
+            return List.of();
+        }
+        final Set<ClanPermission> permissions;
+        if (member.getPermissions().isEmpty()) {
+            final ClanRank rank = getPlayerRank(clan, memberUuid);
+            permissions = rank != null ? EnumSet.copyOf(rank.getPermissions()) : EnumSet.noneOf(ClanPermission.class);
+        } else {
+            permissions = EnumSet.copyOf(member.getPermissions());
+        }
+        return permissions.stream()
+                .map(permission -> permission.name().toLowerCase(Locale.ROOT).replace('_', ' '))
+                .map(value -> Character.toUpperCase(value.charAt(0)) + value.substring(1))
+                .toList();
+    }
+
     public boolean hasPermission(final int clanId, final UUID playerUuid, final String permissionKey) {
         final Clan clan = getClanById(clanId);
         if (clan == null || playerUuid == null || permissionKey == null || permissionKey.isBlank()) {
@@ -409,6 +496,7 @@ public class ClanManager {
             connection.setAutoCommit(false);
 
             deleteEntries(connection, "DELETE FROM clan_members WHERE clan_id = ?", clan.getId());
+            deleteEntries(connection, "DELETE FROM clan_member_permissions WHERE clan_id = ?", clan.getId());
             deleteEntries(connection, "DELETE FROM clan_ranks WHERE clan_id = ?", clan.getId());
             deleteEntries(connection, "DELETE FROM clan_invitations WHERE clan_id = ?", clan.getId());
             deleteEntries(connection, "DELETE FROM clan_transactions WHERE clan_id = ?", clan.getId());
@@ -542,6 +630,7 @@ public class ClanManager {
         switch (key) {
             case "clan.invite":
                 return ClanPermission.INVITE;
+            case "clan.manage_bank":
             case "clan.withdraw":
                 return ClanPermission.MANAGE_BANK;
             case "clan.kick":
@@ -1012,11 +1101,32 @@ public class ClanManager {
                     final String rankName = resultSet.getString("rank_name");
                     final Timestamp joinedAt = resultSet.getTimestamp("joined_at");
                     final long totalContributions = resultSet.getLong("total_contributions");
-                    clan.addMember(new ClanMember(uuid, rankName,
-                            joinedAt != null ? joinedAt.getTime() : System.currentTimeMillis(), totalContributions));
+                    final ClanMember member = new ClanMember(uuid, rankName,
+                            joinedAt != null ? joinedAt.getTime() : System.currentTimeMillis(), totalContributions);
+                    member.setPermissions(loadMemberPermissions(clan.getId(), uuid, connection));
+                    clan.addMember(member);
                 }
             }
         }
+    }
+
+    private Set<ClanPermission> loadMemberPermissions(final int clanId, final UUID memberUuid,
+                                                      final Connection connection) {
+        final String query = "SELECT permissions FROM clan_member_permissions WHERE clan_id = ? AND player_uuid = ?";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setInt(1, clanId);
+            statement.setString(2, memberUuid.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    final String data = resultSet.getString("permissions");
+                    return deserializePermissions(data);
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.FINE,
+                    "Failed to load clan member permissions for " + memberUuid, exception);
+        }
+        return EnumSet.noneOf(ClanPermission.class);
     }
 
     private ClanRank getPlayerRank(final Clan clan, final UUID playerUuid) {
@@ -1075,6 +1185,48 @@ public class ClanManager {
         }
     }
 
+    private boolean storeMemberPermissions(final int clanId, final UUID memberUuid,
+                                           final Set<ClanPermission> permissions) {
+        if (permissions == null || permissions.isEmpty()) {
+            return deleteMemberPermissions(clanId, memberUuid);
+        }
+        final String query;
+        if (databaseManager.getDatabaseType() == DatabaseManager.DatabaseType.MYSQL) {
+            query = "INSERT INTO clan_member_permissions (clan_id, player_uuid, permissions) VALUES (?, ?, ?) "
+                    + "ON DUPLICATE KEY UPDATE permissions = VALUES(permissions)";
+        } else {
+            query = "INSERT INTO clan_member_permissions (clan_id, player_uuid, permissions) VALUES (?, ?, ?) "
+                    + "ON CONFLICT(clan_id, player_uuid) DO UPDATE SET permissions = excluded.permissions";
+        }
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setInt(1, clanId);
+            statement.setString(2, memberUuid.toString());
+            statement.setString(3, serializePermissions(permissions));
+            statement.executeUpdate();
+            return true;
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to store clan member permissions for " + memberUuid, exception);
+            return false;
+        }
+    }
+
+    private boolean deleteMemberPermissions(final int clanId, final UUID memberUuid) {
+        final String query = "DELETE FROM clan_member_permissions WHERE clan_id = ? AND player_uuid = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setInt(1, clanId);
+            statement.setString(2, memberUuid.toString());
+            statement.executeUpdate();
+            return true;
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to delete clan member permissions for " + memberUuid, exception);
+            return false;
+        }
+    }
+
     private Set<ClanPermission> deserializePermissions(final String data) {
         if (data == null || data.isEmpty()) {
             return EnumSet.noneOf(ClanPermission.class);
@@ -1100,6 +1252,21 @@ public class ClanManager {
             return "[]";
         }
         return permissions.stream().map(Enum::name).collect(Collectors.joining(",", "[", "]"));
+    }
+
+    private Set<ClanPermission> resolvePreset(final String presetKey) {
+        final String normalized = presetKey.toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "default", "aucun", "none" -> EnumSet.noneOf(ClanPermission.class);
+            case "moderateur", "moderator", "mod" -> EnumSet.of(ClanPermission.INVITE, ClanPermission.KICK);
+            case "officier", "officer" -> EnumSet.of(ClanPermission.INVITE, ClanPermission.KICK,
+                    ClanPermission.PROMOTE, ClanPermission.DEMOTE);
+            case "gestion", "manager" -> EnumSet.of(ClanPermission.INVITE, ClanPermission.KICK,
+                    ClanPermission.PROMOTE, ClanPermission.DEMOTE, ClanPermission.MANAGE_BANK);
+            case "banquier", "banker" -> EnumSet.of(ClanPermission.MANAGE_BANK);
+            case "admin", "toutes", "all" -> EnumSet.allOf(ClanPermission.class);
+            default -> EnumSet.noneOf(ClanPermission.class);
+        };
     }
 
     private boolean hasColumn(final ResultSetMetaData metaData, final String column) throws SQLException {

--- a/src/main/java/com/lobby/social/clans/ClanMember.java
+++ b/src/main/java/com/lobby/social/clans/ClanMember.java
@@ -1,5 +1,8 @@
 package com.lobby.social.clans;
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.UUID;
 
 public class ClanMember {
@@ -8,6 +11,7 @@ public class ClanMember {
     private String rankName;
     private long joinedAt;
     private long totalContributions;
+    private final EnumSet<ClanPermission> permissions = EnumSet.noneOf(ClanPermission.class);
 
     public ClanMember(final UUID uuid, final String rankName, final long joinedAt, final long totalContributions) {
         this.uuid = uuid;
@@ -42,5 +46,27 @@ public class ClanMember {
 
     public void addContribution(final long amount) {
         this.totalContributions += amount;
+    }
+
+    public Set<ClanPermission> getPermissions() {
+        return Collections.unmodifiableSet(permissions);
+    }
+
+    public void setPermissions(final Set<ClanPermission> updated) {
+        permissions.clear();
+        if (updated != null) {
+            permissions.addAll(updated);
+        }
+    }
+
+    public void togglePermission(final ClanPermission permission) {
+        if (permission == null) {
+            return;
+        }
+        if (permissions.contains(permission)) {
+            permissions.remove(permission);
+        } else {
+            permissions.add(permission);
+        }
     }
 }

--- a/src/main/java/com/lobby/social/friends/FriendManager.java
+++ b/src/main/java/com/lobby/social/friends/FriendManager.java
@@ -433,17 +433,21 @@ public class FriendManager {
         return settingsCache.computeIfAbsent(uuid, this::loadSettings);
     }
 
-    public boolean toggleRequestAcceptance(final UUID playerUuid) {
+    public String cycleRequestAcceptance(final UUID playerUuid) {
         if (playerUuid == null) {
-            return true;
+            return "Tous";
         }
         final FriendSettings current = getFriendSettings(playerUuid);
-        final AcceptMode nextMode = current.getAcceptRequests() == AcceptMode.NONE ? AcceptMode.ALL : AcceptMode.NONE;
+        final AcceptMode nextMode = switch (current.getAcceptRequests()) {
+            case ALL -> AcceptMode.FRIENDS_OF_FRIENDS;
+            case FRIENDS_OF_FRIENDS -> AcceptMode.NONE;
+            case NONE -> AcceptMode.ALL;
+        };
         final FriendSettings updated = new FriendSettings(nextMode, current.isShowOnlineStatus(),
                 current.isAllowNotifications(), current.isAutoAcceptFavorites(),
                 current.isAllowPrivateMessages(), current.getMaxFriends());
         updateSettings(playerUuid, updated);
-        return nextMode != AcceptMode.NONE;
+        return formatAcceptMode(nextMode);
     }
 
     public boolean toggleNotifications(final UUID playerUuid) {
@@ -459,9 +463,9 @@ public class FriendManager {
         return allowNotifications;
     }
 
-    public boolean toggleVisibility(final UUID playerUuid) {
+    public String cycleFriendVisibility(final UUID playerUuid) {
         if (playerUuid == null) {
-            return true;
+            return "Visible";
         }
         final FriendSettings current = getFriendSettings(playerUuid);
         final boolean showStatus = !current.isShowOnlineStatus();
@@ -469,7 +473,7 @@ public class FriendManager {
                 current.isAllowNotifications(), current.isAutoAcceptFavorites(), current.isAllowPrivateMessages(),
                 current.getMaxFriends());
         updateSettings(playerUuid, updated);
-        return showStatus;
+        return showStatus ? "Visible" : "Caché";
     }
 
     public boolean toggleAutoAcceptFavorites(final UUID playerUuid) {
@@ -496,6 +500,17 @@ public class FriendManager {
                 current.getMaxFriends());
         updateSettings(playerUuid, updated);
         return allowPrivateMessages;
+    }
+
+    private String formatAcceptMode(final AcceptMode mode) {
+        if (mode == null) {
+            return "Tous";
+        }
+        return switch (mode) {
+            case ALL -> "Tous";
+            case FRIENDS_OF_FRIENDS -> "Amis d'amis";
+            case NONE -> "Personne";
+        };
     }
 
     public void updateSettings(final UUID uuid, final FriendSettings settings) {

--- a/src/main/java/com/lobby/social/groups/GroupManager.java
+++ b/src/main/java/com/lobby/social/groups/GroupManager.java
@@ -12,10 +12,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.sql.ResultSetMetaData;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 public class GroupManager {
@@ -24,6 +26,7 @@ public class GroupManager {
     private final DatabaseManager databaseManager;
     private final Map<UUID, Group> playerGroups = new HashMap<>();
     private final Map<Integer, Group> groupCache = new HashMap<>();
+    private final Map<UUID, GroupSettings> settingsCache = new ConcurrentHashMap<>();
 
     public GroupManager(final LobbyPlugin plugin) {
         this.plugin = plugin;
@@ -33,6 +36,39 @@ public class GroupManager {
     public void reload() {
         playerGroups.clear();
         groupCache.clear();
+        settingsCache.clear();
+    }
+
+    public GroupSettings getGroupSettings(final UUID uuid) {
+        if (uuid == null) {
+            return new GroupSettings(false, GroupVisibility.PUBLIC);
+        }
+        return settingsCache.computeIfAbsent(uuid, this::loadSettings);
+    }
+
+    public boolean toggleAutoAccept(final UUID playerUuid) {
+        if (playerUuid == null) {
+            return false;
+        }
+        final GroupSettings current = getGroupSettings(playerUuid);
+        final GroupSettings updated = new GroupSettings(!current.isAutoAcceptInvites(), current.getVisibility());
+        updateSettings(playerUuid, updated);
+        return updated.isAutoAcceptInvites();
+    }
+
+    public String cycleGroupVisibility(final UUID playerUuid) {
+        if (playerUuid == null) {
+            return formatVisibility(GroupVisibility.PUBLIC);
+        }
+        final GroupSettings current = getGroupSettings(playerUuid);
+        final GroupVisibility next = switch (current.getVisibility()) {
+            case PUBLIC -> GroupVisibility.FRIENDS_ONLY;
+            case FRIENDS_ONLY -> GroupVisibility.INVITE_ONLY;
+            case INVITE_ONLY -> GroupVisibility.PUBLIC;
+        };
+        final GroupSettings updated = new GroupSettings(current.isAutoAcceptInvites(), next);
+        updateSettings(playerUuid, updated);
+        return formatVisibility(next);
     }
 
     public void createGroup(final Player leader) {
@@ -112,6 +148,14 @@ public class GroupManager {
             return;
         }
         final GroupInvitation invitation = saveInvitation(group.getId(), inviter.getUniqueId(), target.getUniqueId());
+        final GroupSettings targetSettings = getGroupSettings(target.getUniqueId());
+        if (targetSettings.isAutoAcceptInvites()) {
+            acceptInvitation(target, inviter.getName());
+            inviter.sendMessage("§a" + target.getName() + " a rejoint automatiquement votre groupe !");
+            target.sendMessage("§aInvitation de §6" + inviter.getName() + " §aacceptée automatiquement.");
+            target.playSound(target.getLocation(), Sound.UI_TOAST_IN, 1.0f, 1.2f);
+            return;
+        }
         inviter.sendMessage("§aInvitation envoyée à §6" + target.getName() + "§a !");
         target.sendMessage("§e" + inviter.getName() + " §avous a invité à rejoindre son groupe !");
         target.sendMessage("§7Groupe: §f" + group.getDisplayName() + " §7(" + group.getSize() + "/" + group.getMaxSize() + ")");
@@ -262,6 +306,93 @@ public class GroupManager {
             cacheGroup(group);
         }
         return group;
+    }
+
+    private void updateSettings(final UUID uuid, final GroupSettings settings) {
+        final String query;
+        if (databaseManager.getDatabaseType() == DatabaseManager.DatabaseType.MYSQL) {
+            query = "INSERT INTO group_settings (player_uuid, auto_accept, visibility) VALUES (?, ?, ?) "
+                    + "ON DUPLICATE KEY UPDATE auto_accept = VALUES(auto_accept), visibility = VALUES(visibility)";
+        } else {
+            query = "INSERT INTO group_settings (player_uuid, auto_accept, visibility) VALUES (?, ?, ?) "
+                    + "ON CONFLICT(player_uuid) DO UPDATE SET auto_accept = excluded.auto_accept, "
+                    + "visibility = excluded.visibility";
+        }
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, uuid.toString());
+            statement.setBoolean(2, settings.isAutoAcceptInvites());
+            statement.setString(3, settings.getVisibility().toDatabase());
+            statement.executeUpdate();
+            settingsCache.put(uuid, settings);
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to update group settings for " + uuid, exception);
+        }
+    }
+
+    private GroupSettings loadSettings(final UUID uuid) {
+        final String query = "SELECT * FROM group_settings WHERE player_uuid = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, uuid.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    final ResultSetMetaData metaData = resultSet.getMetaData();
+                    final boolean autoAccept = getBoolean(resultSet, metaData, "auto_accept", false);
+                    final String visibilityRaw = getString(resultSet, metaData, "visibility");
+                    return new GroupSettings(autoAccept, GroupVisibility.fromDatabase(visibilityRaw));
+                }
+            }
+            insertDefaultSettings(uuid, connection);
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to load group settings for " + uuid, exception);
+        }
+        return new GroupSettings(false, GroupVisibility.PUBLIC);
+    }
+
+    private void insertDefaultSettings(final UUID uuid, final Connection connection) throws SQLException {
+        final String query = "INSERT INTO group_settings (player_uuid, auto_accept, visibility) VALUES (?, 0, 'PUBLIC')";
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, uuid.toString());
+            statement.executeUpdate();
+        }
+    }
+
+    private boolean getBoolean(final ResultSet resultSet, final ResultSetMetaData metaData,
+                               final String column, final boolean defaultValue) throws SQLException {
+        if (!hasColumn(metaData, column)) {
+            return defaultValue;
+        }
+        return resultSet.getBoolean(column);
+    }
+
+    private String getString(final ResultSet resultSet, final ResultSetMetaData metaData,
+                             final String column) throws SQLException {
+        if (!hasColumn(metaData, column)) {
+            return null;
+        }
+        return resultSet.getString(column);
+    }
+
+    private boolean hasColumn(final ResultSetMetaData metaData, final String column) throws SQLException {
+        final int count = metaData.getColumnCount();
+        for (int index = 1; index <= count; index++) {
+            if (column.equalsIgnoreCase(metaData.getColumnName(index))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String formatVisibility(final GroupVisibility visibility) {
+        if (visibility == null) {
+            return "Public";
+        }
+        return switch (visibility) {
+            case PUBLIC -> "Public";
+            case FRIENDS_ONLY -> "Amis uniquement";
+            case INVITE_ONLY -> "Sur invitation";
+        };
     }
 
     private void cacheGroup(final Group group) {

--- a/src/main/java/com/lobby/social/groups/GroupSettings.java
+++ b/src/main/java/com/lobby/social/groups/GroupSettings.java
@@ -1,0 +1,20 @@
+package com.lobby.social.groups;
+
+public class GroupSettings {
+
+    private final boolean autoAcceptInvites;
+    private final GroupVisibility visibility;
+
+    public GroupSettings(final boolean autoAcceptInvites, final GroupVisibility visibility) {
+        this.autoAcceptInvites = autoAcceptInvites;
+        this.visibility = visibility == null ? GroupVisibility.PUBLIC : visibility;
+    }
+
+    public boolean isAutoAcceptInvites() {
+        return autoAcceptInvites;
+    }
+
+    public GroupVisibility getVisibility() {
+        return visibility;
+    }
+}

--- a/src/main/java/com/lobby/social/groups/GroupVisibility.java
+++ b/src/main/java/com/lobby/social/groups/GroupVisibility.java
@@ -1,0 +1,22 @@
+package com.lobby.social.groups;
+
+public enum GroupVisibility {
+    PUBLIC,
+    FRIENDS_ONLY,
+    INVITE_ONLY;
+
+    public static GroupVisibility fromDatabase(final String value) {
+        if (value == null || value.isBlank()) {
+            return PUBLIC;
+        }
+        try {
+            return GroupVisibility.valueOf(value.toUpperCase());
+        } catch (final IllegalArgumentException exception) {
+            return PUBLIC;
+        }
+    }
+
+    public String toDatabase() {
+        return name();
+    }
+}

--- a/src/main/java/com/lobby/social/menus/ClanMenus.java
+++ b/src/main/java/com/lobby/social/menus/ClanMenus.java
@@ -1,9 +1,11 @@
 package com.lobby.social.menus;
 
 import com.lobby.LobbyPlugin;
+import com.lobby.menus.MenuManager;
 import com.lobby.social.clans.Clan;
 import com.lobby.social.clans.ClanManager;
 import com.lobby.social.clans.ClanMember;
+import com.lobby.social.clans.ClanPermission;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -14,7 +16,11 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class ClanMenus {
 
@@ -23,6 +29,8 @@ public final class ClanMenus {
     public static final int INVITE_SLOT = 46;
     public static final int DEPOSIT_SLOT = 20;
     public static final int WITHDRAW_SLOT = 24;
+
+    private static final Map<UUID, Map<Integer, UUID>> MEMBER_SLOT_CACHE = new ConcurrentHashMap<>();
 
     private ClanMenus() {
     }
@@ -43,6 +51,7 @@ public final class ClanMenus {
         setupRedBorders(menu);
 
         final List<ClanMember> members = clanManager.getClanMembers(clan.getId());
+        final Map<Integer, UUID> slotMap = new HashMap<>();
         int slot = 10;
         for (ClanMember member : members) {
             if (slot >= 44) {
@@ -50,8 +59,11 @@ public final class ClanMenus {
             }
             final ItemStack item = createClanMemberItem(member);
             menu.setItem(slot, item);
+            slotMap.put(slot, member.getUuid());
             slot = nextContentSlot(slot);
         }
+
+        MEMBER_SLOT_CACHE.put(player.getUniqueId(), slotMap);
 
         if (clanManager.hasPermission(clan.getId(), player.getUniqueId(), "clan.invite")) {
             menu.setItem(INVITE_SLOT, createInviteItem());
@@ -120,6 +132,62 @@ public final class ClanMenus {
         player.openInventory(menu);
     }
 
+    public static void openMemberPermissionsMenu(final Player player, final UUID memberUuid) {
+        if (player == null || memberUuid == null) {
+            return;
+        }
+        final LobbyPlugin plugin = LobbyPlugin.getInstance();
+        if (plugin == null) {
+            return;
+        }
+        final ClanManager clanManager = plugin.getClanManager();
+        final MenuManager menuManager = plugin.getMenuManager();
+        if (clanManager == null || menuManager == null) {
+            return;
+        }
+        final Clan clan = clanManager.getPlayerClan(player.getUniqueId());
+        if (clan == null) {
+            player.sendMessage("§cVous n'êtes dans aucun clan!");
+            return;
+        }
+        if (!clan.hasPermission(player.getUniqueId(), ClanPermission.MANAGE_RANKS)
+                && !clan.isLeader(player.getUniqueId())) {
+            player.sendMessage("§cVous n'avez pas la permission de gérer les rangs.");
+            return;
+        }
+        if (clan.isLeader(memberUuid)) {
+            player.sendMessage("§cVous ne pouvez pas modifier les permissions du chef de clan.");
+            return;
+        }
+        final ClanMember member = clan.getMember(memberUuid);
+        if (member == null) {
+            player.sendMessage("§cMembre introuvable.");
+            return;
+        }
+        final var placeholderManager = plugin.getSocialPlaceholderManager();
+        if (placeholderManager != null) {
+            placeholderManager.setClanPermissionTarget(player.getUniqueId(), memberUuid);
+        }
+        menuManager.openMenu(player, "clan_member_permissions_menu");
+    }
+
+    public static UUID getMemberAtSlot(final UUID viewerUuid, final int slot) {
+        if (viewerUuid == null || slot < 0) {
+            return null;
+        }
+        final Map<Integer, UUID> mapping = MEMBER_SLOT_CACHE.get(viewerUuid);
+        if (mapping == null) {
+            return null;
+        }
+        return mapping.get(slot);
+    }
+
+    public static void clearMemberCache(final UUID viewerUuid) {
+        if (viewerUuid != null) {
+            MEMBER_SLOT_CACHE.remove(viewerUuid);
+        }
+    }
+
     private static ItemStack createClanMemberItem(final ClanMember member) {
         final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(member.getUuid());
         final String name = offlinePlayer.getName() != null ? offlinePlayer.getName() : member.getUuid().toString();
@@ -130,7 +198,9 @@ public final class ClanMenus {
             meta.setDisplayName("§e" + name);
             meta.setLore(Arrays.asList(
                     "§7Rang: §f" + member.getRankName(),
-                    "§7Contributions: §b" + member.getTotalContributions()
+                    "§7Contributions: §b" + member.getTotalContributions(),
+                    "§r",
+                    "§8▶ §7Cliquez pour gérer les permissions"
             ));
             item.setItemMeta(meta);
         }

--- a/src/main/java/com/lobby/social/menus/MenuClickHandler.java
+++ b/src/main/java/com/lobby/social/menus/MenuClickHandler.java
@@ -4,8 +4,10 @@ import com.lobby.LobbyPlugin;
 import com.lobby.menus.MenuManager;
 import com.lobby.social.ChatInputManager;
 import com.lobby.social.clans.ClanManager;
+import com.lobby.social.groups.GroupManager;
 import com.lobby.social.friends.FriendManager;
 import com.lobby.social.friends.FriendRequest;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -15,18 +17,24 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
 
 import java.util.Objects;
+import java.util.UUID;
 
 public final class MenuClickHandler implements Listener {
+
+    private static final String FRIEND_SETTINGS_TITLE = "§8» §dParamètres d'Amis";
+    private static final String GROUP_SETTINGS_TITLE = "§8» §eParamètres de Groupe";
 
     private final LobbyPlugin plugin;
     private final MenuManager menuManager;
     private final FriendManager friendManager;
+    private final GroupManager groupManager;
     private final ClanManager clanManager;
 
     public MenuClickHandler(final LobbyPlugin plugin) {
         this.plugin = plugin;
         this.menuManager = plugin.getMenuManager();
         this.friendManager = plugin.getFriendManager();
+        this.groupManager = plugin.getGroupManager();
         this.clanManager = plugin.getClanManager();
     }
 
@@ -35,18 +43,27 @@ public final class MenuClickHandler implements Listener {
         if (!(event.getWhoClicked() instanceof Player player)) {
             return;
         }
+        final String title = event.getView().getTitle();
+        if (title.contains("»")) {
+            event.setCancelled(true);
+        }
+        if (FRIEND_SETTINGS_TITLE.equals(title)) {
+            handleFriendSettings(event, player);
+            return;
+        }
+        if (GROUP_SETTINGS_TITLE.equals(title)) {
+            handleGroupSettings(event, player);
+            return;
+        }
         final Inventory inventory = event.getView().getTopInventory();
         if (!Objects.equals(inventory, event.getClickedInventory())) {
             return;
         }
-        final String title = event.getView().getTitle();
         if (isFriendsMenuTitle(title)) {
-            event.setCancelled(true);
             handleFriendsMenuClick(player, title, event.getSlot(), event.getClick());
             return;
         }
         if (isClanMenuTitle(title)) {
-            event.setCancelled(true);
             handleClanMenuClick(player, title, event.getSlot());
         }
     }
@@ -59,6 +76,19 @@ public final class MenuClickHandler implements Listener {
         final String title = event.getView().getTitle();
         if (isFriendsMenuTitle(title)) {
             FriendsMenus.clearRequestCache(player.getUniqueId());
+        }
+        final var placeholderManager = plugin.getSocialPlaceholderManager();
+        if (ClanMenus.CLAN_MEMBERS_TITLE.equals(title)) {
+            ClanMenus.clearMemberCache(player.getUniqueId());
+            if (placeholderManager != null) {
+                placeholderManager.clearClanPermissionTarget(player.getUniqueId());
+            }
+            return;
+        }
+        if (title.startsWith("§8» §cPermissions")) {
+            if (placeholderManager != null) {
+                placeholderManager.clearClanPermissionTarget(player.getUniqueId());
+            }
         }
     }
 
@@ -89,6 +119,30 @@ public final class MenuClickHandler implements Listener {
         }
     }
 
+    private void handleFriendSettings(final InventoryClickEvent event, final Player player) {
+        switch (event.getSlot()) {
+            case 19 -> cycleFriendRequests(player);
+            case 21 -> toggleFriendNotifications(player);
+            case 23 -> cycleFriendVisibility(player);
+            case 25 -> toggleAutoFavorites(player);
+            case 31 -> togglePrivateMessages(player);
+            case 49 -> reopenMenu(player, "friends_menu");
+            default -> {
+            }
+        }
+    }
+
+    private void handleGroupSettings(final InventoryClickEvent event, final Player player) {
+        switch (event.getSlot()) {
+            case 19 -> toggleGroupAutoAccept(player);
+            case 21 -> cycleGroupVisibility(player);
+            case 23 -> reopenMenu(player, "group_manage_menu");
+            case 49 -> reopenMenu(player, "groups_menu");
+            default -> {
+            }
+        }
+    }
+
     private void handleClanMenuClick(final Player player, final String title, final int slot) {
         if (slot < 0) {
             return;
@@ -100,6 +154,11 @@ public final class MenuClickHandler implements Listener {
         if (ClanMenus.CLAN_MEMBERS_TITLE.equals(title)) {
             if (slot == ClanMenus.INVITE_SLOT) {
                 ChatInputManager.startClanInviteFlow(player);
+                return;
+            }
+            final UUID target = ClanMenus.getMemberAtSlot(player.getUniqueId(), slot);
+            if (target != null) {
+                ClanMenus.openMemberPermissionsMenu(player, target);
             }
             return;
         }
@@ -172,6 +231,73 @@ public final class MenuClickHandler implements Listener {
         if (menuManager != null) {
             menuManager.openMenu(player, menuId);
         }
+    }
+
+    private void cycleFriendRequests(final Player player) {
+        final String mode = friendManager.cycleRequestAcceptance(player.getUniqueId());
+        player.sendMessage("§aDemandes d'amis: §f" + mode);
+        reopenMenu(player, "friend_settings_menu");
+    }
+
+    private void toggleFriendNotifications(final Player player) {
+        final boolean enabled = friendManager.toggleNotifications(player.getUniqueId());
+        player.sendMessage(enabled
+                ? "§aNotifications d'amis activées"
+                : "§cNotifications d'amis désactivées");
+        reopenMenu(player, "friend_settings_menu");
+    }
+
+    private void cycleFriendVisibility(final Player player) {
+        final String visibility = friendManager.cycleFriendVisibility(player.getUniqueId());
+        player.sendMessage("§aVisibilité: §f" + visibility);
+        reopenMenu(player, "friend_settings_menu");
+    }
+
+    private void toggleAutoFavorites(final Player player) {
+        final boolean enabled = friendManager.toggleAutoAcceptFavorites(player.getUniqueId());
+        player.sendMessage(enabled
+                ? "§aAcceptation auto des favoris activée"
+                : "§cAcceptation auto des favoris désactivée");
+        reopenMenu(player, "friend_settings_menu");
+    }
+
+    private void togglePrivateMessages(final Player player) {
+        final boolean enabled = friendManager.togglePrivateMessages(player.getUniqueId());
+        player.sendMessage(enabled
+                ? "§aMessages privés autorisés"
+                : "§cMessages privés désactivés");
+        reopenMenu(player, "friend_settings_menu");
+    }
+
+    private void toggleGroupAutoAccept(final Player player) {
+        if (groupManager == null) {
+            return;
+        }
+        final boolean enabled = groupManager.toggleAutoAccept(player.getUniqueId());
+        player.sendMessage(enabled
+                ? "§aInvitations automatiques activées"
+                : "§cInvitations automatiques désactivées");
+        reopenMenu(player, "group_settings_menu");
+    }
+
+    private void cycleGroupVisibility(final Player player) {
+        if (groupManager == null) {
+            return;
+        }
+        final String visibility = groupManager.cycleGroupVisibility(player.getUniqueId());
+        player.sendMessage("§aVisibilité du groupe: §f" + visibility);
+        reopenMenu(player, "group_settings_menu");
+    }
+
+    private void reopenMenu(final Player player, final String menuId) {
+        if (menuManager == null || player == null) {
+            return;
+        }
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            if (player.isOnline()) {
+                menuManager.openMenu(player, menuId);
+            }
+        });
     }
 
     private boolean isFriendsMenuTitle(final String title) {

--- a/src/main/resources/config/menus.yml
+++ b/src/main/resources/config/menus.yml
@@ -977,27 +977,583 @@ menus:
           - "[CLOSE]"
 
   friends_all_menu:
-    title: "&8» &b&lTous mes Amis"
-    size: 27
+    title: "&8» &aMes Amis"
+    size: 54
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+        material: "GREEN_STAINED_GLASS_PANE"
+        name: "&7"
     items:
-      summary:
-        slot: 13
-        material: BOOK
-        name: "&bRésumé des amis"
+      overview:
+        slot: 22
+        material: "PLAYER_HEAD"
+        head: "hdb:8971"
+        name: "&a&lVue d'ensemble"
         lore:
-          - "&7Total: &a%friends_total%"
-          - "&7Favoris: &6%friends_favorites_count%"
-          - "&7Dernier connecté: %friends_last_seen%"
+          - "&7Amis au total: &f%friends_total_count%"
+          - "&7Slots libres: &f%friends_free_slots%"
+          - "&7Dernier ami vu: &f%friends_last_seen%"
+          - "&r"
+          - "&8▶ &7Utilisez ce menu pour consulter vos amis"
+      online_friends:
+        slot: 20
+        material: "PLAYER_HEAD"
+        head: "hdb:7439"
+        name: "&b&lAmis en ligne"
+        lore:
+          - "&7Connectés: &a%friends_online_count%/&f%friends_total_count%"
+          - "&7Serveurs populaires: &f%friends_popular_servers%"
+          - "&r"
+          - "&8▶ &7Cliquez pour rafraîchir la liste"
+        actions:
+          - "[FRIENDS_ONLINE]"
+      favorites:
+        slot: 24
+        material: "PLAYER_HEAD"
+        head: "hdb:12654"
+        name: "&e&lAmis favoris"
+        lore:
+          - "&7Favoris enregistrés: &f%friends_favorites_count%"
+          - "&7Demande auto: &f%friend_auto_favorites_status%"
+          - "&r"
+          - "&8▶ &7Afficher la liste des favoris"
+        actions:
+          - "[MENU] friends_favorites_menu"
+      requests_info:
+        slot: 31
+        material: "PLAYER_HEAD"
+        head: "hdb:3581"
+        name: "&d&lDemandes en attente"
+        lore:
+          - "&7Reçues: &f%friend_requests_received%"
+          - "&7Envoyées: &f%friend_requests_sent%"
+          - "&7Plus ancienne: &f%friend_requests_oldest%"
+          - "&r"
+          - "&8▶ &7Gérer les demandes"
+        actions:
+          - "[FRIEND_REQUESTS]"
+      settings:
+        slot: 49
+        material: "PLAYER_HEAD"
+        head: "hdb:8537"
+        name: "&d&lParamètres"
+        lore:
+          - "&7Configurer vos préférences sociales"
+          - "&r"
+          - "&8▶ &7Ouvrir les paramètres d'amis"
+        actions:
+          - "[MENU] friend_settings_menu"
       back:
-        slot: 18
-        material: ARROW
-        name: "&aRetour"
+        slot: 45
+        material: "PLAYER_HEAD"
+        head: "hdb:9334"
+        name: "&a&lRetour"
         lore:
-          - "&7Retour à la gestion des amis"
+          - "&7Retourner au menu principal des amis"
         actions:
           - "[MENU] friends_menu"
       close:
-        slot: 26
+        slot: 53
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  clan_member_permissions_menu:
+    title: "&8» &cPermissions de %clan_target_name%"
+    size: 54
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+        material: "RED_STAINED_GLASS_PANE"
+        name: "&7"
+    items:
+      target_overview:
+        slot: 4
+        material: "PLAYER_HEAD"
+        head: "%clan_target_name%"
+        name: "&c&l%clan_target_name%"
+        lore:
+          - "&7Rang actuel: &f%clan_target_rank%"
+          - "&7Permissions actives: &f%clan_target_permissions%"
+          - "&r"
+          - "&8▶ &7Sélectionnez une permission à basculer"
+      permission_invite:
+        slot: 19
+        material: "PLAYER_HEAD"
+        head: "hdb:7439"
+        name: "&a&lInviter des joueurs"
+        lore:
+          - "&7Autorise l'envoi d'invitations."
+          - "&r"
+          - "&8▸ &7Statut: %clan_permission_invite_status%"
+          - "&r"
+          - "&a▶ Basculer"
+        actions:
+          - "[TOGGLE_MEMBER_PERMISSION] %clan_target_uuid%|clan.invite|clan_member_permissions_menu"
+      permission_kick:
+        slot: 20
+        material: "PLAYER_HEAD"
+        head: "hdb:60776"
+        name: "&c&lExclure des membres"
+        lore:
+          - "&7Autorise l'exclusion de membres."
+          - "&r"
+          - "&8▸ &7Statut: %clan_permission_kick_status%"
+          - "&r"
+          - "&c▶ Basculer"
+        actions:
+          - "[TOGGLE_MEMBER_PERMISSION] %clan_target_uuid%|clan.kick|clan_member_permissions_menu"
+      permission_promote:
+        slot: 21
+        material: "PLAYER_HEAD"
+        head: "hdb:1455"
+        name: "&e&lPromouvoir"
+        lore:
+          - "&7Autorise la promotion de membres."
+          - "&r"
+          - "&8▸ &7Statut: %clan_permission_promote_status%"
+          - "&r"
+          - "&e▶ Basculer"
+        actions:
+          - "[TOGGLE_MEMBER_PERMISSION] %clan_target_uuid%|clan.promote|clan_member_permissions_menu"
+      permission_demote:
+        slot: 23
+        material: "PLAYER_HEAD"
+        head: "hdb:1218"
+        name: "&6&lRétrograder"
+        lore:
+          - "&7Autorise la rétrogradation de membres."
+          - "&r"
+          - "&8▸ &7Statut: %clan_permission_demote_status%"
+          - "&r"
+          - "&6▶ Basculer"
+        actions:
+          - "[TOGGLE_MEMBER_PERMISSION] %clan_target_uuid%|clan.demote|clan_member_permissions_menu"
+      permission_manage_ranks:
+        slot: 24
+        material: "PLAYER_HEAD"
+        head: "hdb:38878"
+        name: "&d&lGestion des rangs"
+        lore:
+          - "&7Autorise la modification des rangs."
+          - "&r"
+          - "&8▸ &7Statut: %clan_permission_manage_ranks_status%"
+          - "&r"
+          - "&d▶ Basculer"
+        actions:
+          - "[TOGGLE_MEMBER_PERMISSION] %clan_target_uuid%|clan.manage_ranks|clan_member_permissions_menu"
+      permission_bank:
+        slot: 25
+        material: "PLAYER_HEAD"
+        head: "hdb:35472"
+        name: "&b&lGestion de la banque"
+        lore:
+          - "&7Autorise les retraits du trésor."
+          - "&r"
+          - "&8▸ &7Statut: %clan_permission_withdraw_status%"
+          - "&r"
+          - "&b▶ Basculer"
+        actions:
+          - "[TOGGLE_MEMBER_PERMISSION] %clan_target_uuid%|clan.manage_bank|clan_member_permissions_menu"
+      permission_disband:
+        slot: 31
+        material: "PLAYER_HEAD"
+        head: "hdb:60776"
+        name: "&4&lDissolution"
+        lore:
+          - "&7Autorise la suppression du clan."
+          - "&7À n'accorder qu'aux dirigeants dignes de confiance."
+          - "&r"
+          - "&8▸ &7Statut: %clan_permission_disband_status%"
+          - "&r"
+          - "&4▶ Basculer"
+        actions:
+          - "[TOGGLE_MEMBER_PERMISSION] %clan_target_uuid%|clan.disband|clan_member_permissions_menu"
+      preset_default:
+        slot: 37
+        material: "PLAYER_HEAD"
+        head: "hdb:8971"
+        name: "&7&lPreset - Défaut"
+        lore:
+          - "&7Réinitialise les permissions au rang."
+          - "&r"
+          - "&8▶ &7Appliquer le preset"
+        actions:
+          - "[APPLY_MEMBER_PERMISSION_PRESET] %clan_target_uuid%|default|clan_member_permissions_menu"
+      preset_moderator:
+        slot: 38
+        material: "PLAYER_HEAD"
+        head: "hdb:1455"
+        name: "&a&lPreset - Modérateur"
+        lore:
+          - "&7Inviter et exclure des membres."
+          - "&r"
+          - "&8▶ &7Appliquer le preset"
+        actions:
+          - "[APPLY_MEMBER_PERMISSION_PRESET] %clan_target_uuid%|moderateur|clan_member_permissions_menu"
+      preset_officer:
+        slot: 39
+        material: "PLAYER_HEAD"
+        head: "hdb:7439"
+        name: "&e&lPreset - Officier"
+        lore:
+          - "&7Accès complet aux promotions/dégradations."
+          - "&r"
+          - "&8▶ &7Appliquer le preset"
+        actions:
+          - "[APPLY_MEMBER_PERMISSION_PRESET] %clan_target_uuid%|officier|clan_member_permissions_menu"
+      preset_manager:
+        slot: 40
+        material: "PLAYER_HEAD"
+        head: "hdb:23022"
+        name: "&6&lPreset - Gestion"
+        lore:
+          - "&7Inclut l'accès à la banque du clan."
+          - "&r"
+          - "&8▶ &7Appliquer le preset"
+        actions:
+          - "[APPLY_MEMBER_PERMISSION_PRESET] %clan_target_uuid%|gestion|clan_member_permissions_menu"
+      preset_admin:
+        slot: 41
+        material: "PLAYER_HEAD"
+        head: "hdb:38878"
+        name: "&c&lPreset - Administrateur"
+        lore:
+          - "&7Octroie toutes les permissions disponibles."
+          - "&r"
+          - "&8▶ &7Appliquer le preset"
+        actions:
+          - "[APPLY_MEMBER_PERMISSION_PRESET] %clan_target_uuid%|admin|clan_member_permissions_menu"
+      back:
+        slot: 45
+        material: "PLAYER_HEAD"
+        head: "hdb:9334"
+        name: "&a&lRetour"
+        lore:
+          - "&7Retourner à la liste des membres"
+        actions:
+          - "[CLAN_MEMBERS]"
+      close:
+        slot: 53
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  clan_creation_menu:
+    title: "&8» &cCréation de Clan"
+    size: 54
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+        material: "RED_STAINED_GLASS_PANE"
+        name: "&7"
+    items:
+      overview:
+        slot: 22
+        material: "PLAYER_HEAD"
+        head: "hdb:12654"
+        name: "&c&lCréer votre clan"
+        lore:
+          - "&7Coût: &e10 000 coins"
+          - "&7Taille initiale: &a20 membres"
+          - "&7Accès: &fCoffre, guerres, salon privé"
+          - "&r"
+          - "&8▶ &7Utilisez les options ci-dessous"
+      start_creation:
+        slot: 20
+        material: "PLAYER_HEAD"
+        head: "hdb:7439"
+        name: "&a&lCréer maintenant"
+        lore:
+          - "&7Lance le processus de création."
+          - "&7Vous serez invité à entrer un nom."
+          - "&r"
+          - "&a▶ Cliquez pour commencer"
+        actions:
+          - "[PLAYER_COMMAND] clan create"
+      requirements:
+        slot: 24
+        material: "PLAYER_HEAD"
+        head: "hdb:1455"
+        name: "&e&lConditions"
+        lore:
+          - "&7Avoir suffisamment de coins."
+          - "&7Être sans clan actuellement."
+          - "&7Respecter les règles du serveur."
+      back:
+        slot: 45
+        material: "PLAYER_HEAD"
+        head: "hdb:9334"
+        name: "&a&lRetour"
+        lore:
+          - "&7Retourner au menu de clan"
+        actions:
+          - "[MENU] clan_menu"
+      close:
+        slot: 53
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  clan_shop_menu:
+    title: "&8» &cBoutique de Clan"
+    size: 54
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+        material: "RED_STAINED_GLASS_PANE"
+        name: "&7"
+    items:
+      treasury:
+        slot: 22
+        material: "PLAYER_HEAD"
+        head: "hdb:35472"
+        name: "&6&lTrésor du clan"
+        lore:
+          - "&7Solde actuel: &e%clan_coins% coins"
+          - "&7Points de clan: &b%clan_points%"
+          - "&r"
+          - "&8▶ &7Sélectionnez une option d'amélioration"
+      upgrade_level:
+        slot: 20
+        material: "PLAYER_HEAD"
+        head: "hdb:38878"
+        name: "&a&lAméliorer le niveau"
+        lore:
+          - "&7Augmente les bonus de membres."
+          - "&7Coût variable selon le niveau."
+          - "&r"
+          - "&a▶ Cliquez pour demander une amélioration"
+        actions:
+          - "[MESSAGE] &eContactez un administrateur pour améliorer votre clan."
+      unlock_cosmetics:
+        slot: 24
+        material: "PLAYER_HEAD"
+        head: "hdb:23022"
+        name: "&d&lDébloquer cosmétiques"
+        lore:
+          - "&7Débloquez des décorations pour votre clan."
+          - "&7Fonctionnalité à venir."
+          - "&r"
+          - "&d▶ Recevoir une notification"
+        actions:
+          - "[MESSAGE] &cFonctionnalité prochainement disponible."
+      back:
+        slot: 45
+        material: "PLAYER_HEAD"
+        head: "hdb:9334"
+        name: "&a&lRetour"
+        lore:
+          - "&7Retourner au menu de clan"
+        actions:
+          - "[MENU] clan_menu"
+      close:
+        slot: 53
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  stats_detailed_menu:
+    title: "&8» &9Statistiques détaillées"
+    size: 54
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+        material: "BLUE_STAINED_GLASS_PANE"
+        name: "&7"
+    items:
+      profile_summary:
+        slot: 4
+        material: "PLAYER_HEAD"
+        head: "%player_name%"
+        name: "&b&lProfil de %player_name%"
+        lore:
+          - "&7Coins: &6%player_coins%"
+          - "&7Tokens: &d%player_tokens%"
+          - "&7Temps de jeu: &f%player_playtime%"
+      combat_stats:
+        slot: 20
+        material: "PLAYER_HEAD"
+        head: "hdb:60776"
+        name: "&c&lStatistiques PvP"
+        lore:
+          - "&7Victoires: &f%stats_pvp_wins%"
+          - "&7Défaites: &f%stats_pvp_losses%"
+          - "&7Ratio: &f%stats_pvp_ratio%"
+          - "&r"
+          - "&8▶ &7Consultation uniquement"
+      mini_games:
+        slot: 22
+        material: "PLAYER_HEAD"
+        head: "hdb:23022"
+        name: "&e&lMini-jeux"
+        lore:
+          - "&7BedWars: &f%stats_bedwars_wins% victoires"
+          - "&7SkyWars: &f%stats_skywars_wins% victoires"
+          - "&7Arcade: &f%stats_arcade_score% points"
+      achievements:
+        slot: 24
+        material: "PLAYER_HEAD"
+        head: "hdb:1455"
+        name: "&a&lSuccès"
+        lore:
+          - "&7Succès débloqués: &f%stats_achievements_unlocked%"
+          - "&7Succès restants: &f%stats_achievements_remaining%"
+      back:
+        slot: 45
+        material: "PLAYER_HEAD"
+        head: "hdb:9334"
+        name: "&a&lRetour"
+        lore:
+          - "&7Retourner au profil"
+        actions:
+          - "[MENU] profil_menu"
+      close:
+        slot: 53
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  language_menu:
+    title: "&8» &9Choix de la langue"
+    size: 54
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+        material: "BLUE_STAINED_GLASS_PANE"
+        name: "&7"
+    items:
+      language_info:
+        slot: 22
+        material: "PLAYER_HEAD"
+        head: "hdb:8971"
+        name: "&b&lLangue actuelle"
+        lore:
+          - "&7Langue: &f%player_language%"
+          - "&7Modifiez votre langue préférée ci-dessous."
+      language_fr:
+        slot: 20
+        material: "PLAYER_HEAD"
+        head: "hdb:1455"
+        name: "&e&lFrançais"
+        lore:
+          - "&7Interface et messages en français."
+          - "&r"
+          - "&e▶ Sélectionner"
+        actions:
+          - "[PLAYER_COMMAND] language fr"
+      language_en:
+        slot: 24
+        material: "PLAYER_HEAD"
+        head: "hdb:7439"
+        name: "&a&lEnglish"
+        lore:
+          - "&7Switch interface to English."
+          - "&r"
+          - "&a▶ Select"
+        actions:
+          - "[PLAYER_COMMAND] language en"
+      language_es:
+        slot: 30
+        material: "PLAYER_HEAD"
+        head: "hdb:23022"
+        name: "&6&lEspañol"
+        lore:
+          - "&7Activa la interfaz en español."
+          - "&r"
+          - "&6▶ Seleccionar"
+        actions:
+          - "[PLAYER_COMMAND] language es"
+      reset_language:
+        slot: 32
+        material: "PLAYER_HEAD"
+        head: "hdb:60776"
+        name: "&c&lRéinitialiser"
+        lore:
+          - "&7Revenir à la langue par défaut du serveur."
+          - "&r"
+          - "&c▶ Réinitialiser"
+        actions:
+          - "[PLAYER_COMMAND] language reset"
+      back:
+        slot: 45
+        material: "PLAYER_HEAD"
+        head: "hdb:9334"
+        name: "&a&lRetour"
+        lore:
+          - "&7Retourner au profil"
+        actions:
+          - "[MENU] profil_menu"
+      close:
+        slot: 53
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
+  daily_reward_menu:
+    title: "&8» &9Récompense quotidienne"
+    size: 54
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+        material: "BLUE_STAINED_GLASS_PANE"
+        name: "&7"
+    items:
+      reward_overview:
+        slot: 22
+        material: "PLAYER_HEAD"
+        head: "hdb:38878"
+        name: "&d&lRécompense du jour"
+        lore:
+          - "&7Prochaine récompense disponible dans: &f%daily_reward_cooldown%"
+          - "&7Récompense actuelle: &e%daily_reward_name%"
+          - "&7Bonus de série: &b%daily_reward_streak%"
+      claim_reward:
+        slot: 20
+        material: "PLAYER_HEAD"
+        head: "hdb:7439"
+        name: "&a&lRécupérer"
+        lore:
+          - "&7Cliquez pour recevoir votre récompense quotidienne."
+          - "&r"
+          - "&a▶ Réclamer"
+        actions:
+          - "[PLAYER_COMMAND] dailyreward claim"
+      premium_reward:
+        slot: 24
+        material: "PLAYER_HEAD"
+        head: "hdb:1455"
+        name: "&6&lRécompense premium"
+        lore:
+          - "&7Disponible avec un grade premium."
+          - "&7Bonus supplémentaires exclusifs."
+          - "&r"
+          - "&6▶ Découvrir"
+        actions:
+          - "[MESSAGE] &eObtenez un grade premium pour débloquer cette récompense !"
+      back:
+        slot: 45
+        material: "PLAYER_HEAD"
+        head: "hdb:9334"
+        name: "&a&lRetour"
+        lore:
+          - "&7Retourner au profil"
+        actions:
+          - "[MENU] profil_menu"
+      close:
+        slot: 53
         material: BARRIER
         name: "&cFermer"
         lore:
@@ -1007,89 +1563,112 @@ menus:
 
   friend_settings_menu:
     title: "&8» &dParamètres d'Amis"
-    size: 45
+    size: 54
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+        material: "GREEN_STAINED_GLASS_PANE"
+        name: "&7"
     items:
-      accept_requests:
-        slot: 11
-        material: PLAYER_HEAD
-        head: "hdb:3581"
-        name: "&a&lDemandes d'Amis"
+      summary:
+        slot: 4
+        material: "PLAYER_HEAD"
+        head: "hdb:1455"
+        name: "&d&lCentre de contrôle"
         lore:
-          - "&7Gérez qui peut vous envoyer"
+          - "&7Demandes: &f%friend_request_mode%"
+          - "&7Notifications: &f%friend_notifications_status%"
+          - "&7Visibilité: &f%friend_visibility_mode%"
+          - "&7Messages privés: &f%friend_private_messages_status%"
+      requests:
+        slot: 19
+        material: "PLAYER_HEAD"
+        head: "hdb:3581"
+        name: "&a&lDemandes d'amis"
+        lore:
+          - "&7Contrôlez qui peut vous envoyer"
           - "&7des demandes d'amitié."
           - "&r"
-          - "&8▸ &7Statut: %friend_auto_accept%"
+          - "&8▸ &7Mode actuel: &f%friend_auto_accept%"
           - "&r"
-          - "&a▶ Cliquez pour modifier!"
+          - "&a▶ Cliquez pour changer"
         actions:
-          - "[PLAYER_COMMAND] friend settings toggle requests"
+          - "[CYCLE_FRIEND_REQUESTS]"
       notifications:
-        slot: 13
-        material: PLAYER_HEAD
+        slot: 21
+        material: "PLAYER_HEAD"
         head: "hdb:1455"
         name: "&e&lNotifications"
         lore:
-          - "&7Activez/désactivez les notifications"
-          - "&7d'amis en ligne."
+          - "&7Activez ou désactivez les alertes"
+          - "&7lorsque vos amis se connectent."
           - "&r"
-          - "&8▸ &7Statut: %friend_notifications%"
+          - "&8▸ &7Statut: &f%friend_notifications_status%"
           - "&r"
-          - "&e▶ Cliquez pour basculer!"
+          - "&e▶ Basculer la notification"
         actions:
-          - "[PLAYER_COMMAND] friend settings toggle notifications"
+          - "[TOGGLE_FRIEND_NOTIFICATIONS]"
       visibility:
-        slot: 15
-        material: PLAYER_HEAD
+        slot: 23
+        material: "PLAYER_HEAD"
         head: "hdb:8537"
         name: "&b&lVisibilité"
         lore:
-          - "&7Contrôlez qui peut voir votre"
+          - "&7Choisissez qui peut voir votre"
           - "&7statut en ligne."
           - "&r"
-          - "&8▸ &7Mode: %friend_visibility%"
+          - "&8▸ &7Mode: &f%friend_visibility_mode%"
           - "&r"
-          - "&b▶ Cliquez pour changer!"
+          - "&b▶ Modifier la visibilité"
         actions:
-          - "[PLAYER_COMMAND] friend settings toggle visibility"
-      auto_accept_favorites:
-        slot: 22
-        material: PLAYER_HEAD
+          - "[CYCLE_FRIEND_VISIBILITY]"
+      auto_favorites:
+        slot: 25
+        material: "PLAYER_HEAD"
         head: "hdb:12654"
-        name: "&6&lAcceptation Auto Favoris"
+        name: "&6&lAuto favoris"
         lore:
           - "&7Acceptez automatiquement les"
-          - "&7demandes de vos amis favoris."
+          - "&7demandes de vos favoris."
           - "&r"
-          - "&8▸ &7Statut: %friend_auto_favorites%"
+          - "&8▸ &7Statut: &f%friend_auto_favorites_status%"
           - "&r"
-          - "&6▶ Cliquez pour basculer!"
+          - "&6▶ Basculer l'acceptation"
         actions:
-          - "[PLAYER_COMMAND] friend settings toggle favorites"
+          - "[TOGGLE_FRIEND_AUTO_FAVORITES]"
       private_messages:
-        slot: 24
-        material: PLAYER_HEAD
+        slot: 31
+        material: "PLAYER_HEAD"
         head: "hdb:2736"
-        name: "&d&lMessages Privés"
+        name: "&d&lMessages privés"
         lore:
-          - "&7Autorisez les messages privés"
-          - "&7de vos amis."
+          - "&7Autorisez vos amis à vous"
+          - "&7envoyer des messages privés."
           - "&r"
-          - "&8▸ &7Statut: &eFonctionnalité à venir"
+          - "&8▸ &7Statut: &f%friend_private_messages_status%"
           - "&r"
-          - "&d▶ Revenez bientôt!"
+          - "&d▶ Basculer les messages"
         actions:
-          - "[NONE]"
+          - "[TOGGLE_FRIEND_MESSAGES]"
       back:
-        slot: 40
-        material: PLAYER_HEAD
+        slot: 45
+        material: "PLAYER_HEAD"
         head: "hdb:9334"
         name: "&c&lRetour"
         lore:
           - "&7Retourner au menu des amis"
         actions:
           - "[MENU] friends_menu"
+      overview_menu:
+        slot: 49
+        material: "PLAYER_HEAD"
+        head: "hdb:9723"
+        name: "&a&lVoir mes amis"
+        lore:
+          - "&7Accédez à la liste complète de vos amis"
+        actions:
+          - "[MENU] friends_all_menu"
       close:
-        slot: 44
+        slot: 53
         material: BARRIER
         name: "&cFermer"
         lore:
@@ -1098,28 +1677,74 @@ menus:
           - "[CLOSE]"
 
   friends_favorites_menu:
-    title: "&8» &c&lAmis Favoris"
-    size: 27
+    title: "&8» &6Mes Favoris"
+    size: 54
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+        material: "GREEN_STAINED_GLASS_PANE"
+        name: "&7"
     items:
-      favorites_info:
-        slot: 13
-        material: PLAYER_HEAD
-        head: "%player_name%"
-        name: "&cFavoris"
+      favorites_overview:
+        slot: 22
+        material: "PLAYER_HEAD"
+        head: "hdb:12654"
+        name: "&6&lAmis favoris"
         lore:
-          - "&7Favoris marqués: &6%friends_favorites_count%"
-          - "&7Notifications prioritaires: %friend_notifications%"
-          - "&7Dernière activité: %friends_recent_activity%"
+          - "&7Favoris actuels: &f%friends_favorites_count%"
+          - "&7Notifications: &f%friend_notifications_status%"
+          - "&7Auto-acceptation: &f%friend_auto_favorites_status%"
+          - "&r"
+          - "&8▶ &7Cliquez pour retourner à la liste"
+        actions:
+          - "[MENU] friends_all_menu"
+      auto_accept:
+        slot: 20
+        material: "PLAYER_HEAD"
+        head: "hdb:3581"
+        name: "&a&lAcceptation automatique"
+        lore:
+          - "&7Activez l'ajout instantané"
+          - "&7des demandes provenant de vos favoris."
+          - "&r"
+          - "&8▸ &7Statut: &f%friend_auto_favorites_status%"
+          - "&r"
+          - "&a▶ Basculer la fonctionnalité"
+        actions:
+          - "[TOGGLE_FRIEND_AUTO_FAVORITES]"
+      notifications:
+        slot: 24
+        material: "PLAYER_HEAD"
+        head: "hdb:1455"
+        name: "&e&lAlertes favoris"
+        lore:
+          - "&7Recevez une notification dédiée"
+          - "&7lorsqu'un favori se connecte."
+          - "&r"
+          - "&8▸ &7Statut: &f%friend_notifications_status%"
+          - "&r"
+          - "&e▶ Basculer la notification"
+        actions:
+          - "[TOGGLE_FRIEND_NOTIFICATIONS]"
       back:
-        slot: 18
-        material: ARROW
-        name: "&aRetour"
+        slot: 45
+        material: "PLAYER_HEAD"
+        head: "hdb:9334"
+        name: "&a&lRetour"
         lore:
-          - "&7Retour à la gestion des amis"
+          - "&7Retourner au menu des amis"
         actions:
           - "[MENU] friends_menu"
+      settings:
+        slot: 49
+        material: "PLAYER_HEAD"
+        head: "hdb:8537"
+        name: "&d&lParamètres"
+        lore:
+          - "&7Configurer les préférences d'amis"
+        actions:
+          - "[MENU] friend_settings_menu"
       close:
-        slot: 26
+        slot: 53
         material: BARRIER
         name: "&cFermer"
         lore:
@@ -1128,29 +1753,78 @@ menus:
           - "[CLOSE]"
 
   group_manage_menu:
-    title: "&8» &e&lMon Groupe"
-    size: 27
+    title: "&8» &eMon Groupe"
+    size: 54
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+        material: "YELLOW_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       group_info:
-        slot: 13
-        material: PLAYER_HEAD
+        slot: 22
+        material: "PLAYER_HEAD"
         head: "hdb:9723"
-        name: "&eDétails du groupe"
+        name: "&e&lInformations"
         lore:
           - "&7Nom: &f%group_name%"
           - "&7Leader: &6%group_leader%"
           - "&7Membres: &a%group_members%/%group_max%"
-          - "&7Statut: %group_status%"
-      back:
-        slot: 18
-        material: ARROW
-        name: "&aRetour"
+          - "&7Statut: &f%group_status%"
+      invitations:
+        slot: 20
+        material: "PLAYER_HEAD"
+        head: "hdb:7439"
+        name: "&b&lInvitations"
         lore:
-          - "&7Retour à la gestion des groupes"
+          - "&7Invitations reçues: &f%group_invitations%"
+          - "&7Invitations envoyées: &f%group_invites_sent%"
+          - "&r"
+          - "&8▶ &7Ouvrir le menu d'invitations"
+        actions:
+          - "[MENU] group_invite_menu"
+      queue:
+        slot: 24
+        material: "PLAYER_HEAD"
+        head: "hdb:23022"
+        name: "&6&lFiles d'attente"
+        lore:
+          - "&7Files disponibles: &f%queue_available%"
+          - "&7Temps moyen: &f%queue_wait_time%"
+          - "&7Joueurs en file: &f%queue_players%"
+          - "&r"
+          - "&8▶ &7Choisir une file"
+        actions:
+          - "[MENU] queue_menu"
+      settings:
+        slot: 49
+        material: "PLAYER_HEAD"
+        head: "hdb:8537"
+        name: "&d&lParamètres"
+        lore:
+          - "&7Configurer les paramètres de groupe"
+        actions:
+          - "[MENU] group_settings_menu"
+      explore:
+        slot: 31
+        material: "PLAYER_HEAD"
+        head: "hdb:1218"
+        name: "&b&lExplorer"
+        lore:
+          - "&7Voir les groupes publics disponibles"
+          - "&7Groupes ouverts: &f%groups_open%"
+        actions:
+          - "[MENU] group_browse_menu"
+      back:
+        slot: 45
+        material: "PLAYER_HEAD"
+        head: "hdb:9334"
+        name: "&a&lRetour"
+        lore:
+          - "&7Revenir au menu principal"
         actions:
           - "[MENU] groups_menu"
       close:
-        slot: 26
+        slot: 53
         material: BARRIER
         name: "&cFermer"
         lore:
@@ -1159,27 +1833,61 @@ menus:
           - "[CLOSE]"
 
   group_browse_menu:
-    title: "&8» &b&lExplorer les Groupes"
-    size: 27
+    title: "&8» &bExplorer les Groupes"
+    size: 54
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+        material: "YELLOW_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       browse_info:
-        slot: 13
+        slot: 22
+        material: "PLAYER_HEAD"
+        head: "hdb:1218"
+        name: "&b&lGroupes ouverts"
+        lore:
+          - "&7Groupes ouverts: &f%groups_open%"
+          - "&7Groupes d'amis: &f%groups_friends%"
+          - "&7Invitations en attente: &f%group_invitations%"
+      search_tip:
+        slot: 20
         material: COMPASS
-        name: "&bGroupes disponibles"
+        name: "&e&lRecherche"
         lore:
-          - "&7Groupes ouverts: &a%groups_open%"
-          - "&7Groupes d'amis: &e%groups_friends%"
-          - "&7Invitations reçues: &b%group_invitations%"
+          - "&7Parcourez les groupes recommandés"
+          - "&7ou utilisez /group browse"
+      auto_join:
+        slot: 24
+        material: "PLAYER_HEAD"
+        head: "hdb:7439"
+        name: "&a&lRejoindre automatiquement"
+        lore:
+          - "&7Acceptez automatiquement les"
+          - "&7invitations si la fonction est active."
+          - "&r"
+          - "&8▸ &7Statut: &f%group_auto_accept%"
+        actions:
+          - "[TOGGLE_GROUP_AUTO_ACCEPT]"
       back:
-        slot: 18
-        material: ARROW
-        name: "&aRetour"
+        slot: 45
+        material: "PLAYER_HEAD"
+        head: "hdb:9334"
+        name: "&a&lRetour"
         lore:
-          - "&7Retour à la gestion des groupes"
+          - "&7Retourner au menu des groupes"
         actions:
           - "[MENU] groups_menu"
+      settings:
+        slot: 49
+        material: "PLAYER_HEAD"
+        head: "hdb:8537"
+        name: "&d&lParamètres"
+        lore:
+          - "&7Configurer vos préférences de groupe"
+        actions:
+          - "[MENU] group_settings_menu"
       close:
-        slot: 26
+        slot: 53
         material: BARRIER
         name: "&cFermer"
         lore:
@@ -1247,89 +1955,75 @@ menus:
 
   group_settings_menu:
     title: "&8» &eParamètres de Groupe"
-    size: 45
+    size: 54
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+        material: "YELLOW_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       auto_accept:
-        slot: 11
-        material: PLAYER_HEAD
+        slot: 19
+        material: "PLAYER_HEAD"
         head: "hdb:13389"
-        name: "&a&lAcceptation Automatique"
+        name: "&a&lAcceptation automatique"
         lore:
           - "&7Acceptez automatiquement les"
-          - "&7invitations de groupe d'amis."
+          - "&7invitations des joueurs de confiance."
           - "&r"
-          - "&8▸ &7Statut: %group_auto_accept%"
+          - "&8▸ &7Statut: &f%group_auto_accept%"
           - "&r"
-          - "&a▶ Bientôt disponible"
+          - "&a▶ Basculer"
         actions:
-          - "[NONE]"
-      preferred_gamemode:
-        slot: 13
-        material: PLAYER_HEAD
+          - "[TOGGLE_GROUP_AUTO_ACCEPT]"
+      preferred_mode:
+        slot: 21
+        material: "PLAYER_HEAD"
         head: "hdb:38878"
-        name: "&b&lMode de Jeu Préféré"
+        name: "&b&lMode de jeu préféré"
         lore:
-          - "&7Définissez votre mode de jeu"
-          - "&7préféré pour les groupes."
-          - "&r"
-          - "&8▸ &7Mode actuel: %group_preferred_mode%"
-          - "&r"
-          - "&b▶ Fonctionnalité à venir"
-        actions:
-          - "[NONE]"
+          - "&7Mode actuel: &f%group_preferred_mode%"
+          - "&7(à venir)"
       visibility:
-        slot: 15
-        material: PLAYER_HEAD
+        slot: 23
+        material: "PLAYER_HEAD"
         head: "hdb:7439"
-        name: "&d&lVisibilité du Groupe"
+        name: "&d&lVisibilité"
         lore:
-          - "&7Contrôlez si vos groupes"
-          - "&7sont publics ou privés."
+          - "&7Définissez la visibilité de votre groupe."
           - "&r"
-          - "&8▸ &7Mode: %group_visibility%"
+          - "&8▸ &7Mode: &f%group_visibility%"
           - "&r"
-          - "&d▶ Bientôt disponible"
+          - "&d▶ Changer la visibilité"
         actions:
-          - "[NONE]"
-      max_invites:
-        slot: 22
-        material: PLAYER_HEAD
-        head: "hdb:9969"
-        name: "&6&lLimite d'Invitations"
-        lore:
-          - "&7Nombre maximum d'invitations"
-          - "&7simultanées que vous pouvez avoir."
-          - "&r"
-          - "&8▸ &7Limite actuelle: %group_max%"
-          - "&r"
-          - "&6▶ Paramétrage prochainement"
-        actions:
-          - "[NONE]"
+          - "[CYCLE_GROUP_VISIBILITY]"
       notifications:
-        slot: 24
-        material: PLAYER_HEAD
+        slot: 25
+        material: "PLAYER_HEAD"
         head: "hdb:1455"
-        name: "&c&lNotifications de Groupe"
+        name: "&c&lNotifications"
         lore:
-          - "&7Recevez des notifications pour"
-          - "&7les invitations et événements."
-          - "&r"
-          - "&8▸ &7Statut: %group_status%"
-          - "&r"
-          - "&c▶ Gestion à venir"
-        actions:
-          - "[NONE]"
+          - "&7Alertes d'invitations: &f%group_status%"
+          - "&7(à venir)"
+      info:
+        slot: 31
+        material: "PLAYER_HEAD"
+        head: "hdb:9723"
+        name: "&e&lRésumé"
+        lore:
+          - "&7Groupe: &f%group_name%"
+          - "&7Leader: &6%group_leader%"
+          - "&7Membres: &a%group_members%/%group_max%"
       back:
-        slot: 40
-        material: PLAYER_HEAD
+        slot: 45
+        material: "PLAYER_HEAD"
         head: "hdb:9334"
-        name: "&c&lRetour"
+        name: "&a&lRetour"
         lore:
           - "&7Retourner au menu des groupes"
         actions:
           - "[MENU] groups_menu"
       close:
-        slot: 44
+        slot: 53
         material: BARRIER
         name: "&cFermer"
         lore:

--- a/src/main/resources/config/menus/clan_menu.yml
+++ b/src/main/resources/config/menus/clan_menu.yml
@@ -139,6 +139,19 @@ menu:
       actions:
         - "[CLAN_VAULT]"
 
+    clan_shop:
+      slot: 29
+      material: "PLAYER_HEAD"
+      head: "hdb:38878"
+      name: "&6&lBoutique du Clan"
+      lore:
+        - "&7Investissez les coins du clan"
+        - "&7dans des améliorations et cosmétiques."
+        - "&r"
+        - "&8▶ &7Ouvrir la boutique"
+      actions:
+        - "[MENU] clan_shop_menu"
+
     clan_wars:
       slot: 31
       material: "PLAYER_HEAD"
@@ -170,7 +183,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour créer !"
       actions:
-        - "[COMMAND] clan create"
+        - "[MENU] clan_creation_menu"
 
     clan_delete:
       slot: 33


### PR DESCRIPTION
## Summary
- wire NPC actions to clan permission toggles and presets while improving display names
- extend placeholder manager to track selected clan members and provide stats, language, and reward defaults
- add red and blue glass menu layouts for clan management, stats, languages, and rewards, including clan menu links

## Testing
- mvn test *(fails: Maven repository unreachable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d0223430fc8329bb3524dd2e5410e4