### PR TITLE
Implement social menu cooldown and unified design

### DIFF
--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -30,13 +30,18 @@ public class ConfiguredMenu implements Menu {
     private final LobbyPlugin plugin;
     private final String menuId;
     private final ConfigurationSection menuSection;
+    private final MenuDesignProvider menuDesignProvider;
     private Inventory inventory;
     private final Map<Integer, List<String>> actionsBySlot = new HashMap<>();
 
-    public ConfiguredMenu(final LobbyPlugin plugin, final String menuId, final ConfigurationSection menuSection) {
+    public ConfiguredMenu(final LobbyPlugin plugin,
+                          final String menuId,
+                          final ConfigurationSection menuSection,
+                          final MenuDesignProvider menuDesignProvider) {
         this.plugin = plugin;
         this.menuId = menuId;
         this.menuSection = menuSection;
+        this.menuDesignProvider = menuDesignProvider;
     }
 
     @Override
@@ -67,6 +72,7 @@ public class ConfiguredMenu implements Menu {
             }
         }
 
+        applyDesignTemplate(player);
         applyBorders(player);
 
         final ConfigurationSection itemsSection = menuSection.getConfigurationSection("items");
@@ -82,6 +88,41 @@ public class ConfiguredMenu implements Menu {
         }
 
         player.openInventory(inventory);
+    }
+
+    private void applyDesignTemplate(final Player player) {
+        if (inventory == null || menuDesignProvider == null) {
+            return;
+        }
+        final String templateName = menuSection.getString("design_template");
+        if (templateName == null || templateName.isBlank()) {
+            return;
+        }
+        final Optional<MenuDesign> designOptional = menuDesignProvider.getDesign(templateName);
+        if (designOptional.isEmpty()) {
+            return;
+        }
+        final MenuDesign design = designOptional.get();
+        final ItemStack decorative = design.createDecorativeItem();
+        for (Integer slot : design.decorationSlots()) {
+            if (slot == null) {
+                continue;
+            }
+            final int index = slot;
+            if (index >= 0 && index < inventory.getSize()) {
+                inventory.setItem(index, decorative.clone());
+            }
+        }
+        final ItemStack border = design.createBorderItem();
+        for (Integer slot : design.borderSlots()) {
+            if (slot == null) {
+                continue;
+            }
+            final int index = slot;
+            if (index >= 0 && index < inventory.getSize()) {
+                inventory.setItem(index, border.clone());
+            }
+        }
     }
 
     @Override

--- a/src/main/java/com/lobby/menus/MenuDesign.java
+++ b/src/main/java/com/lobby/menus/MenuDesign.java
@@ -1,0 +1,70 @@
+package com.lobby.menus;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class MenuDesign {
+
+    private final ItemStack decorativeItem;
+    private final ItemStack borderItem;
+    private final ItemStack confirmItem;
+    private final ItemStack cancelItem;
+    private final List<Integer> decorationSlots;
+    private final List<Integer> borderSlots;
+
+    public MenuDesign(final Material decorativeMaterial,
+                      final Material borderMaterial,
+                      final Material confirmMaterial,
+                      final Material cancelMaterial,
+                      final List<Integer> decorationSlots,
+                      final List<Integer> borderSlots) {
+        this.decorativeItem = createItem(decorativeMaterial);
+        this.borderItem = createItem(borderMaterial);
+        this.confirmItem = createItem(confirmMaterial);
+        this.cancelItem = createItem(cancelMaterial);
+        this.decorationSlots = List.copyOf(Objects.requireNonNullElse(decorationSlots, List.of()));
+        this.borderSlots = List.copyOf(Objects.requireNonNullElse(borderSlots, List.of()));
+    }
+
+    private ItemStack createItem(final Material material) {
+        final Material resolved = material != null ? material : Material.BLACK_STAINED_GLASS_PANE;
+        final ItemStack itemStack = new ItemStack(resolved);
+        final ItemMeta meta = itemStack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            meta.addItemFlags(ItemFlag.values());
+            itemStack.setItemMeta(meta);
+        }
+        return itemStack;
+    }
+
+    public ItemStack createDecorativeItem() {
+        return decorativeItem.clone();
+    }
+
+    public ItemStack createBorderItem() {
+        return borderItem.clone();
+    }
+
+    public ItemStack createConfirmItem() {
+        return confirmItem.clone();
+    }
+
+    public ItemStack createCancelItem() {
+        return cancelItem.clone();
+    }
+
+    public List<Integer> decorationSlots() {
+        return decorationSlots;
+    }
+
+    public List<Integer> borderSlots() {
+        return borderSlots;
+    }
+}
+

--- a/src/main/java/com/lobby/menus/MenuDesignProvider.java
+++ b/src/main/java/com/lobby/menus/MenuDesignProvider.java
@@ -1,0 +1,85 @@
+package com.lobby.menus;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.utils.LogUtils;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class MenuDesignProvider {
+
+    private final LobbyPlugin plugin;
+    private final Map<String, MenuDesign> cache = new ConcurrentHashMap<>();
+
+    public MenuDesignProvider(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public Optional<MenuDesign> getDesign(final String templateName) {
+        if (templateName == null || templateName.isBlank()) {
+            return Optional.empty();
+        }
+        final String normalized = templateName.toLowerCase(Locale.ROOT);
+        final MenuDesign cached = cache.get(normalized);
+        if (cached != null) {
+            return Optional.of(cached);
+        }
+        final MenuDesign loaded = loadDesign(normalized);
+        if (loaded != null) {
+            cache.put(normalized, loaded);
+            return Optional.of(loaded);
+        }
+        return Optional.empty();
+    }
+
+    public void reload() {
+        cache.clear();
+    }
+
+    private MenuDesign loadDesign(final String templateName) {
+        final String fileName = templateName + "_design_template.yml";
+        final File file = new File(plugin.getDataFolder(), "config/menus/" + fileName);
+        if (!file.exists()) {
+            plugin.saveResource("config/menus/" + fileName, false);
+        }
+        if (!file.exists()) {
+            LogUtils.warning(plugin, "Unable to locate design template '" + fileName + "'.");
+            return null;
+        }
+        final YamlConfiguration configuration = YamlConfiguration.loadConfiguration(file);
+        final ConfigurationSection designSection = configuration.getConfigurationSection("design");
+        if (designSection == null) {
+            LogUtils.warning(plugin, "Design template '" + fileName + "' is missing a 'design' section.");
+            return null;
+        }
+
+        final Material decorative = parseMaterial(designSection, "decorative_glass", Material.BLUE_STAINED_GLASS_PANE);
+        final Material border = parseMaterial(designSection, "info_glass", Material.LIGHT_BLUE_STAINED_GLASS_PANE);
+        final Material confirm = parseMaterial(designSection, "confirm_glass", Material.GREEN_STAINED_GLASS_PANE);
+        final Material cancel = parseMaterial(designSection, "cancel_glass", Material.RED_STAINED_GLASS_PANE);
+        final List<Integer> decorationSlots = designSection.getIntegerList("decoration_slots");
+        final List<Integer> borderSlots = designSection.getIntegerList("border_slots");
+        return new MenuDesign(decorative, border, confirm, cancel, decorationSlots, borderSlots);
+    }
+
+    private Material parseMaterial(final ConfigurationSection section, final String key, final Material fallback) {
+        final String value = section.getString(key);
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        final Material material = Material.matchMaterial(value.toUpperCase(Locale.ROOT));
+        if (material == null) {
+            LogUtils.warning(plugin, "Invalid material '" + value + "' in design template '" + section.getCurrentPath() + "'.");
+            return fallback;
+        }
+        return material;
+    }
+}
+

--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -28,9 +28,11 @@ public class MenuManager implements Listener {
     private final LobbyPlugin plugin;
     private final Map<UUID, Menu> openMenus = new ConcurrentHashMap<>();
     private final Map<String, ConfigurationSection> menuDefinitions = new ConcurrentHashMap<>();
+    private final MenuDesignProvider menuDesignProvider;
 
     public MenuManager(final LobbyPlugin plugin) {
         this.plugin = plugin;
+        this.menuDesignProvider = new MenuDesignProvider(plugin);
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
         reloadMenus();
     }
@@ -50,7 +52,7 @@ public class MenuManager implements Listener {
             }
         }
 
-        final Menu menu = new ConfiguredMenu(plugin, normalizedId, menuSection);
+        final Menu menu = new ConfiguredMenu(plugin, normalizedId, menuSection, menuDesignProvider);
         openMenus.put(player.getUniqueId(), menu);
         menu.open(player);
         if (menu.getInventory() == null) {
@@ -80,6 +82,7 @@ public class MenuManager implements Listener {
 
     public void reloadMenus() {
         menuDefinitions.clear();
+        menuDesignProvider.reload();
         loadMenusFromMainConfig();
         loadMenusFromDirectory();
     }
@@ -181,7 +184,8 @@ public class MenuManager implements Listener {
                 "language_menu.yml",
                 "friends_menu.yml",
                 "groups_menu.yml",
-                "clan_menu.yml"
+                "clan_menu.yml",
+                "social_design_template.yml"
         );
         for (String fileName : defaults) {
             final File target = new File(directory, fileName);

--- a/src/main/java/com/lobby/social/menus/MenuClickHandler.java
+++ b/src/main/java/com/lobby/social/menus/MenuClickHandler.java
@@ -18,9 +18,9 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 public final class MenuClickHandler implements Listener {
 
@@ -28,8 +28,9 @@ public final class MenuClickHandler implements Listener {
     private static final String GROUP_SETTINGS_TITLE = "§8» §eParamètres de Groupe";
     private static final String CLAN_MEMBER_MANAGEMENT_PREFIX = "§8» §eGestion";
 
-    private static final long CLICK_COOLDOWN = 500L;
-    private static final ConcurrentMap<UUID, Long> LAST_CLICK_TIME = new ConcurrentHashMap<>();
+    private static final long CLICK_DELAY_TICKS = 10L;
+
+    private final Set<UUID> clickCooldown = ConcurrentHashMap.newKeySet();
 
     private final LobbyPlugin plugin;
     private final MenuManager menuManager;
@@ -50,6 +51,14 @@ public final class MenuClickHandler implements Listener {
         if (!(event.getWhoClicked() instanceof Player player)) {
             return;
         }
+        final UUID playerId = player.getUniqueId();
+        if (clickCooldown.contains(playerId)) {
+            event.setCancelled(true);
+            return;
+        }
+        clickCooldown.add(playerId);
+        Bukkit.getScheduler().runTaskLater(plugin, () -> clickCooldown.remove(playerId), CLICK_DELAY_TICKS);
+
         final String title = event.getView().getTitle();
         final boolean menuTitle = title.contains("»");
         if (menuTitle) {
@@ -98,7 +107,7 @@ public final class MenuClickHandler implements Listener {
             if (placeholderManager != null) {
                 placeholderManager.clearClanPermissionTarget(player.getUniqueId());
             }
-            LAST_CLICK_TIME.remove(player.getUniqueId());
+            clickCooldown.remove(player.getUniqueId());
         }
     }
 
@@ -130,9 +139,6 @@ public final class MenuClickHandler implements Listener {
     }
 
     private void handleFriendSettings(final InventoryClickEvent event, final Player player) {
-        if (isDoubleClick(player)) {
-            return;
-        }
         final int slot = event.getSlot();
         switch (slot) {
             case 19 -> {
@@ -162,9 +168,6 @@ public final class MenuClickHandler implements Listener {
     }
 
     private void handleGroupSettings(final InventoryClickEvent event, final Player player) {
-        if (isDoubleClick(player)) {
-            return;
-        }
         switch (event.getSlot()) {
             case 19 -> {
                 toggleGroupAutoAccept(player);
@@ -357,16 +360,6 @@ public final class MenuClickHandler implements Listener {
                 menuManager.openMenu(player, menuId);
             }
         }, ticks);
-    }
-
-    private boolean isDoubleClick(final Player player) {
-        if (player == null) {
-            return false;
-        }
-        final long now = System.currentTimeMillis();
-        final UUID uuid = player.getUniqueId();
-        final Long last = LAST_CLICK_TIME.put(uuid, now);
-        return last != null && (now - last) < CLICK_COOLDOWN;
     }
 
     private void openClanMemberManagement(final Player player, final UUID target) {

--- a/src/main/resources/config/menus.yml
+++ b/src/main/resources/config/menus.yml
@@ -36,7 +36,8 @@ menus:
           - "[MENU] servers_menu"
       close:
         slot: 26
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -279,10 +280,7 @@ menus:
   clan_menu:
     title: "&8» &c&lGestion de Clan"
     size: 54
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,45,53]
-        material: "RED_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       clan_overview:
         slot: 19
@@ -422,10 +420,7 @@ menus:
   friends_menu:
     title: "&8» &a&lGestion d'Amis"
     size: 54
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,45,53]
-        material: "GREEN_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       friends_online:
         slot: 20
@@ -530,47 +525,8 @@ menus:
   groups_menu:
     title: "&8» &e&lGestion de Groupes"
     size: 54
+    design_template: "social"
     items:
-      decor_0:
-        slot: 0
-        material: YELLOW_STAINED_GLASS_PANE
-        name: "&7"
-      decor_1:
-        slot: 1
-        material: YELLOW_STAINED_GLASS_PANE
-        name: "&7"
-      decor_2:
-        slot: 2
-        material: YELLOW_STAINED_GLASS_PANE
-        name: "&7"
-      decor_6:
-        slot: 6
-        material: YELLOW_STAINED_GLASS_PANE
-        name: "&7"
-      decor_7:
-        slot: 7
-        material: YELLOW_STAINED_GLASS_PANE
-        name: "&7"
-      decor_8:
-        slot: 8
-        material: YELLOW_STAINED_GLASS_PANE
-        name: "&7"
-      decor_9:
-        slot: 9
-        material: YELLOW_STAINED_GLASS_PANE
-        name: "&7"
-      decor_17:
-        slot: 17
-        material: YELLOW_STAINED_GLASS_PANE
-        name: "&7"
-      decor_45:
-        slot: 45
-        material: YELLOW_STAINED_GLASS_PANE
-        name: "&7"
-      decor_53:
-        slot: 53
-        material: YELLOW_STAINED_GLASS_PANE
-        name: "&7"
       group_current:
         slot: 20
         material: PLAYER_HEAD
@@ -677,10 +633,7 @@ menus:
   clan_info_menu:
     title: "&8» &c&lMon Clan"
     size: 27
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,18,26]
-        material: "RED_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       details:
         slot: 13
@@ -705,7 +658,8 @@ menus:
           - "[MENU] clan_menu"
       close:
         slot: 26
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -715,14 +669,12 @@ menus:
   clan_members_menu:
     title: "&8» &c&lMembres du Clan"
     size: 27
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,18,26]
-        material: "RED_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       summary:
         slot: 13
-        material: BOOK
+        material: PLAYER_HEAD
+        head: "hdb:9969"
         name: "&eListe des membres"
         lore:
           - "&7Membres totaux: &a%clan_members%"
@@ -740,7 +692,8 @@ menus:
           - "[MENU] clan_menu"
       close:
         slot: 26
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -750,14 +703,12 @@ menus:
   clan_ranks_menu:
     title: "&8» &d&lRangs de Clan"
     size: 27
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,18,26]
-        material: "RED_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       overview:
         slot: 13
-        material: PAPER
+        material: PLAYER_HEAD
+        head: "hdb:38878"
         name: "&dAperçu des rangs"
         lore:
           - "&7Votre rang: &6%clan_player_level%"
@@ -775,7 +726,8 @@ menus:
           - "[MENU] clan_menu"
       close:
         slot: 26
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -785,14 +737,12 @@ menus:
   clan_vault_menu:
     title: "&8» &a&lTrésor du Clan"
     size: 27
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,18,26]
-        material: "RED_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       vault_info:
         slot: 13
-        material: CHEST
+        material: PLAYER_HEAD
+        head: "hdb:35472"
         name: "&aInformations du coffre"
         lore:
           - "&7Solde: &e%clan_coins%"
@@ -809,7 +759,8 @@ menus:
           - "[MENU] clan_menu"
       close:
         slot: 26
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -819,14 +770,12 @@ menus:
   clan_wars_menu:
     title: "&8» &b&lGuerres de Clans"
     size: 27
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,18,26]
-        material: "RED_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       war_info:
         slot: 13
-        material: IRON_SWORD
+        material: PLAYER_HEAD
+        head: "hdb:23022"
         name: "&bStatistiques de guerre"
         lore:
           - "&7Statut: %clan_war_status%"
@@ -844,7 +793,8 @@ menus:
           - "[MENU] clan_menu"
       close:
         slot: 26
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -854,14 +804,12 @@ menus:
   clan_browse_menu:
     title: "&8» &e&lExplorer les Clans"
     size: 27
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,18,26]
-        material: "RED_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       listing:
         slot: 13
-        material: COMPASS
+        material: PLAYER_HEAD
+        head: "hdb:1455"
         name: "&eClans disponibles"
         lore:
           - "&7Clans ouverts: &a%clans_open_count%"
@@ -878,7 +826,8 @@ menus:
           - "[MENU] clan_menu"
       close:
         slot: 26
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -888,10 +837,7 @@ menus:
   friends_online_menu:
     title: "&8» &a&lAmis En Ligne"
     size: 27
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,18,26]
-        material: "GREEN_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       overview:
         slot: 13
@@ -913,7 +859,8 @@ menus:
           - "[MENU] friends_menu"
       close:
         slot: 26
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -923,14 +870,12 @@ menus:
   friend_requests_menu:
     title: "&8» &e&lDemandes d'Amis"
     size: 27
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,18,26]
-        material: "GREEN_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       summary:
         slot: 13
-        material: PAPER
+        material: PLAYER_HEAD
+        head: "hdb:1455"
         name: "&eDemandes en attente"
         lore:
           - "&7Reçues: &e%friend_requests_received%"
@@ -947,7 +892,8 @@ menus:
           - "[MENU] friends_menu"
       close:
         slot: 26
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -957,10 +903,7 @@ menus:
   friends_all_menu:
     title: "&8» &aMes Amis"
     size: 54
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,45,53]
-        material: "GREEN_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       overview:
         slot: 22
@@ -1032,7 +975,8 @@ menus:
           - "[MENU] friends_menu"
       close:
         slot: 53
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -1042,10 +986,7 @@ menus:
   clan_member_permissions_menu:
     title: "&8» &cPermissions de %clan_target_name%"
     size: 54
-    borders:
-      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
-        material: "RED_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       target_overview:
         slot: 4
@@ -1215,7 +1156,8 @@ menus:
           - "[CLAN_MEMBERS]"
       close:
         slot: 53
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -1225,10 +1167,7 @@ menus:
   clan_member_management_menu:
     title: "&8» &eGestion &6%clan_target_name%"
     size: 54
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,45,53]
-        material: "RED_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       member_info:
         slot: 13
@@ -1334,7 +1273,8 @@ menus:
           - "[CLAN_MEMBERS]"
       close:
         slot: 53
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -1344,10 +1284,7 @@ menus:
   clan_creation_menu:
     title: "&8» &cCréation de Clan"
     size: 54
-    borders:
-      - slots: [0,1,2,3,4,5,6,7,8,9,17,18,26,27,35,36,37,38,39,40,41,42,43,44,46,47,48,50,51,52]
-        material: "RED_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       overview:
         slot: 22
@@ -1392,7 +1329,8 @@ menus:
           - "[MENU] clan_menu"
       close:
         slot: 53
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -1402,10 +1340,7 @@ menus:
   clan_shop_menu:
     title: "&8» &cBoutique de Clan"
     size: 54
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,45,53]
-        material: "RED_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       treasury:
         slot: 22
@@ -1452,7 +1387,8 @@ menus:
           - "[MENU] clan_menu"
       close:
         slot: 53
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -1515,7 +1451,8 @@ menus:
           - "[MENU] profil_menu"
       close:
         slot: 53
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -1593,7 +1530,8 @@ menus:
           - "[MENU] profil_menu"
       close:
         slot: 53
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -1651,7 +1589,8 @@ menus:
           - "[MENU] profil_menu"
       close:
         slot: 53
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -1661,10 +1600,7 @@ menus:
   friend_settings_menu:
     title: "&8» &dParamètres d'Amis"
     size: 54
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,45,53]
-        material: "GREEN_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       summary:
         slot: 4
@@ -1766,7 +1702,8 @@ menus:
           - "[MENU] friends_all_menu"
       close:
         slot: 53
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -1776,10 +1713,7 @@ menus:
   friends_favorites_menu:
     title: "&8» &6Mes Favoris"
     size: 54
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,45,53]
-        material: "GREEN_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       favorites_overview:
         slot: 22
@@ -1852,10 +1786,7 @@ menus:
   group_manage_menu:
     title: "&8» &eMon Groupe"
     size: 54
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,45,53]
-        material: "YELLOW_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       group_info:
         slot: 22
@@ -1932,10 +1863,7 @@ menus:
   group_browse_menu:
     title: "&8» &bExplorer les Groupes"
     size: 54
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,45,53]
-        material: "YELLOW_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       browse_info:
         slot: 22
@@ -1948,7 +1876,8 @@ menus:
           - "&7Invitations en attente: &f%group_invitations%"
       search_tip:
         slot: 20
-        material: COMPASS
+        material: PLAYER_HEAD
+        head: "hdb:1455"
         name: "&e&lRecherche"
         lore:
           - "&7Parcourez les groupes recommandés"
@@ -1985,7 +1914,8 @@ menus:
           - "[MENU] group_settings_menu"
       close:
         slot: 53
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -1995,14 +1925,12 @@ menus:
   group_invite_menu:
     title: "&8» &d&lInvitations de Groupe"
     size: 27
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,18,26]
-        material: "YELLOW_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       invite_info:
         slot: 13
-        material: PAPER
+        material: PLAYER_HEAD
+        head: "hdb:7439"
         name: "&dInvitations"
         lore:
           - "&7Amis en ligne: &a%friends_online_count%"
@@ -2019,7 +1947,8 @@ menus:
           - "[MENU] groups_menu"
       close:
         slot: 26
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -2029,14 +1958,12 @@ menus:
   queue_menu:
     title: "&8» &6&lFiles d'Attente"
     size: 27
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,18,26]
-        material: "YELLOW_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       queue_info:
         slot: 13
-        material: CLOCK
+        material: PLAYER_HEAD
+        head: "hdb:23022"
         name: "&6Statut des files"
         lore:
           - "&7Files disponibles: %queue_available%"
@@ -2053,7 +1980,8 @@ menus:
           - "[MENU] groups_menu"
       close:
         slot: 26
-        material: BARRIER
+        material: PLAYER_HEAD
+        head: "hdb:60776"
         name: "&cFermer"
         lore:
           - "&7Fermer le menu"
@@ -2063,10 +1991,7 @@ menus:
   group_settings_menu:
     title: "&8» &eParamètres de Groupe"
     size: 54
-    borders:
-      - slots: [0,1,2,6,7,8,9,17,45,53]
-        material: "YELLOW_STAINED_GLASS_PANE"
-        name: "&7"
+    design_template: "social"
     items:
       auto_accept:
         slot: 19

--- a/src/main/resources/config/menus/clan_menu.yml
+++ b/src/main/resources/config/menus/clan_menu.yml
@@ -2,10 +2,7 @@ menu:
   id: "clan_menu"
   title: "&8» &c&lGestion de Clan"
   size: 54
-  borders:
-    - slots: [0,1,2,6,7,8,9,17,45,53]
-      material: "RED_STAINED_GLASS_PANE"
-      name: "&7"
+  design_template: "social"
 
   items:
     my_clan:

--- a/src/main/resources/config/menus/friends_menu.yml
+++ b/src/main/resources/config/menus/friends_menu.yml
@@ -2,10 +2,7 @@ menu:
   id: "friends_menu"
   title: "&8» &a&lGestion d'Amis"
   size: 54
-  borders:
-    - slots: [0,1,2,6,7,8,9,17,45,53]
-      material: "GREEN_STAINED_GLASS_PANE"
-      name: "&7"
+  design_template: "social"
 
   items:
     friends_online:

--- a/src/main/resources/config/menus/groups_menu.yml
+++ b/src/main/resources/config/menus/groups_menu.yml
@@ -2,10 +2,7 @@ menu:
   id: "groups_menu"
   title: "&8» &e&lGestion de Groupes"
   size: 54
-  borders:
-    - slots: [0,1,2,6,7,8,9,17,45,53]
-      material: "YELLOW_STAINED_GLASS_PANE"
-      name: "&7"
+  design_template: "social"
 
   items:
     current_group:

--- a/src/main/resources/config/menus/social_design_template.yml
+++ b/src/main/resources/config/menus/social_design_template.yml
@@ -1,0 +1,8 @@
+design:
+  decorative_glass: "BLUE_STAINED_GLASS_PANE"
+  confirm_glass: "GREEN_STAINED_GLASS_PANE"
+  cancel_glass: "RED_STAINED_GLASS_PANE"
+  info_glass: "LIGHT_BLUE_STAINED_GLASS_PANE"
+
+  decoration_slots: [0, 1, 2, 6, 7, 8, 45, 53]
+  border_slots: [9, 17, 18, 26, 27, 35, 36, 44]


### PR DESCRIPTION
## Summary
- add a reusable design template loader so configured menus can share a unified look
- enforce a short click cooldown inside social menus to avoid duplicate actions
- convert the social menu YAML definitions to use the template and HeadDatabase icons, including a new template file

## Testing
- mvn -DskipTests package *(fails: network unreachable while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d047fa9ac483298a6663866abc6e8a