### PR TITLE
Fix default border material lookup in ConfiguredMenu

### DIFF
--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -265,7 +265,9 @@ public class ConfiguredMenu implements Menu {
     }
 
     private ItemStack createBorderItem(final Player player, final Map<?, ?> definition) {
-        final Object materialObject = definition.getOrDefault("material", "BLACK_STAINED_GLASS_PANE");
+        final Object materialObject = definition.containsKey("material")
+                ? definition.get("material")
+                : "BLACK_STAINED_GLASS_PANE";
         final String materialName = materialObject != null ? materialObject.toString() : "BLACK_STAINED_GLASS_PANE";
         final Material material = Material.matchMaterial(materialName);
         if (material == null) {


### PR DESCRIPTION
## Summary
- avoid using Map#getOrDefault with wildcard maps when building border items
- gracefully fall back to the default material when the border definition omits it

## Testing
- `mvn clean compile` *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d029b4cec0832987f639dcc4d88dd9