### PR TITLE
Handle empty clan permission sets

### DIFF
--- a/src/main/java/com/lobby/social/clans/ClanManager.java
+++ b/src/main/java/com/lobby/social/clans/ClanManager.java
@@ -322,9 +322,16 @@ public class ClanManager {
             return List.of();
         }
         final Set<ClanPermission> permissions;
-        if (member.getPermissions().isEmpty()) {
+        if (member.getPermissions() == null || member.getPermissions().isEmpty()) {
             final ClanRank rank = getPlayerRank(clan, memberUuid);
-            permissions = rank != null ? EnumSet.copyOf(rank.getPermissions()) : EnumSet.noneOf(ClanPermission.class);
+            if (rank == null) {
+                permissions = EnumSet.noneOf(ClanPermission.class);
+            } else {
+                final Set<ClanPermission> rankPermissions = rank.getPermissions();
+                permissions = (rankPermissions == null || rankPermissions.isEmpty())
+                        ? EnumSet.noneOf(ClanPermission.class)
+                        : EnumSet.copyOf(rankPermissions);
+            }
         } else {
             permissions = EnumSet.copyOf(member.getPermissions());
         }


### PR DESCRIPTION
## Summary
- guard against null or empty permission collections when resolving clan member permissions
- fall back to an empty EnumSet when ranks have no configured permissions

## Testing
- `mvn -q -DskipTests package` *(fails: network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d043f2734883298e9a9c9945b28556