### PR TITLE
Add missing Timestamp import in GroupManager

### DIFF
--- a/src/main/java/com/lobby/social/groups/GroupManager.java
+++ b/src/main/java/com/lobby/social/groups/GroupManager.java
@@ -11,6 +11,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.sql.ResultSetMetaData;
 import java.util.HashMap;
 import java.util.Locale;


### PR DESCRIPTION
## Summary
- add the missing java.sql.Timestamp import to GroupManager to resolve compilation errors

## Testing
- mvn clean compile *(fails: unable to reach Maven Central from container)*

------
https://chatgpt.com/codex/tasks/task_e_68d02fdc23488329a6d9d2be066e588f