### PR TITLE
Normalize social interactions menus and clan management

### DIFF
--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -107,6 +107,26 @@ public class ActionProcessor {
             ClanMenus.openClanVaultMenu(player);
             return;
         }
+        if (trimmed.equalsIgnoreCase("[CLAN_PROMOTE_MEMBER]")) {
+            handleClanRankChange(player, true);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CLAN_DEMOTE_MEMBER]")) {
+            handleClanRankChange(player, false);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CLAN_KICK_MEMBER]")) {
+            handleClanRemoval(player, false);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CLAN_BAN_MEMBER]")) {
+            handleClanRemoval(player, true);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CLAN_TRANSFER_LEADERSHIP]")) {
+            handleClanLeadershipTransfer(player);
+            return;
+        }
         if (startsWithIgnoreCase(trimmed, "[TOGGLE_MEMBER_PERMISSION]")) {
             final String value = processed.substring("[TOGGLE_MEMBER_PERMISSION]".length()).trim();
             toggleMemberPermission(player, value);
@@ -442,6 +462,108 @@ public class ActionProcessor {
         reopenMenu(player, menuId);
     }
 
+    private void handleClanRankChange(final Player player, final boolean promote) {
+        if (player == null) {
+            return;
+        }
+        final ClanManager clanManager = plugin.getClanManager();
+        final var placeholderManager = plugin.getSocialPlaceholderManager();
+        if (clanManager == null || placeholderManager == null) {
+            player.sendMessage("§cAction indisponible pour le moment.");
+            return;
+        }
+        final UUID target = placeholderManager.getClanPermissionTarget(player.getUniqueId());
+        if (target == null) {
+            player.sendMessage("§cAucun membre sélectionné.");
+            return;
+        }
+        final boolean success = promote
+                ? clanManager.promotePlayer(player.getUniqueId(), target)
+                : clanManager.demotePlayer(player.getUniqueId(), target);
+        final String targetName = resolvePlayerName(target);
+        if (success) {
+            player.sendMessage(promote
+                    ? "§a" + targetName + " a été promu."
+                    : "§e" + targetName + " a été rétrogradé.");
+        } else {
+            player.sendMessage(promote
+                    ? "§cImpossible de promouvoir " + targetName + "."
+                    : "§cImpossible de rétrograder " + targetName + ".");
+        }
+        reopenClanManagementMenu(player);
+    }
+
+    private void handleClanRemoval(final Player player, final boolean ban) {
+        if (player == null) {
+            return;
+        }
+        final ClanManager clanManager = plugin.getClanManager();
+        final var placeholderManager = plugin.getSocialPlaceholderManager();
+        if (clanManager == null || placeholderManager == null) {
+            player.sendMessage("§cAction indisponible pour le moment.");
+            return;
+        }
+        final UUID target = placeholderManager.getClanPermissionTarget(player.getUniqueId());
+        if (target == null) {
+            player.sendMessage("§cAucun membre sélectionné.");
+            return;
+        }
+        final boolean success = ban
+                ? clanManager.banMember(player.getUniqueId(), target)
+                : clanManager.kickMember(player.getUniqueId(), target);
+        final String targetName = resolvePlayerName(target);
+        if (success) {
+            player.sendMessage(ban
+                    ? "§c" + targetName + " a été banni du clan."
+                    : "§c" + targetName + " a été expulsé du clan.");
+            placeholderManager.clearClanPermissionTarget(player.getUniqueId());
+            openClanMembersMenu(player);
+        } else {
+            player.sendMessage(ban
+                    ? "§cImpossible de bannir " + targetName + "."
+                    : "§cImpossible d'expulser " + targetName + ".");
+            reopenClanManagementMenu(player);
+        }
+    }
+
+    private void handleClanLeadershipTransfer(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final ClanManager clanManager = plugin.getClanManager();
+        final var placeholderManager = plugin.getSocialPlaceholderManager();
+        if (clanManager == null || placeholderManager == null) {
+            player.sendMessage("§cAction indisponible pour le moment.");
+            return;
+        }
+        final UUID target = placeholderManager.getClanPermissionTarget(player.getUniqueId());
+        if (target == null) {
+            player.sendMessage("§cAucun membre sélectionné.");
+            return;
+        }
+        final boolean success = clanManager.transferLeadership(player.getUniqueId(), target);
+        final String targetName = resolvePlayerName(target);
+        if (success) {
+            player.sendMessage("§aLe leadership a été transféré à §e" + targetName + "§a.");
+            placeholderManager.clearClanPermissionTarget(player.getUniqueId());
+            openClanMembersMenu(player);
+        } else {
+            player.sendMessage("§cImpossible de transférer le leadership à " + targetName + ".");
+            reopenClanManagementMenu(player);
+        }
+    }
+
+    private void reopenClanManagementMenu(final Player player) {
+        reopenMenu(player, "clan_member_management_menu");
+    }
+
+    private void openClanMembersMenu(final Player player) {
+        if (player == null) {
+            return;
+        }
+        Bukkit.getScheduler().runTask(plugin, () -> ClanMenus.openClanMembersMenu(player));
+    }
+
     private void reopenMenu(final Player player, final String menuId) {
         if (player == null || menuId == null || menuId.isBlank()) {
             return;
@@ -466,6 +588,19 @@ public class ActionProcessor {
         } catch (final IllegalArgumentException exception) {
             return null;
         }
+    }
+
+    private String resolvePlayerName(final UUID uuid) {
+        if (uuid == null) {
+            return "Inconnu";
+        }
+        final Player online = Bukkit.getPlayer(uuid);
+        if (online != null) {
+            return online.getName();
+        }
+        final var offline = Bukkit.getOfflinePlayer(uuid);
+        final String name = offline.getName();
+        return name != null ? name : uuid.toString();
     }
 
     private String formatPermissionName(final String permissionKey) {

--- a/src/main/java/com/lobby/social/SocialPlaceholderManager.java
+++ b/src/main/java/com/lobby/social/SocialPlaceholderManager.java
@@ -22,6 +22,8 @@ import org.bukkit.entity.Player;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +36,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class SocialPlaceholderManager {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")
+            .withLocale(Locale.FRENCH);
 
     private final LobbyPlugin plugin;
     private final Map<UUID, UUID> clanPermissionTargets = new ConcurrentHashMap<>();
@@ -382,10 +387,30 @@ public class SocialPlaceholderManager {
                 replacements.put("%clan_target_uuid%", targetUuid.toString());
                 replacements.put("%clan_target_name%", targetName);
                 replacements.put("%clan_target_rank%", target.getRankName());
+
+                final ClanRank targetRank = clan.getRank(target.getRankName());
+                replacements.put("%clan_target_rank_display%", targetRank != null
+                        ? targetRank.getDisplayName()
+                        : target.getRankName());
+                replacements.put("%clan_target_rank_priority%", String.valueOf(targetRank != null
+                        ? targetRank.getPriority()
+                        : 0));
+                replacements.put("%clan_target_join_date%", formatJoinDate(target.getJoinedAt()));
+                replacements.put("%clan_target_last_seen%", formatLastSeen(targetUuid));
+                replacements.put("%clan_target_contribution%", String.valueOf(target.getTotalContributions()));
+
                 final List<String> permissionList = clanManager.getMemberPermissions(targetUuid);
                 replacements.put("%clan_target_permissions%", permissionList.isEmpty()
                         ? "Aucune"
                         : String.join(", ", permissionList));
+                replacements.put("%clan_target_permissions_count%", String.valueOf(permissionList.size()));
+
+                final int rankPriority = targetRank != null ? targetRank.getPriority() : 0;
+                final ClanRank nextRank = targetRank != null ? clanManager.getNextRank(clan.getId(), rankPriority) : null;
+                final ClanRank previousRank = targetRank != null ? clanManager.getPreviousRank(clan.getId(), rankPriority) : null;
+                replacements.put("%clan_target_next_rank%", nextRank != null ? nextRank.getDisplayName() : "Aucun");
+                replacements.put("%clan_target_previous_rank%", previousRank != null ? previousRank.getDisplayName() : "Aucun");
+
                 replacements.put("%clan_permission_invite_status%", formatPermissionStatus(
                         clan.hasPermission(targetUuid, ClanPermission.INVITE)));
                 replacements.put("%clan_permission_kick_status%", formatPermissionStatus(
@@ -400,6 +425,28 @@ public class SocialPlaceholderManager {
                         clan.hasPermission(targetUuid, ClanPermission.MANAGE_BANK)));
                 replacements.put("%clan_permission_disband_status%", formatPermissionStatus(
                         clan.hasPermission(targetUuid, ClanPermission.DISBAND)));
+
+                final boolean isSelf = player.getUniqueId().equals(targetUuid);
+                final boolean targetIsLeader = clan.isLeader(targetUuid);
+                final boolean hasNextRank = nextRank != null;
+                final boolean hasPreviousRank = previousRank != null;
+
+                final boolean canPromoteTarget = !isSelf && hasNextRank && !targetIsLeader
+                        && clanManager.hasPermission(clan.getId(), player.getUniqueId(), "clan.promote");
+                final boolean canDemoteTarget = !isSelf && hasPreviousRank && !targetIsLeader
+                        && clanManager.hasPermission(clan.getId(), player.getUniqueId(), "clan.demote");
+                final boolean canKickTarget = !isSelf && !targetIsLeader
+                        && clanManager.hasPermission(clan.getId(), player.getUniqueId(), "clan.kick");
+                final boolean canBanTarget = !isSelf && !targetIsLeader
+                        && (clan.isLeader(player.getUniqueId())
+                        || clan.hasPermission(player.getUniqueId(), ClanPermission.DISBAND));
+                final boolean canTransfer = clan.isLeader(player.getUniqueId()) && !isSelf && !targetIsLeader;
+
+                replacements.put("%clan_target_can_promote%", formatActionStatus(canPromoteTarget));
+                replacements.put("%clan_target_can_demote%", formatActionStatus(canDemoteTarget));
+                replacements.put("%clan_target_can_kick%", formatActionStatus(canKickTarget));
+                replacements.put("%clan_target_can_ban%", formatActionStatus(canBanTarget));
+                replacements.put("%clan_target_can_transfer%", formatActionStatus(canTransfer));
             }
         }
 
@@ -415,6 +462,13 @@ public class SocialPlaceholderManager {
         } else {
             clanPermissionTargets.put(viewer, target);
         }
+    }
+
+    public UUID getClanPermissionTarget(final UUID viewer) {
+        if (viewer == null) {
+            return null;
+        }
+        return clanPermissionTargets.get(viewer);
     }
 
     public void clearClanPermissionTarget(final UUID viewer) {
@@ -535,6 +589,33 @@ public class SocialPlaceholderManager {
 
     private String formatPermissionStatus(final boolean enabled) {
         return enabled ? "§aActivée" : "§cDésactivée";
+    }
+
+    private String formatActionStatus(final boolean available) {
+        return available ? "§aDisponible" : "§cIndisponible";
+    }
+
+    private String formatJoinDate(final long timestamp) {
+        if (timestamp <= 0L) {
+            return "Inconnue";
+        }
+        final Instant instant = Instant.ofEpochMilli(timestamp);
+        return DATE_TIME_FORMATTER.format(instant.atZone(ZoneId.systemDefault()));
+    }
+
+    private String formatLastSeen(final UUID uuid) {
+        if (uuid == null) {
+            return "Inconnue";
+        }
+        final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(uuid);
+        if (offlinePlayer.isOnline()) {
+            return "En ligne";
+        }
+        final long lastSeen = offlinePlayer.getLastSeen();
+        if (lastSeen <= 0L) {
+            return "Inconnue";
+        }
+        return formatRelativeTime(lastSeen);
     }
 
     private String resolveName(final UUID uuid) {

--- a/src/main/java/com/lobby/social/clans/Clan.java
+++ b/src/main/java/com/lobby/social/clans/Clan.java
@@ -11,7 +11,7 @@ public class Clan {
     private int id;
     private final String name;
     private final String tag;
-    private final UUID leaderUUID;
+    private UUID leaderUUID;
     private String description;
     private int maxMembers = 50;
     private int points = 0;
@@ -49,6 +49,12 @@ public class Clan {
 
     public UUID getLeaderUUID() {
         return leaderUUID;
+    }
+
+    public void setLeaderUUID(final UUID leaderUUID) {
+        if (leaderUUID != null) {
+            this.leaderUUID = leaderUUID;
+        }
     }
 
     public String getDescription() {

--- a/src/main/java/com/lobby/social/clans/ClanManager.java
+++ b/src/main/java/com/lobby/social/clans/ClanManager.java
@@ -26,6 +26,7 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.sql.ResultSetMetaData;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ClanManager {
 
@@ -35,6 +36,7 @@ public class ClanManager {
     private final Map<String, Clan> clanCache = new HashMap<>();
     private final Map<Integer, Clan> clanCacheById = new HashMap<>();
     private final Map<UUID, String> playerClanCache = new HashMap<>();
+    private final Map<Integer, Set<UUID>> clanBanCache = new ConcurrentHashMap<>();
 
     public ClanManager(final LobbyPlugin plugin) {
         this.plugin = plugin;
@@ -46,6 +48,7 @@ public class ClanManager {
         clanCache.clear();
         clanCacheById.clear();
         playerClanCache.clear();
+        clanBanCache.clear();
     }
 
     public void createClan(final Player leader, final String name, final String tag) {
@@ -114,6 +117,10 @@ public class ClanManager {
             inviter.sendMessage("§c" + targetName + " est déjà dans un clan !");
             return false;
         }
+        if (isPlayerBanned(clan.getId(), targetUUID)) {
+            inviter.sendMessage("§cCe joueur est banni du clan.");
+            return false;
+        }
         final ClanInvitation invitation = saveInvitation(clan.getId(), inviter.getUniqueId(), targetUUID, message);
         inviter.sendMessage("§aInvitation envoyée à §6" + targetName + "§a !");
         if (targetPlayer != null) {
@@ -145,6 +152,10 @@ public class ClanManager {
         }
         if (clan.isFull()) {
             player.sendMessage("§cLe clan est complet.");
+            return;
+        }
+        if (isPlayerBanned(clan.getId(), player.getUniqueId())) {
+            player.sendMessage("§cVous êtes banni de ce clan.");
             return;
         }
         saveMember(clan.getId(), player.getUniqueId(), "Membre");
@@ -436,6 +447,129 @@ public class ClanManager {
             return true;
         }
         return false;
+    }
+
+    public boolean kickMember(final UUID executorUuid, final UUID targetUuid) {
+        if (executorUuid == null || targetUuid == null) {
+            return false;
+        }
+        final Clan clan = getPlayerClan(executorUuid);
+        final Clan targetClan = getPlayerClan(targetUuid);
+        if (clan == null || targetClan == null || clan.getId() != targetClan.getId()) {
+            return false;
+        }
+        if (executorUuid.equals(targetUuid) || clan.isLeader(targetUuid)) {
+            return false;
+        }
+        if (!hasPermission(clan.getId(), executorUuid, "clan.kick")) {
+            return false;
+        }
+        final String targetName = getNameByUuid(targetUuid);
+        if (!removeMemberFromClan(clan, targetUuid)) {
+            return false;
+        }
+        broadcastLeaveMessage(clan, targetName != null ? targetName : targetUuid.toString(), "Expulsé");
+        final Player executor = Bukkit.getPlayer(executorUuid);
+        if (executor != null) {
+            executor.sendMessage("§aVous avez expulsé §6" + (targetName != null ? targetName : targetUuid));
+        }
+        final Player kicked = Bukkit.getPlayer(targetUuid);
+        if (kicked != null) {
+            kicked.sendMessage("§cVous avez été expulsé du clan §6" + clan.getName() + "§c.");
+            kicked.closeInventory();
+        }
+        return true;
+    }
+
+    public boolean banMember(final UUID executorUuid, final UUID targetUuid) {
+        if (executorUuid == null || targetUuid == null) {
+            return false;
+        }
+        final Clan clan = getPlayerClan(executorUuid);
+        final Clan targetClan = getPlayerClan(targetUuid);
+        if (clan == null || targetClan == null || clan.getId() != targetClan.getId()) {
+            return false;
+        }
+        if (executorUuid.equals(targetUuid) || clan.isLeader(targetUuid)) {
+            return false;
+        }
+        if (!clan.isLeader(executorUuid) && !clan.hasPermission(executorUuid, ClanPermission.DISBAND)) {
+            return false;
+        }
+        final String targetName = getNameByUuid(targetUuid);
+        if (!removeMemberFromClan(clan, targetUuid)) {
+            return false;
+        }
+        addClanBan(clan.getId(), targetUuid);
+        broadcastLeaveMessage(clan, targetName != null ? targetName : targetUuid.toString(), "Banni");
+        final Player executor = Bukkit.getPlayer(executorUuid);
+        if (executor != null) {
+            executor.sendMessage("§cVous avez banni §6" + (targetName != null ? targetName : targetUuid) + " §cdu clan.");
+        }
+        final Player banned = Bukkit.getPlayer(targetUuid);
+        if (banned != null) {
+            banned.sendMessage("§cVous avez été banni définitivement du clan §6" + clan.getName() + "§c.");
+            banned.closeInventory();
+        }
+        return true;
+    }
+
+    public boolean transferLeadership(final UUID currentLeaderUuid, final UUID targetUuid) {
+        if (currentLeaderUuid == null || targetUuid == null || currentLeaderUuid.equals(targetUuid)) {
+            return false;
+        }
+        final Clan clan = getPlayerClan(currentLeaderUuid);
+        final Clan targetClan = getPlayerClan(targetUuid);
+        if (clan == null || targetClan == null || clan.getId() != targetClan.getId()) {
+            return false;
+        }
+        if (!clan.isLeader(currentLeaderUuid)) {
+            return false;
+        }
+        final ClanMember targetMember = clan.getMember(targetUuid);
+        if (targetMember == null) {
+            return false;
+        }
+        final ClanRank leaderRank = clan.getRank("Leader");
+        final ClanRank fallbackRank = leaderRank != null
+                ? getPreviousRank(clan, leaderRank.getPriority())
+                : null;
+        final ClanRank memberRank = clan.getRank("Membre");
+        final ClanRank newLeaderRank = leaderRank != null ? leaderRank : memberRank;
+        final ClanRank newFormerLeaderRank = fallbackRank != null ? fallbackRank : memberRank;
+        if (newLeaderRank == null || newFormerLeaderRank == null) {
+            return false;
+        }
+        final String updateLeaderQuery = "UPDATE clans SET leader_uuid = ? WHERE id = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(updateLeaderQuery)) {
+            statement.setString(1, targetUuid.toString());
+            statement.setInt(2, clan.getId());
+            if (statement.executeUpdate() <= 0) {
+                return false;
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to transfer clan leadership for clan " + clan.getId(), exception);
+            return false;
+        }
+        clan.setLeaderUUID(targetUuid);
+        setPlayerRank(clan, targetUuid, newLeaderRank);
+        setPlayerRank(clan, currentLeaderUuid, newFormerLeaderRank);
+
+        final String oldLeaderName = getNameByUuid(currentLeaderUuid);
+        final String newLeaderName = getNameByUuid(targetUuid);
+        broadcastClanMessage(clan, "§6" + (oldLeaderName != null ? oldLeaderName : currentLeaderUuid)
+                + " §7a transféré le leadership à §e" + (newLeaderName != null ? newLeaderName : targetUuid) + "§7.");
+        final Player newLeader = Bukkit.getPlayer(targetUuid);
+        if (newLeader != null) {
+            newLeader.sendMessage("§eVous êtes désormais le leader du clan §6" + clan.getName() + "§e !");
+        }
+        final Player formerLeader = Bukkit.getPlayer(currentLeaderUuid);
+        if (formerLeader != null) {
+            formerLeader.sendMessage("§aLeadership transféré avec succès.");
+        }
+        return true;
     }
 
     public boolean depositCoins(final Player player, final long amount) {
@@ -751,6 +885,42 @@ public class ClanManager {
         } catch (final SQLException exception) {
             plugin.getLogger().log(Level.SEVERE, "Failed to add clan member", exception);
         }
+    }
+
+    private boolean removeMemberFromClan(final Clan clan, final UUID memberUuid) {
+        if (clan == null || memberUuid == null) {
+            return false;
+        }
+        deleteMemberPermissions(clan.getId(), memberUuid);
+        final String query = "DELETE FROM clan_members WHERE clan_id = ? AND player_uuid = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setInt(1, clan.getId());
+            statement.setString(2, memberUuid.toString());
+            final boolean removed = statement.executeUpdate() > 0;
+            clan.removeMember(memberUuid);
+            playerClanCache.remove(memberUuid);
+            return removed;
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "Failed to remove clan member " + memberUuid + " from clan " + clan.getId(), exception);
+            return false;
+        }
+    }
+
+    private void addClanBan(final int clanId, final UUID memberUuid) {
+        if (memberUuid == null) {
+            return;
+        }
+        clanBanCache.computeIfAbsent(clanId, key -> ConcurrentHashMap.newKeySet()).add(memberUuid);
+    }
+
+    private boolean isPlayerBanned(final int clanId, final UUID memberUuid) {
+        if (memberUuid == null) {
+            return false;
+        }
+        final Set<UUID> bans = clanBanCache.get(clanId);
+        return bans != null && bans.contains(memberUuid);
     }
 
     private ClanInvitation saveInvitation(final int clanId, final UUID inviter, final UUID invited, final String message) {

--- a/src/main/java/com/lobby/social/menus/MenuClickHandler.java
+++ b/src/main/java/com/lobby/social/menus/MenuClickHandler.java
@@ -3,11 +3,12 @@ package com.lobby.social.menus;
 import com.lobby.LobbyPlugin;
 import com.lobby.menus.MenuManager;
 import com.lobby.social.ChatInputManager;
-import com.lobby.social.clans.ClanManager;
-import com.lobby.social.groups.GroupManager;
 import com.lobby.social.friends.FriendManager;
 import com.lobby.social.friends.FriendRequest;
+import com.lobby.social.groups.GroupManager;
+import com.lobby.social.clans.ClanManager;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -18,11 +19,17 @@ import org.bukkit.inventory.Inventory;
 
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public final class MenuClickHandler implements Listener {
 
     private static final String FRIEND_SETTINGS_TITLE = "§8» §dParamètres d'Amis";
     private static final String GROUP_SETTINGS_TITLE = "§8» §eParamètres de Groupe";
+    private static final String CLAN_MEMBER_MANAGEMENT_PREFIX = "§8» §eGestion";
+
+    private static final long CLICK_COOLDOWN = 500L;
+    private static final ConcurrentMap<UUID, Long> LAST_CLICK_TIME = new ConcurrentHashMap<>();
 
     private final LobbyPlugin plugin;
     private final MenuManager menuManager;
@@ -44,8 +51,13 @@ public final class MenuClickHandler implements Listener {
             return;
         }
         final String title = event.getView().getTitle();
-        if (title.contains("»")) {
+        final boolean menuTitle = title.contains("»");
+        if (menuTitle) {
             event.setCancelled(true);
+        }
+        if (ClanMenus.CLAN_MEMBERS_TITLE.equals(title)) {
+            handleClanMembersClick(event, player);
+            return;
         }
         if (FRIEND_SETTINGS_TITLE.equals(title)) {
             handleFriendSettings(event, player);
@@ -55,8 +67,7 @@ public final class MenuClickHandler implements Listener {
             handleGroupSettings(event, player);
             return;
         }
-        final Inventory inventory = event.getView().getTopInventory();
-        if (!Objects.equals(inventory, event.getClickedInventory())) {
+        if (!Objects.equals(event.getView().getTopInventory(), event.getClickedInventory())) {
             return;
         }
         if (isFriendsMenuTitle(title)) {
@@ -78,17 +89,16 @@ public final class MenuClickHandler implements Listener {
             FriendsMenus.clearRequestCache(player.getUniqueId());
         }
         final var placeholderManager = plugin.getSocialPlaceholderManager();
-        if (ClanMenus.CLAN_MEMBERS_TITLE.equals(title)) {
-            ClanMenus.clearMemberCache(player.getUniqueId());
+        if (ClanMenus.CLAN_MEMBERS_TITLE.equals(title)
+                || title.startsWith(CLAN_MEMBER_MANAGEMENT_PREFIX)
+                || title.startsWith("§8» §cPermissions")) {
+            if (ClanMenus.CLAN_MEMBERS_TITLE.equals(title)) {
+                ClanMenus.clearMemberCache(player.getUniqueId());
+            }
             if (placeholderManager != null) {
                 placeholderManager.clearClanPermissionTarget(player.getUniqueId());
             }
-            return;
-        }
-        if (title.startsWith("§8» §cPermissions")) {
-            if (placeholderManager != null) {
-                placeholderManager.clearClanPermissionTarget(player.getUniqueId());
-            }
+            LAST_CLICK_TIME.remove(player.getUniqueId());
         }
     }
 
@@ -120,12 +130,31 @@ public final class MenuClickHandler implements Listener {
     }
 
     private void handleFriendSettings(final InventoryClickEvent event, final Player player) {
-        switch (event.getSlot()) {
-            case 19 -> cycleFriendRequests(player);
-            case 21 -> toggleFriendNotifications(player);
-            case 23 -> cycleFriendVisibility(player);
-            case 25 -> toggleAutoFavorites(player);
-            case 31 -> togglePrivateMessages(player);
+        if (isDoubleClick(player)) {
+            return;
+        }
+        final int slot = event.getSlot();
+        switch (slot) {
+            case 19 -> {
+                cycleFriendRequests(player);
+                scheduleMenuReopen(player, "friend_settings_menu", 1000L);
+            }
+            case 21 -> {
+                toggleFriendNotifications(player);
+                scheduleMenuReopen(player, "friend_settings_menu", 1000L);
+            }
+            case 23 -> {
+                cycleFriendVisibility(player);
+                scheduleMenuReopen(player, "friend_settings_menu", 1000L);
+            }
+            case 25 -> {
+                toggleAutoFavorites(player);
+                scheduleMenuReopen(player, "friend_settings_menu", 1000L);
+            }
+            case 31 -> {
+                togglePrivateMessages(player);
+                scheduleMenuReopen(player, "friend_settings_menu", 1000L);
+            }
             case 49 -> reopenMenu(player, "friends_menu");
             default -> {
             }
@@ -133,14 +162,50 @@ public final class MenuClickHandler implements Listener {
     }
 
     private void handleGroupSettings(final InventoryClickEvent event, final Player player) {
+        if (isDoubleClick(player)) {
+            return;
+        }
         switch (event.getSlot()) {
-            case 19 -> toggleGroupAutoAccept(player);
-            case 21 -> cycleGroupVisibility(player);
+            case 19 -> {
+                toggleGroupAutoAccept(player);
+                scheduleMenuReopen(player, "group_settings_menu", 1000L);
+            }
+            case 21 -> {
+                cycleGroupVisibility(player);
+                scheduleMenuReopen(player, "group_settings_menu", 1000L);
+            }
             case 23 -> reopenMenu(player, "group_manage_menu");
             case 49 -> reopenMenu(player, "groups_menu");
             default -> {
             }
         }
+    }
+
+    private void handleClanMembersClick(final InventoryClickEvent event, final Player player) {
+        if (!Objects.equals(event.getView().getTopInventory(), event.getClickedInventory())) {
+            return;
+        }
+        final int slot = event.getSlot();
+        if (slot < 0) {
+            return;
+        }
+        if (slot == 49) {
+            openMenu(player, "clan_menu");
+            return;
+        }
+        if (slot == ClanMenus.INVITE_SLOT) {
+            ChatInputManager.startClanInviteFlow(player);
+            return;
+        }
+        final var current = event.getCurrentItem();
+        if (current == null || current.getType() != Material.PLAYER_HEAD) {
+            return;
+        }
+        final UUID target = ClanMenus.getMemberAtSlot(player.getUniqueId(), slot);
+        if (target == null) {
+            return;
+        }
+        openClanMemberManagement(player, target);
     }
 
     private void handleClanMenuClick(final Player player, final String title, final int slot) {
@@ -149,17 +214,6 @@ public final class MenuClickHandler implements Listener {
         }
         if (slot == 49) {
             openMenu(player, "clan_menu");
-            return;
-        }
-        if (ClanMenus.CLAN_MEMBERS_TITLE.equals(title)) {
-            if (slot == ClanMenus.INVITE_SLOT) {
-                ChatInputManager.startClanInviteFlow(player);
-                return;
-            }
-            final UUID target = ClanMenus.getMemberAtSlot(player.getUniqueId(), slot);
-            if (target != null) {
-                ClanMenus.openMemberPermissionsMenu(player, target);
-            }
             return;
         }
         if (ClanMenus.CLAN_VAULT_TITLE.equals(title)) {
@@ -236,7 +290,6 @@ public final class MenuClickHandler implements Listener {
     private void cycleFriendRequests(final Player player) {
         final String mode = friendManager.cycleRequestAcceptance(player.getUniqueId());
         player.sendMessage("§aDemandes d'amis: §f" + mode);
-        reopenMenu(player, "friend_settings_menu");
     }
 
     private void toggleFriendNotifications(final Player player) {
@@ -244,13 +297,11 @@ public final class MenuClickHandler implements Listener {
         player.sendMessage(enabled
                 ? "§aNotifications d'amis activées"
                 : "§cNotifications d'amis désactivées");
-        reopenMenu(player, "friend_settings_menu");
     }
 
     private void cycleFriendVisibility(final Player player) {
         final String visibility = friendManager.cycleFriendVisibility(player.getUniqueId());
         player.sendMessage("§aVisibilité: §f" + visibility);
-        reopenMenu(player, "friend_settings_menu");
     }
 
     private void toggleAutoFavorites(final Player player) {
@@ -258,7 +309,6 @@ public final class MenuClickHandler implements Listener {
         player.sendMessage(enabled
                 ? "§aAcceptation auto des favoris activée"
                 : "§cAcceptation auto des favoris désactivée");
-        reopenMenu(player, "friend_settings_menu");
     }
 
     private void togglePrivateMessages(final Player player) {
@@ -266,7 +316,6 @@ public final class MenuClickHandler implements Listener {
         player.sendMessage(enabled
                 ? "§aMessages privés autorisés"
                 : "§cMessages privés désactivés");
-        reopenMenu(player, "friend_settings_menu");
     }
 
     private void toggleGroupAutoAccept(final Player player) {
@@ -277,7 +326,6 @@ public final class MenuClickHandler implements Listener {
         player.sendMessage(enabled
                 ? "§aInvitations automatiques activées"
                 : "§cInvitations automatiques désactivées");
-        reopenMenu(player, "group_settings_menu");
     }
 
     private void cycleGroupVisibility(final Player player) {
@@ -286,7 +334,6 @@ public final class MenuClickHandler implements Listener {
         }
         final String visibility = groupManager.cycleGroupVisibility(player.getUniqueId());
         player.sendMessage("§aVisibilité du groupe: §f" + visibility);
-        reopenMenu(player, "group_settings_menu");
     }
 
     private void reopenMenu(final Player player, final String menuId) {
@@ -300,11 +347,46 @@ public final class MenuClickHandler implements Listener {
         });
     }
 
+    private void scheduleMenuReopen(final Player player, final String menuId, final long delayMs) {
+        if (menuManager == null || player == null) {
+            return;
+        }
+        final long ticks = Math.max(0L, delayMs / 50L);
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (player.isOnline()) {
+                menuManager.openMenu(player, menuId);
+            }
+        }, ticks);
+    }
+
+    private boolean isDoubleClick(final Player player) {
+        if (player == null) {
+            return false;
+        }
+        final long now = System.currentTimeMillis();
+        final UUID uuid = player.getUniqueId();
+        final Long last = LAST_CLICK_TIME.put(uuid, now);
+        return last != null && (now - last) < CLICK_COOLDOWN;
+    }
+
+    private void openClanMemberManagement(final Player player, final UUID target) {
+        if (menuManager == null) {
+            return;
+        }
+        final var placeholderManager = plugin.getSocialPlaceholderManager();
+        if (placeholderManager != null) {
+            placeholderManager.setClanPermissionTarget(player.getUniqueId(), target);
+        }
+        menuManager.openMenu(player, "clan_member_management_menu");
+    }
+
     private boolean isFriendsMenuTitle(final String title) {
         return FriendsMenus.FRIENDS_ONLINE_TITLE.equals(title) || FriendsMenus.FRIEND_REQUESTS_TITLE.equals(title);
     }
 
     private boolean isClanMenuTitle(final String title) {
-        return ClanMenus.CLAN_MEMBERS_TITLE.equals(title) || ClanMenus.CLAN_VAULT_TITLE.equals(title);
+        return ClanMenus.CLAN_MEMBERS_TITLE.equals(title)
+                || ClanMenus.CLAN_VAULT_TITLE.equals(title)
+                || title.startsWith(CLAN_MEMBER_MANAGEMENT_PREFIX);
     }
 }

--- a/src/main/resources/config/menus.yml
+++ b/src/main/resources/config/menus.yml
@@ -150,6 +150,10 @@ menus:
   profile_menu:
     title: "&bProfil de %player_name%"
     size: 45
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,36,44]
+        material: "BLUE_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       overview:
         slot: 11
@@ -220,8 +224,9 @@ menus:
           - "[MENU] groups_menu"
       back:
         slot: 36
-        material: ARROW
-        name: "&aRetour"
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
           - "&7Retour au menu principal"
         actions:
@@ -238,6 +243,10 @@ menus:
   stats_menu:
     title: "&bStatistiques"
     size: 27
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,18,26]
+        material: "BLUE_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       summary:
         slot: 13
@@ -251,8 +260,9 @@ menus:
           - "&7Dernière connexion: &f%player_last_join%"
       back:
         slot: 18
-        material: ARROW
-        name: "&aRetour"
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
           - "&7Retour au profil"
         actions:
@@ -269,47 +279,11 @@ menus:
   clan_menu:
     title: "&8» &c&lGestion de Clan"
     size: 54
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,45,53]
+        material: "RED_STAINED_GLASS_PANE"
+        name: "&7"
     items:
-      decor_0:
-        slot: 0
-        material: RED_STAINED_GLASS_PANE
-        name: "&7"
-      decor_1:
-        slot: 1
-        material: RED_STAINED_GLASS_PANE
-        name: "&7"
-      decor_2:
-        slot: 2
-        material: RED_STAINED_GLASS_PANE
-        name: "&7"
-      decor_6:
-        slot: 6
-        material: RED_STAINED_GLASS_PANE
-        name: "&7"
-      decor_7:
-        slot: 7
-        material: RED_STAINED_GLASS_PANE
-        name: "&7"
-      decor_8:
-        slot: 8
-        material: RED_STAINED_GLASS_PANE
-        name: "&7"
-      decor_9:
-        slot: 9
-        material: RED_STAINED_GLASS_PANE
-        name: "&7"
-      decor_17:
-        slot: 17
-        material: RED_STAINED_GLASS_PANE
-        name: "&7"
-      decor_45:
-        slot: 45
-        material: RED_STAINED_GLASS_PANE
-        name: "&7"
-      decor_53:
-        slot: 53
-        material: RED_STAINED_GLASS_PANE
-        name: "&7"
       clan_overview:
         slot: 19
         material: PLAYER_HEAD
@@ -448,47 +422,11 @@ menus:
   friends_menu:
     title: "&8» &a&lGestion d'Amis"
     size: 54
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,45,53]
+        material: "GREEN_STAINED_GLASS_PANE"
+        name: "&7"
     items:
-      decor_0:
-        slot: 0
-        material: GREEN_STAINED_GLASS_PANE
-        name: "&7"
-      decor_1:
-        slot: 1
-        material: GREEN_STAINED_GLASS_PANE
-        name: "&7"
-      decor_2:
-        slot: 2
-        material: GREEN_STAINED_GLASS_PANE
-        name: "&7"
-      decor_6:
-        slot: 6
-        material: GREEN_STAINED_GLASS_PANE
-        name: "&7"
-      decor_7:
-        slot: 7
-        material: GREEN_STAINED_GLASS_PANE
-        name: "&7"
-      decor_8:
-        slot: 8
-        material: GREEN_STAINED_GLASS_PANE
-        name: "&7"
-      decor_9:
-        slot: 9
-        material: GREEN_STAINED_GLASS_PANE
-        name: "&7"
-      decor_17:
-        slot: 17
-        material: GREEN_STAINED_GLASS_PANE
-        name: "&7"
-      decor_45:
-        slot: 45
-        material: GREEN_STAINED_GLASS_PANE
-        name: "&7"
-      decor_53:
-        slot: 53
-        material: GREEN_STAINED_GLASS_PANE
-        name: "&7"
       friends_online:
         slot: 20
         material: PLAYER_HEAD
@@ -739,6 +677,10 @@ menus:
   clan_info_menu:
     title: "&8» &c&lMon Clan"
     size: 27
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,18,26]
+        material: "RED_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       details:
         slot: 13
@@ -754,8 +696,9 @@ menus:
           - "&7Points: &e%clan_points%"
       back:
         slot: 18
-        material: ARROW
-        name: "&aRetour"
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
           - "&7Retour à la gestion du clan"
         actions:
@@ -772,6 +715,10 @@ menus:
   clan_members_menu:
     title: "&8» &c&lMembres du Clan"
     size: 27
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,18,26]
+        material: "RED_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       summary:
         slot: 13
@@ -784,8 +731,9 @@ menus:
           - "&7Permissions: %clan_permissions%"
       back:
         slot: 18
-        material: ARROW
-        name: "&aRetour"
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
           - "&7Revenir au menu clan"
         actions:
@@ -802,6 +750,10 @@ menus:
   clan_ranks_menu:
     title: "&8» &d&lRangs de Clan"
     size: 27
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,18,26]
+        material: "RED_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       overview:
         slot: 13
@@ -814,8 +766,9 @@ menus:
           - "&7Accès coffre: %clan_vault_access%"
       back:
         slot: 18
-        material: ARROW
-        name: "&aRetour"
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
           - "&7Revenir au menu clan"
         actions:
@@ -832,6 +785,10 @@ menus:
   clan_vault_menu:
     title: "&8» &a&lTrésor du Clan"
     size: 27
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,18,26]
+        material: "RED_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       vault_info:
         slot: 13
@@ -843,8 +800,9 @@ menus:
           - "&7Accès: %clan_vault_access%"
       back:
         slot: 18
-        material: ARROW
-        name: "&aRetour"
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
           - "&7Revenir au menu clan"
         actions:
@@ -861,6 +819,10 @@ menus:
   clan_wars_menu:
     title: "&8» &b&lGuerres de Clans"
     size: 27
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,18,26]
+        material: "RED_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       war_info:
         slot: 13
@@ -873,8 +835,9 @@ menus:
           - "&7Ratio: &6%clan_war_ratio%"
       back:
         slot: 18
-        material: ARROW
-        name: "&aRetour"
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
           - "&7Revenir au menu clan"
         actions:
@@ -891,6 +854,10 @@ menus:
   clan_browse_menu:
     title: "&8» &e&lExplorer les Clans"
     size: 27
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,18,26]
+        material: "RED_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       listing:
         slot: 13
@@ -902,8 +869,9 @@ menus:
           - "&7Popularité: Top clans actifs"
       back:
         slot: 18
-        material: ARROW
-        name: "&aRetour"
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
           - "&7Revenir au menu clan"
         actions:
@@ -920,6 +888,10 @@ menus:
   friends_online_menu:
     title: "&8» &a&lAmis En Ligne"
     size: 27
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,18,26]
+        material: "GREEN_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       overview:
         slot: 13
@@ -932,8 +904,9 @@ menus:
           - "&7Dernière activité: %friends_recent_activity%"
       back:
         slot: 18
-        material: ARROW
-        name: "&aRetour"
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
           - "&7Retour à la gestion des amis"
         actions:
@@ -950,6 +923,10 @@ menus:
   friend_requests_menu:
     title: "&8» &e&lDemandes d'Amis"
     size: 27
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,18,26]
+        material: "GREEN_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       summary:
         slot: 13
@@ -961,8 +938,9 @@ menus:
           - "&7Plus ancienne: %friend_requests_oldest%"
       back:
         slot: 18
-        material: ARROW
-        name: "&aRetour"
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
           - "&7Retour à la gestion des amis"
         actions:
@@ -980,7 +958,7 @@ menus:
     title: "&8» &aMes Amis"
     size: 54
     borders:
-      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+      - slots: [0,1,2,6,7,8,9,17,45,53]
         material: "GREEN_STAINED_GLASS_PANE"
         name: "&7"
     items:
@@ -1244,6 +1222,125 @@ menus:
         actions:
           - "[CLOSE]"
 
+  clan_member_management_menu:
+    title: "&8» &eGestion &6%clan_target_name%"
+    size: 54
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,45,53]
+        material: "RED_STAINED_GLASS_PANE"
+        name: "&7"
+    items:
+      member_info:
+        slot: 13
+        material: "PLAYER_HEAD"
+        head: "%clan_target_name%"
+        name: "&6&l%clan_target_name%"
+        lore:
+          - "&7Rang: &f%clan_target_rank_display%"
+          - "&7Priorité: &f%clan_target_rank_priority%"
+          - "&7Depuis le: &f%clan_target_join_date%"
+          - "&7Dernière connexion: &f%clan_target_last_seen%"
+          - "&7Contributions: &e%clan_target_contribution% coins"
+          - "&7Permissions perso: &d%clan_target_permissions_count%"
+          - "&r"
+          - "&eSélectionnez une action"
+      promote:
+        slot: 19
+        material: "PLAYER_HEAD"
+        head: "hdb:12654"
+        name: "&a&lPromouvoir"
+        lore:
+          - "&7Rang actuel: &f%clan_target_rank_display%"
+          - "&7Rang suivant: &a%clan_target_next_rank%"
+          - "&r"
+          - "&8▸ &7Statut: %clan_target_can_promote%"
+          - "&r"
+          - "&a▶ Cliquez pour promouvoir"
+        actions:
+          - "[CLAN_PROMOTE_MEMBER]"
+      demote:
+        slot: 21
+        material: "PLAYER_HEAD"
+        head: "hdb:23022"
+        name: "&c&lRétrograder"
+        lore:
+          - "&7Rang actuel: &f%clan_target_rank_display%"
+          - "&7Rang précédent: &c%clan_target_previous_rank%"
+          - "&r"
+          - "&8▸ &7Statut: %clan_target_can_demote%"
+          - "&r"
+          - "&c▶ Cliquez pour rétrograder"
+        actions:
+          - "[CLAN_DEMOTE_MEMBER]"
+      permissions:
+        slot: 23
+        material: "PLAYER_HEAD"
+        head: "hdb:1218"
+        name: "&d&lPermissions"
+        lore:
+          - "&7Permissions actuelles:"
+          - "&f%clan_target_permissions%"
+          - "&r"
+          - "&d▶ Cliquez pour gérer"
+        actions:
+          - "[MENU] clan_member_permissions_menu"
+      kick:
+        slot: 25
+        material: "PLAYER_HEAD"
+        head: "hdb:60776"
+        name: "&4&lExpulser"
+        lore:
+          - "&7Expulser ce membre du clan."
+          - "&r"
+          - "&8▸ &7Statut: %clan_target_can_kick%"
+          - "&r"
+          - "&4▶ Cliquez pour expulser"
+        actions:
+          - "[CLAN_KICK_MEMBER]"
+      ban:
+        slot: 31
+        material: "PLAYER_HEAD"
+        head: "hdb:38878"
+        name: "&4&lBannir Définitivement"
+        lore:
+          - "&7Bannir ce membre définitivement."
+          - "&r"
+          - "&8▸ &7Statut: %clan_target_can_ban%"
+          - "&r"
+          - "&4▶ Cliquez pour bannir"
+        actions:
+          - "[CLAN_BAN_MEMBER]"
+      transfer_leadership:
+        slot: 33
+        material: "PLAYER_HEAD"
+        head: "hdb:8971"
+        name: "&6&lTransférer le Leadership"
+        lore:
+          - "&7Donner le rôle de leader à ce membre."
+          - "&r"
+          - "&8▸ &7Statut: %clan_target_can_transfer%"
+          - "&r"
+          - "&6▶ Cliquez pour transférer"
+        actions:
+          - "[CLAN_TRANSFER_LEADERSHIP]"
+      back:
+        slot: 49
+        material: "PLAYER_HEAD"
+        head: "hdb:9334"
+        name: "&c&lRetour"
+        lore:
+          - "&7Retourner à la liste des membres"
+        actions:
+          - "[CLAN_MEMBERS]"
+      close:
+        slot: 53
+        material: BARRIER
+        name: "&cFermer"
+        lore:
+          - "&7Fermer le menu"
+        actions:
+          - "[CLOSE]"
+
   clan_creation_menu:
     title: "&8» &cCréation de Clan"
     size: 54
@@ -1306,7 +1403,7 @@ menus:
     title: "&8» &cBoutique de Clan"
     size: 54
     borders:
-      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+      - slots: [0,1,2,6,7,8,9,17,45,53]
         material: "RED_STAINED_GLASS_PANE"
         name: "&7"
     items:
@@ -1366,7 +1463,7 @@ menus:
     title: "&8» &9Statistiques détaillées"
     size: 54
     borders:
-      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+      - slots: [0,1,2,6,7,8,9,17,45,53]
         material: "BLUE_STAINED_GLASS_PANE"
         name: "&7"
     items:
@@ -1429,7 +1526,7 @@ menus:
     title: "&8» &9Choix de la langue"
     size: 54
     borders:
-      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+      - slots: [0,1,2,6,7,8,9,17,45,53]
         material: "BLUE_STAINED_GLASS_PANE"
         name: "&7"
     items:
@@ -1507,7 +1604,7 @@ menus:
     title: "&8» &9Récompense quotidienne"
     size: 54
     borders:
-      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+      - slots: [0,1,2,6,7,8,9,17,45,53]
         material: "BLUE_STAINED_GLASS_PANE"
         name: "&7"
     items:
@@ -1565,7 +1662,7 @@ menus:
     title: "&8» &dParamètres d'Amis"
     size: 54
     borders:
-      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+      - slots: [0,1,2,6,7,8,9,17,45,53]
         material: "GREEN_STAINED_GLASS_PANE"
         name: "&7"
     items:
@@ -1680,7 +1777,7 @@ menus:
     title: "&8» &6Mes Favoris"
     size: 54
     borders:
-      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+      - slots: [0,1,2,6,7,8,9,17,45,53]
         material: "GREEN_STAINED_GLASS_PANE"
         name: "&7"
     items:
@@ -1756,7 +1853,7 @@ menus:
     title: "&8» &eMon Groupe"
     size: 54
     borders:
-      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+      - slots: [0,1,2,6,7,8,9,17,45,53]
         material: "YELLOW_STAINED_GLASS_PANE"
         name: "&7"
     items:
@@ -1836,7 +1933,7 @@ menus:
     title: "&8» &bExplorer les Groupes"
     size: 54
     borders:
-      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+      - slots: [0,1,2,6,7,8,9,17,45,53]
         material: "YELLOW_STAINED_GLASS_PANE"
         name: "&7"
     items:
@@ -1898,6 +1995,10 @@ menus:
   group_invite_menu:
     title: "&8» &d&lInvitations de Groupe"
     size: 27
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,18,26]
+        material: "YELLOW_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       invite_info:
         slot: 13
@@ -1909,8 +2010,9 @@ menus:
           - "&7Invitations reçues: &e%group_invitations%"
       back:
         slot: 18
-        material: ARROW
-        name: "&aRetour"
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
           - "&7Retour à la gestion des groupes"
         actions:
@@ -1927,6 +2029,10 @@ menus:
   queue_menu:
     title: "&8» &6&lFiles d'Attente"
     size: 27
+    borders:
+      - slots: [0,1,2,6,7,8,9,17,18,26]
+        material: "YELLOW_STAINED_GLASS_PANE"
+        name: "&7"
     items:
       queue_info:
         slot: 13
@@ -1938,8 +2044,9 @@ menus:
           - "&7Joueurs en file: &e%queue_players%"
       back:
         slot: 18
-        material: ARROW
-        name: "&aRetour"
+        material: PLAYER_HEAD
+        head: "hdb:9334"
+        name: "&c&lRetour"
         lore:
           - "&7Retour à la gestion des groupes"
         actions:
@@ -1957,7 +2064,7 @@ menus:
     title: "&8» &eParamètres de Groupe"
     size: 54
     borders:
-      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
+      - slots: [0,1,2,6,7,8,9,17,45,53]
         material: "YELLOW_STAINED_GLASS_PANE"
         name: "&7"
     items:

--- a/src/main/resources/config/menus/clan_menu.yml
+++ b/src/main/resources/config/menus/clan_menu.yml
@@ -2,78 +2,12 @@ menu:
   id: "clan_menu"
   title: "&8» &c&lGestion de Clan"
   size: 54
+  borders:
+    - slots: [0,1,2,6,7,8,9,17,45,53]
+      material: "RED_STAINED_GLASS_PANE"
+      name: "&7"
 
   items:
-    decor_top_left_1:
-      slot: 0
-      material: "RED_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_left_2:
-      slot: 1
-      material: "RED_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_left_3:
-      slot: 2
-      material: "RED_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_right_1:
-      slot: 6
-      material: "RED_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_right_2:
-      slot: 7
-      material: "RED_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_right_3:
-      slot: 8
-      material: "RED_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_left:
-      slot: 9
-      material: "RED_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_right:
-      slot: 17
-      material: "RED_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_bottom_left:
-      slot: 45
-      material: "RED_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_bottom_right:
-      slot: 53
-      material: "RED_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
     my_clan:
       slot: 19
       material: "PLAYER_HEAD"

--- a/src/main/resources/config/menus/friends_menu.yml
+++ b/src/main/resources/config/menus/friends_menu.yml
@@ -2,78 +2,12 @@ menu:
   id: "friends_menu"
   title: "&8» &a&lGestion d'Amis"
   size: 54
+  borders:
+    - slots: [0,1,2,6,7,8,9,17,45,53]
+      material: "GREEN_STAINED_GLASS_PANE"
+      name: "&7"
 
   items:
-    decor_top_left_1:
-      slot: 0
-      material: "GREEN_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_left_2:
-      slot: 1
-      material: "GREEN_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_left_3:
-      slot: 2
-      material: "GREEN_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_right_1:
-      slot: 6
-      material: "GREEN_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_right_2:
-      slot: 7
-      material: "GREEN_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_right_3:
-      slot: 8
-      material: "GREEN_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_left:
-      slot: 9
-      material: "GREEN_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_right:
-      slot: 17
-      material: "GREEN_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_bottom_left:
-      slot: 45
-      material: "GREEN_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_bottom_right:
-      slot: 53
-      material: "GREEN_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
     friends_online:
       slot: 20
       material: "PLAYER_HEAD"

--- a/src/main/resources/config/menus/groups_menu.yml
+++ b/src/main/resources/config/menus/groups_menu.yml
@@ -2,78 +2,12 @@ menu:
   id: "groups_menu"
   title: "&8» &e&lGestion de Groupes"
   size: 54
+  borders:
+    - slots: [0,1,2,6,7,8,9,17,45,53]
+      material: "YELLOW_STAINED_GLASS_PANE"
+      name: "&7"
 
   items:
-    decor_top_left_1:
-      slot: 0
-      material: "YELLOW_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_left_2:
-      slot: 1
-      material: "YELLOW_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_left_3:
-      slot: 2
-      material: "YELLOW_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_right_1:
-      slot: 6
-      material: "YELLOW_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_right_2:
-      slot: 7
-      material: "YELLOW_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_right_3:
-      slot: 8
-      material: "YELLOW_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_left:
-      slot: 9
-      material: "YELLOW_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_right:
-      slot: 17
-      material: "YELLOW_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_bottom_left:
-      slot: 45
-      material: "YELLOW_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_bottom_right:
-      slot: 53
-      material: "YELLOW_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
     current_group:
       slot: 20
       material: "PLAYER_HEAD"

--- a/src/main/resources/config/menus/language_menu.yml
+++ b/src/main/resources/config/menus/language_menu.yml
@@ -2,6 +2,10 @@ menu:
   id: "language_menu"
   title: "&8» &fSélection de Langue"
   size: 27
+  borders:
+    - slots: [0,1,2,6,7,8,9,17,18,26]
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
 
   items:
     french:

--- a/src/main/resources/config/menus/profil_menu.yml
+++ b/src/main/resources/config/menus/profil_menu.yml
@@ -2,78 +2,12 @@ menu:
   id: "profil_menu"
   title: "&8» &6Mon Profil"
   size: 54
+  borders:
+    - slots: [0,1,2,6,7,8,9,17,45,53]
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
 
   items:
-    decor_top_left_1:
-      slot: 0
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_left_2:
-      slot: 1
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_left_3:
-      slot: 2
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_right_1:
-      slot: 6
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_right_2:
-      slot: 7
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_top_right_3:
-      slot: 8
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_left:
-      slot: 9
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_right:
-      slot: 17
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_bottom_left:
-      slot: 45
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
-    decor_bottom_right:
-      slot: 53
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-
     friends:
       slot: 3
       material: "PLAYER_HEAD"


### PR DESCRIPTION
## Summary
- add double-click protection and clan member management routing in `MenuClickHandler`
- expand clan management logic, social placeholders, and NPC actions to support promoting, demoting, kicking, banning, and leadership transfer
- introduce the dedicated clan member management menu and standardize menu borders/colors across friends, groups, clans, and profile configurations

## Testing
- `mvn -q -DskipTests package` *(fails: repository unreachable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d03a15fc8c8329a47ab2d4f63b8ec0