### PR TITLE
Implement clan role management and menus

### DIFF
--- a/src/main/java/com/lobby/social/SocialPlaceholderManager.java
+++ b/src/main/java/com/lobby/social/SocialPlaceholderManager.java
@@ -356,14 +356,15 @@ public class SocialPlaceholderManager {
         replacements.put("%clan_online%", String.valueOf(onlineCount));
 
         final ClanMember member = clan.getMember(player.getUniqueId());
+        final ClanRank rank = member != null ? clan.getRank(member.getRankName()) : null;
         if (member != null) {
-            replacements.put("%clan_rank%", member.getRankName());
-            replacements.put("%clan_player_level%", member.getRankName());
+            final String displayRank = rank != null ? rank.getDisplayName() : member.getRankName();
+            replacements.put("%clan_rank%", displayRank);
+            replacements.put("%clan_player_level%", displayRank);
             replacements.put("%clan_contributions%", String.valueOf(member.getTotalContributions()));
             replacements.put("%clan_last_activity%", formatRelativeTime(member.getJoinedAt()));
         }
 
-        final ClanRank rank = member != null ? clan.getRank(member.getRankName()) : null;
         if (rank != null) {
             final String permissions = rank.getPermissions().isEmpty()
                     ? "Standard"
@@ -376,7 +377,7 @@ public class SocialPlaceholderManager {
             replacements.put("%clan_player_level%", rank.getDisplayName());
         }
 
-        final boolean vaultAccess = clan.hasPermission(player.getUniqueId(), ClanPermission.MANAGE_BANK);
+        final boolean vaultAccess = clan.hasPermission(player.getUniqueId(), ClanPermission.MANAGE_CLAN_INFO);
         replacements.put("%clan_vault_access%", vaultAccess ? "Autorisé" : "Réservé");
 
         final UUID targetUuid = clanPermissionTargets.get(player.getUniqueId());
@@ -386,9 +387,10 @@ public class SocialPlaceholderManager {
                 final String targetName = resolveName(targetUuid);
                 replacements.put("%clan_target_uuid%", targetUuid.toString());
                 replacements.put("%clan_target_name%", targetName);
-                replacements.put("%clan_target_rank%", target.getRankName());
-
                 final ClanRank targetRank = clan.getRank(target.getRankName());
+                replacements.put("%clan_target_rank%", targetRank != null
+                        ? targetRank.getDisplayName()
+                        : target.getRankName());
                 replacements.put("%clan_target_rank_display%", targetRank != null
                         ? targetRank.getDisplayName()
                         : target.getRankName());
@@ -412,19 +414,19 @@ public class SocialPlaceholderManager {
                 replacements.put("%clan_target_previous_rank%", previousRank != null ? previousRank.getDisplayName() : "Aucun");
 
                 replacements.put("%clan_permission_invite_status%", formatPermissionStatus(
-                        clan.hasPermission(targetUuid, ClanPermission.INVITE)));
+                        clan.hasPermission(targetUuid, ClanPermission.INVITE_MEMBERS)));
                 replacements.put("%clan_permission_kick_status%", formatPermissionStatus(
-                        clan.hasPermission(targetUuid, ClanPermission.KICK)));
+                        clan.hasPermission(targetUuid, ClanPermission.KICK_MEMBERS)));
                 replacements.put("%clan_permission_promote_status%", formatPermissionStatus(
-                        clan.hasPermission(targetUuid, ClanPermission.PROMOTE)));
+                        clan.hasPermission(targetUuid, ClanPermission.PROMOTE_MEMBERS)));
                 replacements.put("%clan_permission_demote_status%", formatPermissionStatus(
-                        clan.hasPermission(targetUuid, ClanPermission.DEMOTE)));
+                        clan.hasPermission(targetUuid, ClanPermission.DEMOTE_MEMBERS)));
                 replacements.put("%clan_permission_manage_ranks_status%", formatPermissionStatus(
-                        clan.hasPermission(targetUuid, ClanPermission.MANAGE_RANKS)));
+                        clan.hasPermission(targetUuid, ClanPermission.MANAGE_PERMISSIONS)));
                 replacements.put("%clan_permission_withdraw_status%", formatPermissionStatus(
-                        clan.hasPermission(targetUuid, ClanPermission.MANAGE_BANK)));
+                        clan.hasPermission(targetUuid, ClanPermission.MANAGE_CLAN_INFO)));
                 replacements.put("%clan_permission_disband_status%", formatPermissionStatus(
-                        clan.hasPermission(targetUuid, ClanPermission.DISBAND)));
+                        clan.hasPermission(targetUuid, ClanPermission.DISBAND_CLAN)));
 
                 final boolean isSelf = player.getUniqueId().equals(targetUuid);
                 final boolean targetIsLeader = clan.isLeader(targetUuid);
@@ -438,9 +440,9 @@ public class SocialPlaceholderManager {
                 final boolean canKickTarget = !isSelf && !targetIsLeader
                         && clanManager.hasPermission(clan.getId(), player.getUniqueId(), "clan.kick");
                 final boolean canBanTarget = !isSelf && !targetIsLeader
-                        && (clan.isLeader(player.getUniqueId())
-                        || clan.hasPermission(player.getUniqueId(), ClanPermission.DISBAND));
-                final boolean canTransfer = clan.isLeader(player.getUniqueId()) && !isSelf && !targetIsLeader;
+                        && clan.hasPermission(player.getUniqueId(), ClanPermission.BAN_MEMBERS);
+                final boolean canTransfer = !isSelf && !targetIsLeader
+                        && clan.hasPermission(player.getUniqueId(), ClanPermission.TRANSFER_LEADERSHIP);
 
                 replacements.put("%clan_target_can_promote%", formatActionStatus(canPromoteTarget));
                 replacements.put("%clan_target_can_demote%", formatActionStatus(canDemoteTarget));

--- a/src/main/java/com/lobby/social/clans/Clan.java
+++ b/src/main/java/com/lobby/social/clans/Clan.java
@@ -3,6 +3,7 @@ package com.lobby.social.clans;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -126,11 +127,24 @@ public class Clan {
     }
 
     public void addRank(final ClanRank rank) {
-        ranks.put(rank.getName(), rank);
+        if (rank == null) {
+            return;
+        }
+        ranks.put(normalize(rank.getName()), rank);
     }
 
     public ClanRank getRank(final String name) {
-        return ranks.get(name);
+        if (name == null) {
+            return null;
+        }
+        final ClanRank direct = ranks.get(normalize(name));
+        if (direct != null) {
+            return direct;
+        }
+        return ranks.values().stream()
+                .filter(rank -> rank.getDisplayName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElse(null);
     }
 
     public boolean isLeader(final UUID uuid) {
@@ -164,5 +178,9 @@ public class Clan {
             points -= requiredPoints;
             maxMembers += 5;
         }
+    }
+
+    private String normalize(final String value) {
+        return value.toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/java/com/lobby/social/clans/ClanManager.java
+++ b/src/main/java/com/lobby/social/clans/ClanManager.java
@@ -36,7 +36,7 @@ public class ClanManager {
     private final Map<String, Clan> clanCache = new HashMap<>();
     private final Map<Integer, Clan> clanCacheById = new HashMap<>();
     private final Map<UUID, String> playerClanCache = new HashMap<>();
-    private final Map<Integer, Set<UUID>> clanBanCache = new ConcurrentHashMap<>();
+    private final Map<Integer, Map<UUID, ClanBanEntry>> clanBanCache = new ConcurrentHashMap<>();
 
     public ClanManager(final LobbyPlugin plugin) {
         this.plugin = plugin;
@@ -98,7 +98,7 @@ public class ClanManager {
             inviter.sendMessage("§cVous n'êtes dans aucun clan !");
             return false;
         }
-        if (!clan.hasPermission(inviter.getUniqueId(), ClanPermission.INVITE)) {
+        if (!clan.hasPermission(inviter.getUniqueId(), ClanPermission.INVITE_MEMBERS)) {
             inviter.sendMessage("§cVous n'avez pas la permission d'inviter des joueurs !");
             return false;
         }
@@ -158,8 +158,9 @@ public class ClanManager {
             player.sendMessage("§cVous êtes banni de ce clan.");
             return;
         }
-        saveMember(clan.getId(), player.getUniqueId(), "Membre");
-        clan.addMember(new ClanMember(player.getUniqueId(), "Membre", System.currentTimeMillis(), 0L));
+        final String memberRankName = resolveRankName(clan, ClanRole.MEMBER);
+        saveMember(clan.getId(), player.getUniqueId(), memberRankName);
+        clan.addMember(new ClanMember(player.getUniqueId(), memberRankName, System.currentTimeMillis(), 0L));
         playerClanCache.put(player.getUniqueId(), clan.getName().toLowerCase(Locale.ROOT));
         updateInvitationStatus(invitation.getId(), "ACCEPTED");
         broadcastClanMessage(clan, "§a" + player.getName() + " a rejoint le clan !");
@@ -256,7 +257,7 @@ public class ClanManager {
         if (clan == null || targetClan == null || clan.getId() != targetClan.getId()) {
             return false;
         }
-        if (!clan.hasPermission(managerUuid, ClanPermission.MANAGE_RANKS)) {
+        if (!clan.hasPermission(managerUuid, ClanPermission.MANAGE_PERMISSIONS)) {
             return false;
         }
         if (clan.isLeader(memberUuid)) {
@@ -294,7 +295,7 @@ public class ClanManager {
         if (clan == null || targetClan == null || clan.getId() != targetClan.getId()) {
             return false;
         }
-        if (!clan.hasPermission(managerUuid, ClanPermission.MANAGE_RANKS)) {
+        if (!clan.hasPermission(managerUuid, ClanPermission.MANAGE_PERMISSIONS)) {
             return false;
         }
         if (clan.isLeader(memberUuid)) {
@@ -385,8 +386,8 @@ public class ClanManager {
         return getPreviousRank(clan, currentPriority);
     }
 
-    public boolean promotePlayer(final UUID promoter, final UUID target) {
-        if (promoter == null || target == null) {
+    public boolean promoteMember(final UUID promoter, final UUID target) {
+        if (promoter == null || target == null || promoter.equals(target)) {
             return false;
         }
         final Clan clan = getPlayerClan(promoter);
@@ -394,9 +395,13 @@ public class ClanManager {
         if (clan == null || targetClan == null || clan.getId() != targetClan.getId()) {
             return false;
         }
-        if (!hasPermission(clan.getId(), promoter, "clan.promote")) {
+        if (!clan.hasPermission(promoter, ClanPermission.PROMOTE_MEMBERS)) {
             return false;
         }
+        if (clan.isLeader(target)) {
+            return false;
+        }
+
         final ClanRank currentRank = getPlayerRank(clan, target);
         if (currentRank == null) {
             return false;
@@ -405,11 +410,27 @@ public class ClanManager {
         if (nextRank == null) {
             return false;
         }
+
         final ClanRank promoterRank = getPlayerRank(clan, promoter);
-        if (!clan.isLeader(promoter) && promoterRank != null
+        final ClanRole promoterRole = getMemberRole(clan, promoter);
+        final ClanRole targetRole = getMemberRole(clan, target);
+        ClanRole nextRole = ClanRole.fromName(nextRank.getName());
+        if (nextRole == null) {
+            nextRole = ClanRole.fromName(nextRank.getDisplayName());
+        }
+
+        if (promoterRole != null && promoterRole != ClanRole.LEADER) {
+            if (targetRole != null && targetRole.getLevel() >= promoterRole.getLevel()) {
+                return false;
+            }
+            if (nextRole != null && nextRole.getLevel() >= promoterRole.getLevel()) {
+                return false;
+            }
+        } else if (!clan.isLeader(promoter) && promoterRank != null
                 && nextRank.getPriority() >= promoterRank.getPriority()) {
             return false;
         }
+
         if (setPlayerRank(clan, target, nextRank)) {
             final String targetName = getNameByUuid(target);
             broadcastRankChangeMessage(clan, targetName != null ? targetName : target.toString(),
@@ -419,8 +440,8 @@ public class ClanManager {
         return false;
     }
 
-    public boolean demotePlayer(final UUID demoter, final UUID target) {
-        if (demoter == null || target == null) {
+    public boolean demoteMember(final UUID demoter, final UUID target) {
+        if (demoter == null || target == null || demoter.equals(target)) {
             return false;
         }
         final Clan clan = getPlayerClan(demoter);
@@ -428,12 +449,13 @@ public class ClanManager {
         if (clan == null || targetClan == null || clan.getId() != targetClan.getId()) {
             return false;
         }
-        if (!hasPermission(clan.getId(), demoter, "clan.demote")) {
+        if (!clan.hasPermission(demoter, ClanPermission.DEMOTE_MEMBERS)) {
             return false;
         }
         if (clan.isLeader(target)) {
             return false;
         }
+
         final ClanRank currentRank = getPlayerRank(clan, target);
         if (currentRank == null) {
             return false;
@@ -442,11 +464,27 @@ public class ClanManager {
         if (previousRank == null) {
             return false;
         }
+
         final ClanRank demoterRank = getPlayerRank(clan, demoter);
-        if (!clan.isLeader(demoter) && demoterRank != null
+        final ClanRole demoterRole = getMemberRole(clan, demoter);
+        final ClanRole targetRole = getMemberRole(clan, target);
+        ClanRole previousRole = ClanRole.fromName(previousRank.getName());
+        if (previousRole == null) {
+            previousRole = ClanRole.fromName(previousRank.getDisplayName());
+        }
+
+        if (demoterRole != null && demoterRole != ClanRole.LEADER) {
+            if (targetRole != null && targetRole.getLevel() >= demoterRole.getLevel()) {
+                return false;
+            }
+            if (previousRole != null && previousRole.getLevel() >= demoterRole.getLevel()) {
+                return false;
+            }
+        } else if (!clan.isLeader(demoter) && demoterRank != null
                 && previousRank.getPriority() >= demoterRank.getPriority()) {
             return false;
         }
+
         if (setPlayerRank(clan, target, previousRank)) {
             final String targetName = getNameByUuid(target);
             broadcastRankChangeMessage(clan, targetName != null ? targetName : target.toString(),
@@ -456,69 +494,138 @@ public class ClanManager {
         return false;
     }
 
-    public boolean kickMember(final UUID executorUuid, final UUID targetUuid) {
-        if (executorUuid == null || targetUuid == null) {
+    public boolean kickMember(final UUID kicker, final UUID target, final String reason) {
+        if (kicker == null || target == null || kicker.equals(target)) {
             return false;
         }
-        final Clan clan = getPlayerClan(executorUuid);
-        final Clan targetClan = getPlayerClan(targetUuid);
+        final Clan clan = getPlayerClan(kicker);
+        final Clan targetClan = getPlayerClan(target);
         if (clan == null || targetClan == null || clan.getId() != targetClan.getId()) {
             return false;
         }
-        if (executorUuid.equals(targetUuid) || clan.isLeader(targetUuid)) {
+        if (!clan.hasPermission(kicker, ClanPermission.KICK_MEMBERS)) {
             return false;
         }
-        if (!hasPermission(clan.getId(), executorUuid, "clan.kick")) {
+        if (clan.isLeader(target)) {
             return false;
         }
-        final String targetName = getNameByUuid(targetUuid);
-        if (!removeMemberFromClan(clan, targetUuid)) {
+
+        final ClanRole kickerRole = getMemberRole(clan, kicker);
+        final ClanRole targetRole = getMemberRole(clan, target);
+        final ClanRank kickerRank = getPlayerRank(clan, kicker);
+        final ClanRank targetRank = getPlayerRank(clan, target);
+
+        if (kickerRole != null && targetRole != null && kickerRole != ClanRole.LEADER
+                && targetRole.getLevel() >= kickerRole.getLevel()) {
             return false;
         }
-        broadcastLeaveMessage(clan, targetName != null ? targetName : targetUuid.toString(), "Expulsé");
-        final Player executor = Bukkit.getPlayer(executorUuid);
+        if ((kickerRole == null || targetRole == null) && kickerRank != null && targetRank != null
+                && !clan.isLeader(kicker) && targetRank.getPriority() >= kickerRank.getPriority()) {
+            return false;
+        }
+
+        if (!removeMemberFromClan(clan, target)) {
+            return false;
+        }
+
+        final String targetName = getNameByUuid(target);
+        final String finalReason = (reason != null && !reason.isBlank()) ? reason : "Expulsé";
+        broadcastLeaveMessage(clan, targetName != null ? targetName : target.toString(), finalReason);
+
+        final Player executor = Bukkit.getPlayer(kicker);
         if (executor != null) {
-            executor.sendMessage("§aVous avez expulsé §6" + (targetName != null ? targetName : targetUuid));
+            executor.sendMessage("§aVous avez expulsé §6" + (targetName != null ? targetName : target)
+                    + " §adu clan." + (reason != null && !reason.isBlank() ? " §7Raison: §f" + reason : ""));
         }
-        final Player kicked = Bukkit.getPlayer(targetUuid);
+        final Player kicked = Bukkit.getPlayer(target);
         if (kicked != null) {
-            kicked.sendMessage("§cVous avez été expulsé du clan §6" + clan.getName() + "§c.");
+            kicked.sendMessage("§cVous avez été expulsé du clan §6" + clan.getName() + "§c." +
+                    (reason != null && !reason.isBlank() ? " §7Raison: §f" + reason : ""));
             kicked.closeInventory();
         }
         return true;
     }
 
-    public boolean banMember(final UUID executorUuid, final UUID targetUuid) {
-        if (executorUuid == null || targetUuid == null) {
+    public boolean banMember(final UUID banner, final UUID target, final String reason, final long durationMs) {
+        if (banner == null || target == null || banner.equals(target)) {
             return false;
         }
-        final Clan clan = getPlayerClan(executorUuid);
-        final Clan targetClan = getPlayerClan(targetUuid);
+        final Clan clan = getPlayerClan(banner);
+        final Clan targetClan = getPlayerClan(target);
         if (clan == null || targetClan == null || clan.getId() != targetClan.getId()) {
             return false;
         }
-        if (executorUuid.equals(targetUuid) || clan.isLeader(targetUuid)) {
+        if (!clan.hasPermission(banner, ClanPermission.BAN_MEMBERS)) {
             return false;
         }
-        if (!clan.isLeader(executorUuid) && !clan.hasPermission(executorUuid, ClanPermission.DISBAND)) {
+        if (clan.isLeader(target)) {
             return false;
         }
-        final String targetName = getNameByUuid(targetUuid);
-        if (!removeMemberFromClan(clan, targetUuid)) {
+
+        final ClanRole bannerRole = getMemberRole(clan, banner);
+        final ClanRole targetRole = getMemberRole(clan, target);
+        final ClanRank bannerRank = getPlayerRank(clan, banner);
+        final ClanRank targetRank = getPlayerRank(clan, target);
+
+        if (bannerRole != null && targetRole != null && bannerRole != ClanRole.LEADER
+                && targetRole.getLevel() >= bannerRole.getLevel()) {
             return false;
         }
-        addClanBan(clan.getId(), targetUuid);
-        broadcastLeaveMessage(clan, targetName != null ? targetName : targetUuid.toString(), "Banni");
-        final Player executor = Bukkit.getPlayer(executorUuid);
+        if ((bannerRole == null || targetRole == null) && bannerRank != null && targetRank != null
+                && !clan.isLeader(banner) && targetRank.getPriority() >= bannerRank.getPriority()) {
+            return false;
+        }
+
+        if (!removeMemberFromClan(clan, target)) {
+            return false;
+        }
+
+        addClanBan(clan.getId(), target, reason, durationMs);
+        final String targetName = getNameByUuid(target);
+        final String finalReason = (reason != null && !reason.isBlank()) ? reason : "Banni";
+        broadcastLeaveMessage(clan, targetName != null ? targetName : target.toString(), finalReason);
+
+        final Player executor = Bukkit.getPlayer(banner);
         if (executor != null) {
-            executor.sendMessage("§cVous avez banni §6" + (targetName != null ? targetName : targetUuid) + " §cdu clan.");
+            executor.sendMessage("§cVous avez banni §6" + (targetName != null ? targetName : target)
+                    + " §cdu clan." + (reason != null && !reason.isBlank() ? " §7Raison: §f" + reason : ""));
         }
-        final Player banned = Bukkit.getPlayer(targetUuid);
-        if (banned != null) {
-            banned.sendMessage("§cVous avez été banni définitivement du clan §6" + clan.getName() + "§c.");
-            banned.closeInventory();
+        final Player bannedPlayer = Bukkit.getPlayer(target);
+        if (bannedPlayer != null) {
+            final StringBuilder message = new StringBuilder("§cVous avez été banni du clan §6")
+                    .append(clan.getName()).append("§c.");
+            if (reason != null && !reason.isBlank()) {
+                message.append(" §7Raison: §f").append(reason).append('.');
+            }
+            if (durationMs > 0L) {
+                message.append(" §7Durée: §f").append(formatDuration(durationMs)).append('.');
+            } else {
+                message.append(" §7Durée: §fDéfinitive.");
+            }
+            bannedPlayer.sendMessage(message.toString());
+            bannedPlayer.closeInventory();
         }
         return true;
+    }
+
+    @Deprecated
+    public boolean promotePlayer(final UUID promoter, final UUID target) {
+        return promoteMember(promoter, target);
+    }
+
+    @Deprecated
+    public boolean demotePlayer(final UUID demoter, final UUID target) {
+        return demoteMember(demoter, target);
+    }
+
+    @Deprecated
+    public boolean kickMember(final UUID executorUuid, final UUID targetUuid) {
+        return kickMember(executorUuid, targetUuid, null);
+    }
+
+    @Deprecated
+    public boolean banMember(final UUID executorUuid, final UUID targetUuid) {
+        return banMember(executorUuid, targetUuid, null, -1L);
     }
 
     public boolean transferLeadership(final UUID currentLeaderUuid, final UUID targetUuid) {
@@ -537,14 +644,16 @@ public class ClanManager {
         if (targetMember == null) {
             return false;
         }
-        final ClanRank leaderRank = clan.getRank("Leader");
-        final ClanRank fallbackRank = leaderRank != null
-                ? getPreviousRank(clan, leaderRank.getPriority())
-                : null;
-        final ClanRank memberRank = clan.getRank("Membre");
-        final ClanRank newLeaderRank = leaderRank != null ? leaderRank : memberRank;
-        final ClanRank newFormerLeaderRank = fallbackRank != null ? fallbackRank : memberRank;
-        if (newLeaderRank == null || newFormerLeaderRank == null) {
+        final ClanRank leaderRank = getRankForRole(clan, ClanRole.LEADER);
+        ClanRole fallbackRole = ClanRole.CO_LEADER;
+        if (getRankForRole(clan, fallbackRole) == null) {
+            fallbackRole = ClanRole.MODERATOR;
+            if (getRankForRole(clan, fallbackRole) == null) {
+                fallbackRole = ClanRole.MEMBER;
+            }
+        }
+        final ClanRank newLeaderRank = leaderRank != null ? leaderRank : getRankForRole(clan, ClanRole.MEMBER);
+        if (newLeaderRank == null) {
             return false;
         }
         final String updateLeaderQuery = "UPDATE clans SET leader_uuid = ? WHERE id = ?";
@@ -561,8 +670,8 @@ public class ClanManager {
             return false;
         }
         clan.setLeaderUUID(targetUuid);
-        setPlayerRank(clan, targetUuid, newLeaderRank);
-        setPlayerRank(clan, currentLeaderUuid, newFormerLeaderRank);
+        updateMemberRole(clan, targetUuid, ClanRole.LEADER);
+        updateMemberRole(clan, currentLeaderUuid, fallbackRole);
 
         final String oldLeaderName = getNameByUuid(currentLeaderUuid);
         final String newLeaderName = getNameByUuid(targetUuid);
@@ -607,7 +716,7 @@ public class ClanManager {
         if (clan == null) {
             return false;
         }
-        if (!clan.hasPermission(player.getUniqueId(), ClanPermission.MANAGE_BANK)) {
+        if (!clan.hasPermission(player.getUniqueId(), ClanPermission.MANAGE_CLAN_INFO)) {
             return false;
         }
         if (clan.getBankCoins() < amount) {
@@ -770,20 +879,26 @@ public class ClanManager {
         final String key = permissionKey.toLowerCase(Locale.ROOT);
         switch (key) {
             case "clan.invite":
-                return ClanPermission.INVITE;
+                return ClanPermission.INVITE_MEMBERS;
             case "clan.manage_bank":
             case "clan.withdraw":
-                return ClanPermission.MANAGE_BANK;
+            case "clan.manage_info":
+                return ClanPermission.MANAGE_CLAN_INFO;
             case "clan.kick":
-                return ClanPermission.KICK;
+                return ClanPermission.KICK_MEMBERS;
             case "clan.promote":
-                return ClanPermission.PROMOTE;
+                return ClanPermission.PROMOTE_MEMBERS;
             case "clan.demote":
-                return ClanPermission.DEMOTE;
+                return ClanPermission.DEMOTE_MEMBERS;
+            case "clan.ban":
+                return ClanPermission.BAN_MEMBERS;
             case "clan.manage_ranks":
-                return ClanPermission.MANAGE_RANKS;
+            case "clan.manage_permissions":
+                return ClanPermission.MANAGE_PERMISSIONS;
+            case "clan.transfer":
+                return ClanPermission.TRANSFER_LEADERSHIP;
             case "clan.disband":
-                return ClanPermission.DISBAND;
+                return ClanPermission.DISBAND_CLAN;
             default:
                 return null;
         }
@@ -839,17 +954,18 @@ public class ClanManager {
     }
 
     private void setupDefaultRanks(final Clan clan) {
-        final EnumSet<ClanPermission> leaderPermissions = EnumSet.allOf(ClanPermission.class);
-        final ClanRank leaderRank = new ClanRank("Leader", Integer.MAX_VALUE, leaderPermissions);
-        clan.addRank(leaderRank);
-        saveRank(clan.getId(), leaderRank);
+        for (final ClanRole role : ClanRole.values()) {
+            final EnumSet<ClanPermission> permissions = role == ClanRole.LEADER
+                    ? EnumSet.allOf(ClanPermission.class)
+                    : role.getPermissions();
+            final ClanRank rank = new ClanRank(role.name(), role.getDisplayName(), role.getLevel(), permissions);
+            clan.addRank(rank);
+            saveRank(clan.getId(), rank);
+        }
 
-        final EnumSet<ClanPermission> memberPermissions = EnumSet.noneOf(ClanPermission.class);
-        final ClanRank memberRank = new ClanRank("Membre", 0, memberPermissions);
-        clan.addRank(memberRank);
-        saveRank(clan.getId(), memberRank);
-
-        clan.addMember(new ClanMember(clan.getLeaderUUID(), leaderRank.getName(), System.currentTimeMillis(), 0L));
+        final ClanRank leaderRank = getRankForRole(clan, ClanRole.LEADER);
+        final String rankName = leaderRank != null ? leaderRank.getName() : ClanRole.LEADER.name();
+        clan.addMember(new ClanMember(clan.getLeaderUUID(), rankName, System.currentTimeMillis(), 0L));
     }
 
     private void saveRank(final int clanId, final ClanRank rank) {
@@ -860,9 +976,9 @@ public class ClanManager {
             statement.setString(3, rank.getDisplayName());
             statement.setString(4, serializePermissions(rank.getPermissions()));
             statement.setInt(5, rank.getPriority());
-            statement.setBoolean(6, rank.hasPermission(ClanPermission.PROMOTE));
-            statement.setBoolean(7, rank.hasPermission(ClanPermission.DEMOTE));
-            statement.setBoolean(8, rank.hasPermission(ClanPermission.MANAGE_RANKS));
+            statement.setBoolean(6, rank.hasPermission(ClanPermission.PROMOTE_MEMBERS));
+            statement.setBoolean(7, rank.hasPermission(ClanPermission.DEMOTE_MEMBERS));
+            statement.setBoolean(8, rank.hasPermission(ClanPermission.MANAGE_PERMISSIONS));
             statement.executeUpdate();
         } catch (final SQLException exception) {
             plugin.getLogger().log(Level.SEVERE, "Failed to save clan rank", exception);
@@ -874,7 +990,7 @@ public class ClanManager {
         try (Connection connection = databaseManager.getConnection(); PreparedStatement statement = connection.prepareStatement(query)) {
             statement.setInt(1, clan.getId());
             statement.setString(2, leaderUUID.toString());
-            statement.setString(3, "Leader");
+            statement.setString(3, resolveRankName(clan, ClanRole.LEADER));
             statement.executeUpdate();
         } catch (final SQLException exception) {
             plugin.getLogger().log(Level.SEVERE, "Failed to add clan leader", exception);
@@ -915,19 +1031,32 @@ public class ClanManager {
         }
     }
 
-    private void addClanBan(final int clanId, final UUID memberUuid) {
+    private void addClanBan(final int clanId, final UUID memberUuid, final String reason, final long durationMs) {
         if (memberUuid == null) {
             return;
         }
-        clanBanCache.computeIfAbsent(clanId, key -> ConcurrentHashMap.newKeySet()).add(memberUuid);
+        final long expiresAt = durationMs <= 0L ? -1L : System.currentTimeMillis() + durationMs;
+        clanBanCache.computeIfAbsent(clanId, key -> new ConcurrentHashMap<>())
+                .put(memberUuid, new ClanBanEntry(memberUuid, reason, expiresAt));
     }
 
     private boolean isPlayerBanned(final int clanId, final UUID memberUuid) {
         if (memberUuid == null) {
             return false;
         }
-        final Set<UUID> bans = clanBanCache.get(clanId);
-        return bans != null && bans.contains(memberUuid);
+        final Map<UUID, ClanBanEntry> bans = clanBanCache.get(clanId);
+        if (bans == null) {
+            return false;
+        }
+        final ClanBanEntry entry = bans.get(memberUuid);
+        if (entry == null) {
+            return false;
+        }
+        if (!entry.isActive()) {
+            bans.remove(memberUuid);
+            return false;
+        }
+        return true;
     }
 
     private ClanInvitation saveInvitation(final int clanId, final UUID inviter, final UUID invited, final String message) {
@@ -1254,13 +1383,13 @@ public class ClanManager {
                     final int priority = resultSet.getInt("priority");
                     final Set<ClanPermission> permissions = deserializePermissions(permissionsString);
                     if (hasColumn(metaData, "can_promote") && resultSet.getBoolean("can_promote")) {
-                        permissions.add(ClanPermission.PROMOTE);
+                        permissions.add(ClanPermission.PROMOTE_MEMBERS);
                     }
                     if (hasColumn(metaData, "can_demote") && resultSet.getBoolean("can_demote")) {
-                        permissions.add(ClanPermission.DEMOTE);
+                        permissions.add(ClanPermission.DEMOTE_MEMBERS);
                     }
                     if (hasColumn(metaData, "can_manage_ranks") && resultSet.getBoolean("can_manage_ranks")) {
-                        permissions.add(ClanPermission.MANAGE_RANKS);
+                        permissions.add(ClanPermission.MANAGE_PERMISSIONS);
                     }
                     clan.addRank(new ClanRank(name, displayName, priority, permissions));
                 }
@@ -1311,13 +1440,67 @@ public class ClanManager {
             return null;
         }
         if (clan.isLeader(playerUuid)) {
-            return clan.getRank("Leader");
+            return getRankForRole(clan, ClanRole.LEADER);
         }
         final ClanMember member = clan.getMember(playerUuid);
         if (member == null) {
             return null;
         }
         return clan.getRank(member.getRankName());
+    }
+
+    private ClanRank getRankForRole(final Clan clan, final ClanRole role) {
+        if (clan == null || role == null) {
+            return null;
+        }
+        ClanRank rank = clan.getRank(role.name());
+        if (rank == null) {
+            rank = clan.getRank(role.getDisplayName());
+        }
+        return rank;
+    }
+
+    private String resolveRankName(final Clan clan, final ClanRole role) {
+        final ClanRank rank = getRankForRole(clan, role);
+        return rank != null ? rank.getName() : role.name();
+    }
+
+    private ClanRole getMemberRole(final Clan clan, final UUID memberUuid) {
+        if (clan == null || memberUuid == null) {
+            return null;
+        }
+        if (clan.isLeader(memberUuid)) {
+            return ClanRole.LEADER;
+        }
+        final ClanMember member = clan.getMember(memberUuid);
+        if (member == null) {
+            return null;
+        }
+        final String rankName = member.getRankName();
+        ClanRole role = ClanRole.fromName(rankName);
+        if (role != null) {
+            return role;
+        }
+        final ClanRank rank = clan.getRank(rankName);
+        if (rank != null) {
+            role = ClanRole.fromName(rank.getName());
+            if (role != null) {
+                return role;
+            }
+            role = ClanRole.fromName(rank.getDisplayName());
+            if (role != null) {
+                return role;
+            }
+        }
+        return null;
+    }
+
+    private boolean updateMemberRole(final Clan clan, final UUID memberUuid, final ClanRole newRole) {
+        if (clan == null || memberUuid == null || newRole == null) {
+            return false;
+        }
+        final ClanRank targetRank = getRankForRole(clan, newRole);
+        return targetRank != null && setPlayerRank(clan, memberUuid, targetRank);
     }
 
     private ClanRank getNextRank(final Clan clan, final int currentPriority) {
@@ -1435,12 +1618,16 @@ public class ClanManager {
         final String normalized = presetKey.toLowerCase(Locale.ROOT);
         return switch (normalized) {
             case "default", "aucun", "none" -> EnumSet.noneOf(ClanPermission.class);
-            case "moderateur", "moderator", "mod" -> EnumSet.of(ClanPermission.INVITE, ClanPermission.KICK);
-            case "officier", "officer" -> EnumSet.of(ClanPermission.INVITE, ClanPermission.KICK,
-                    ClanPermission.PROMOTE, ClanPermission.DEMOTE);
-            case "gestion", "manager" -> EnumSet.of(ClanPermission.INVITE, ClanPermission.KICK,
-                    ClanPermission.PROMOTE, ClanPermission.DEMOTE, ClanPermission.MANAGE_BANK);
-            case "banquier", "banker" -> EnumSet.of(ClanPermission.MANAGE_BANK);
+            case "moderateur", "moderator", "mod" -> EnumSet.of(
+                    ClanPermission.INVITE_MEMBERS, ClanPermission.KICK_MEMBERS);
+            case "officier", "officer" -> EnumSet.of(
+                    ClanPermission.INVITE_MEMBERS, ClanPermission.KICK_MEMBERS,
+                    ClanPermission.PROMOTE_MEMBERS, ClanPermission.DEMOTE_MEMBERS);
+            case "gestion", "manager" -> EnumSet.of(
+                    ClanPermission.INVITE_MEMBERS, ClanPermission.KICK_MEMBERS,
+                    ClanPermission.PROMOTE_MEMBERS, ClanPermission.DEMOTE_MEMBERS,
+                    ClanPermission.BAN_MEMBERS, ClanPermission.MANAGE_CLAN_INFO);
+            case "banquier", "banker" -> EnumSet.of(ClanPermission.MANAGE_CLAN_INFO);
             case "admin", "toutes", "all" -> EnumSet.allOf(ClanPermission.class);
             default -> EnumSet.noneOf(ClanPermission.class);
         };
@@ -1454,6 +1641,34 @@ public class ClanManager {
             }
         }
         return false;
+    }
+
+    private String formatDuration(final long durationMs) {
+        if (durationMs <= 0L) {
+            return "Permanent";
+        }
+        long remainingSeconds = durationMs / 1000L;
+        final long days = remainingSeconds / 86400L;
+        remainingSeconds %= 86400L;
+        final long hours = remainingSeconds / 3600L;
+        remainingSeconds %= 3600L;
+        final long minutes = remainingSeconds / 60L;
+        final long seconds = remainingSeconds % 60L;
+
+        final List<String> parts = new ArrayList<>();
+        if (days > 0L) {
+            parts.add(days + "j");
+        }
+        if (hours > 0L) {
+            parts.add(hours + "h");
+        }
+        if (minutes > 0L) {
+            parts.add(minutes + "m");
+        }
+        if (seconds > 0L || parts.isEmpty()) {
+            parts.add(seconds + "s");
+        }
+        return String.join(" ", parts);
     }
 
     private String getNameByUuid(final UUID uuid) {
@@ -1484,5 +1699,30 @@ public class ClanManager {
             plugin.getLogger().log(Level.SEVERE, "Failed to resolve player name", exception);
         }
         return null;
+    }
+
+    private static final class ClanBanEntry {
+
+        private final UUID memberUuid;
+        private final String reason;
+        private final long expiresAt;
+
+        private ClanBanEntry(final UUID memberUuid, final String reason, final long expiresAt) {
+            this.memberUuid = memberUuid;
+            this.reason = reason;
+            this.expiresAt = expiresAt;
+        }
+
+        private boolean isActive() {
+            return expiresAt < 0L || expiresAt > System.currentTimeMillis();
+        }
+
+        private String getReason() {
+            return reason;
+        }
+
+        private long getExpiresAt() {
+            return expiresAt;
+        }
     }
 }

--- a/src/main/java/com/lobby/social/clans/ClanPermission.java
+++ b/src/main/java/com/lobby/social/clans/ClanPermission.java
@@ -1,11 +1,25 @@
 package com.lobby.social.clans;
 
 public enum ClanPermission {
-    INVITE,
-    KICK,
-    PROMOTE,
-    DEMOTE,
-    MANAGE_RANKS,
-    MANAGE_BANK,
-    DISBAND
+
+    // Base permissions
+    CHAT_CLAN,
+    VIEW_MEMBER_LIST,
+
+    // Moderator permissions
+    INVITE_MEMBERS,
+    KICK_MEMBERS,
+
+    // Co-leader permissions
+    PROMOTE_MEMBERS,
+    DEMOTE_MEMBERS,
+    BAN_MEMBERS,
+    MANAGE_CLAN_INFO,
+
+    // Management permissions
+    MANAGE_PERMISSIONS,
+
+    // Leader exclusive permissions
+    TRANSFER_LEADERSHIP,
+    DISBAND_CLAN
 }

--- a/src/main/java/com/lobby/social/clans/ClanRole.java
+++ b/src/main/java/com/lobby/social/clans/ClanRole.java
@@ -1,0 +1,113 @@
+package com.lobby.social.clans;
+
+import org.bukkit.ChatColor;
+
+import java.text.Normalizer;
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public enum ClanRole {
+
+    MEMBER(1, "Membre", ChatColor.GRAY,
+            EnumSet.of(ClanPermission.CHAT_CLAN, ClanPermission.VIEW_MEMBER_LIST)),
+
+    MODERATOR(2, "Modérateur", ChatColor.YELLOW,
+            EnumSet.of(ClanPermission.CHAT_CLAN, ClanPermission.VIEW_MEMBER_LIST,
+                    ClanPermission.INVITE_MEMBERS, ClanPermission.KICK_MEMBERS)),
+
+    CO_LEADER(3, "Co-Leader", ChatColor.GOLD,
+            EnumSet.of(ClanPermission.CHAT_CLAN, ClanPermission.VIEW_MEMBER_LIST,
+                    ClanPermission.INVITE_MEMBERS, ClanPermission.KICK_MEMBERS,
+                    ClanPermission.PROMOTE_MEMBERS, ClanPermission.DEMOTE_MEMBERS,
+                    ClanPermission.BAN_MEMBERS, ClanPermission.MANAGE_CLAN_INFO)),
+
+    LEADER(4, "Leader", ChatColor.RED, EnumSet.allOf(ClanPermission.class));
+
+    private static final Map<String, ClanRole> LOOKUP = new ConcurrentHashMap<>();
+
+    static {
+        for (final ClanRole role : values()) {
+            LOOKUP.put(normalize(role.name()), role);
+            LOOKUP.put(normalize(role.displayName), role);
+        }
+    }
+
+    private final int level;
+    private final String displayName;
+    private final ChatColor color;
+    private final EnumSet<ClanPermission> permissions;
+
+    ClanRole(final int level, final String displayName, final ChatColor color,
+             final Set<ClanPermission> permissions) {
+        this.level = level;
+        this.displayName = Objects.requireNonNull(displayName, "displayName");
+        this.color = Objects.requireNonNull(color, "color");
+        this.permissions = permissions == null || permissions.isEmpty()
+                ? EnumSet.noneOf(ClanPermission.class)
+                : EnumSet.copyOf(permissions);
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public ChatColor getColor() {
+        return color;
+    }
+
+    public EnumSet<ClanPermission> getPermissions() {
+        return EnumSet.copyOf(permissions);
+    }
+
+    public boolean hasPermission(final ClanPermission permission) {
+        return permission != null && (this == LEADER || permissions.contains(permission));
+    }
+
+    public ClanRole getNext() {
+        return switch (this) {
+            case MEMBER -> MODERATOR;
+            case MODERATOR -> CO_LEADER;
+            case CO_LEADER -> LEADER;
+            case LEADER -> null;
+        };
+    }
+
+    public ClanRole getPrevious() {
+        return switch (this) {
+            case MEMBER -> null;
+            case MODERATOR -> MEMBER;
+            case CO_LEADER -> MODERATOR;
+            case LEADER -> CO_LEADER;
+        };
+    }
+
+    public static ClanRole fromName(final String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        final String normalized = normalize(value);
+        final ClanRole role = LOOKUP.get(normalized);
+        if (role != null) {
+            return role;
+        }
+        // Attempt lookup with spacing removed
+        return LOOKUP.get(normalized.replace(" ", ""));
+    }
+
+    private static String normalize(final String input) {
+        final String trimmed = Normalizer.normalize(input.trim(), Normalizer.Form.NFD)
+                .replaceAll("\\p{M}+", "");
+        return trimmed.toLowerCase(Locale.ROOT)
+                .replace('-', ' ')
+                .replace('_', ' ');
+    }
+}
+

--- a/src/main/java/com/lobby/social/menus/ClanMenus.java
+++ b/src/main/java/com/lobby/social/menus/ClanMenus.java
@@ -6,6 +6,7 @@ import com.lobby.social.clans.Clan;
 import com.lobby.social.clans.ClanManager;
 import com.lobby.social.clans.ClanMember;
 import com.lobby.social.clans.ClanPermission;
+import com.lobby.social.clans.ClanRole;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -150,7 +151,7 @@ public final class ClanMenus {
             player.sendMessage("§cVous n'êtes dans aucun clan!");
             return;
         }
-        if (!clan.hasPermission(player.getUniqueId(), ClanPermission.MANAGE_RANKS)
+        if (!clan.hasPermission(player.getUniqueId(), ClanPermission.MANAGE_PERMISSIONS)
                 && !clan.isLeader(player.getUniqueId())) {
             player.sendMessage("§cVous n'avez pas la permission de gérer les rangs.");
             return;
@@ -196,8 +197,10 @@ public final class ClanMenus {
         if (meta != null) {
             meta.setOwningPlayer(offlinePlayer);
             meta.setDisplayName("§e" + name);
+            final ClanRole role = ClanRole.fromName(member.getRankName());
+            final String displayRank = role != null ? role.getDisplayName() : member.getRankName();
             meta.setLore(Arrays.asList(
-                    "§7Rang: §f" + member.getRankName(),
+                    "§7Rang: §f" + displayRank,
                     "§7Contributions: §b" + member.getTotalContributions(),
                     "§r",
                     "§8▶ §7Cliquez pour gérer les permissions"

--- a/src/main/resources/config/menus/clan_ban_confirm.yml
+++ b/src/main/resources/config/menus/clan_ban_confirm.yml
@@ -1,0 +1,32 @@
+menu:
+  id: "clan_ban_confirm"
+  title: "&8» &8Bannir un Membre"
+  size: 27
+  items:
+    confirm:
+      slot: 11
+      material: LIME_CONCRETE
+      name: "&c&lConfirmer le Bannissement"
+      lore:
+        - "&7Bannir définitivement &f%clan_target_name%&7."
+        - "&cCette action est irréversible !"
+      actions:
+        - "[COMMAND] clan ban %clan_target_name%"
+        - "[CLOSE_MENU]"
+
+    cancel:
+      slot: 15
+      material: RED_CONCRETE
+      name: "&c&lAnnuler"
+      lore:
+        - "&7Retourner à la gestion du membre."
+      actions:
+        - "[MENU] clan_member_management_menu"
+
+    info:
+      slot: 13
+      head: "%clan_target_name%"
+      name: "&6%clan_target_name%"
+      lore:
+        - "&7Rang: &f%clan_target_rank_display%"
+        - "&7Dernière connexion: &f%clan_target_last_seen%"

--- a/src/main/resources/config/menus/clan_kick_confirm.yml
+++ b/src/main/resources/config/menus/clan_kick_confirm.yml
@@ -1,0 +1,32 @@
+menu:
+  id: "clan_kick_confirm"
+  title: "&8» &4Confirmer l'Expulsion"
+  size: 27
+  items:
+    confirm:
+      slot: 11
+      material: LIME_CONCRETE
+      name: "&a&lConfirmer"
+      lore:
+        - "&7Expulser &f%clan_target_name% &7du clan."
+        - "&cCette action est immédiate !"
+      actions:
+        - "[COMMAND] clan kick %clan_target_name%"
+        - "[CLOSE_MENU]"
+
+    cancel:
+      slot: 15
+      material: RED_CONCRETE
+      name: "&c&lAnnuler"
+      lore:
+        - "&7Retourner à la gestion du membre."
+      actions:
+        - "[MENU] clan_member_management_menu"
+
+    info:
+      slot: 13
+      head: "%clan_target_name%"
+      name: "&6%clan_target_name%"
+      lore:
+        - "&7Rang: &f%clan_target_rank_display%"
+        - "&7Contribution: &e%clan_target_contribution%"

--- a/src/main/resources/config/menus/clan_member_management.yml
+++ b/src/main/resources/config/menus/clan_member_management.yml
@@ -1,0 +1,81 @@
+menu:
+  id: "clan_member_management_menu"
+  title: "&8» &cGestion des Membres"
+  size: 54
+  items:
+    member_promote:
+      slot: 20
+      head: "hdb:5390"
+      name: "&a&lPromouvoir"
+      lore:
+        - "&7Promouvoir ce membre au rang"
+        - "&7supérieur s'il existe."
+        - "&r"
+        - "&8▸ &7Rang actuel: %clan_target_rank_display%"
+        - "&8▸ &7Prochain rang: %clan_target_next_rank%"
+        - "&r"
+        - "&a▶ Cliquez pour promouvoir !"
+      actions:
+        - "[COMMAND] clan promote %clan_target_name%"
+        - "[CLOSE_MENU]"
+
+    member_demote:
+      slot: 22
+      head: "hdb:5393"
+      name: "&c&lRétrograder"
+      lore:
+        - "&7Rétrograder ce membre au rang"
+        - "&7inférieur s'il existe."
+        - "&r"
+        - "&8▸ &7Rang actuel: %clan_target_rank_display%"
+        - "&8▸ &7Rang précédent: %clan_target_previous_rank%"
+        - "&r"
+        - "&c▶ Cliquez pour rétrograder !"
+      actions:
+        - "[COMMAND] clan demote %clan_target_name%"
+        - "[CLOSE_MENU]"
+
+    member_kick:
+      slot: 24
+      head: "hdb:9334"
+      name: "&4&lExpulser"
+      lore:
+        - "&7Expulser ce membre du clan."
+        - "&7Cette action est immédiate."
+        - "&r"
+        - "&c⚠ Cette action est irréversible !"
+        - "&r"
+        - "&4▶ Cliquez pour expulser !"
+      actions:
+        - "[MENU] clan_kick_confirm"
+
+    member_ban:
+      slot: 31
+      head: "hdb:46237"
+      name: "&8&lBannir"
+      lore:
+        - "&7Bannir ce membre du clan."
+        - "&7Il ne pourra plus rejoindre."
+        - "&r"
+        - "&c⚠ Cette action est irréversible !"
+        - "&r"
+        - "&8▶ Cliquez pour bannir !"
+      actions:
+        - "[MENU] clan_ban_confirm"
+
+    transfer_leadership:
+      slot: 40
+      head: "hdb:50218"
+      name: "&6&lTransférer le Leadership"
+      lore:
+        - "&7Transférer le leadership de"
+        - "&7votre clan à ce membre."
+        - "&r"
+        - "&c⚠ Vous deviendrez Co-Leader !"
+        - "&c⚠ Cette action est irréversible !"
+        - "&r"
+        - "&6▶ Cliquez pour transférer !"
+      actions:
+        - "[MENU] clan_transfer_confirm"
+      conditions:
+        - "is_leader: true"

--- a/src/main/resources/config/menus/clan_transfer_confirm.yml
+++ b/src/main/resources/config/menus/clan_transfer_confirm.yml
@@ -1,0 +1,32 @@
+menu:
+  id: "clan_transfer_confirm"
+  title: "&8» &6Transférer le Leadership"
+  size: 27
+  items:
+    confirm:
+      slot: 11
+      material: LIME_CONCRETE
+      name: "&6&lConfirmer le Transfert"
+      lore:
+        - "&7Donner le rôle de leader à &f%clan_target_name%"
+        - "&cVous deviendrez Co-Leader."
+      actions:
+        - "[COMMAND] clan transfer %clan_target_name%"
+        - "[CLOSE_MENU]"
+
+    cancel:
+      slot: 15
+      material: RED_CONCRETE
+      name: "&c&lAnnuler"
+      lore:
+        - "&7Retourner à la gestion du membre."
+      actions:
+        - "[MENU] clan_member_management_menu"
+
+    info:
+      slot: 13
+      head: "%clan_target_name%"
+      name: "&6%clan_target_name%"
+      lore:
+        - "&7Rang actuel: &f%clan_target_rank_display%"
+        - "&7Rejoint le: &f%clan_target_join_date%"


### PR DESCRIPTION
## Summary
- add a ClanRole enum and extend ClanPermission to model role-based abilities
- rework ClanManager to use the new roles for promotion, demotion, removal, bans, and leadership transfers while updating default rank creation and ban tracking
- refresh menu placeholders and clan UI displays to show role names and add confirmation menus for kicking, banning, and leadership transfer

## Testing
- `mvn -q -DskipTests package` *(fails: repository unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0486715ec83299c2a68e720155353