### PR TITLE
Implement social UI templates and confirmation system

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -15,6 +15,8 @@ import com.lobby.economy.EconomyManager;
 import com.lobby.heads.HeadDatabaseManager;
 import com.lobby.holograms.HologramManager;
 import com.lobby.menus.MenuManager;
+import com.lobby.menus.confirmation.ConfirmationManager;
+import com.lobby.menus.templates.UITemplateManager;
 import com.lobby.npcs.NPCInteractionHandler;
 import com.lobby.npcs.NPCManager;
 import com.lobby.events.PlayerJoinLeaveEvent;
@@ -48,6 +50,8 @@ public final class LobbyPlugin extends JavaPlugin {
     private NPCManager npcManager;
     private LobbyManager lobbyManager;
     private MenuManager menuManager;
+    private UITemplateManager uiTemplateManager;
+    private ConfirmationManager confirmationManager;
     private HeadDatabaseManager headDatabaseManager;
     private ShopManager shopManager;
     private ShopCommands shopCommands;
@@ -97,7 +101,9 @@ public final class LobbyPlugin extends JavaPlugin {
         npcManager.initialize();
         lobbyManager = new LobbyManager(this);
         lobbyManager.applyWorldSettings();
+        uiTemplateManager = new UITemplateManager(this);
         menuManager = new MenuManager(this);
+        confirmationManager = new ConfirmationManager(this);
         shopManager = new ShopManager(this);
         shopManager.initialize();
         shopCommands = new ShopCommands(this, shopManager);
@@ -145,6 +151,9 @@ public final class LobbyPlugin extends JavaPlugin {
         if (menuManager != null) {
             menuManager.closeAll();
         }
+        if (confirmationManager != null) {
+            confirmationManager.clearAll();
+        }
         instance = null;
     }
 
@@ -176,8 +185,16 @@ public final class LobbyPlugin extends JavaPlugin {
         return menuManager;
     }
 
+    public UITemplateManager getUiTemplateManager() {
+        return uiTemplateManager;
+    }
+
     public HeadDatabaseManager getHeadDatabaseManager() {
         return headDatabaseManager;
+    }
+
+    public ConfirmationManager getConfirmationManager() {
+        return confirmationManager;
     }
 
     public ShopManager getShopManager() {

--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -2,6 +2,7 @@ package com.lobby.menus;
 
 import com.lobby.LobbyPlugin;
 import com.lobby.heads.HeadDatabaseManager;
+import com.lobby.menus.templates.DesignTemplate;
 import com.lobby.npcs.ActionProcessor;
 import com.lobby.utils.LogUtils;
 import com.lobby.utils.MessageUtils;
@@ -19,6 +20,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -47,9 +49,11 @@ public class ConfiguredMenu implements Menu {
         inventory = Bukkit.createInventory(null, size, title);
         actionsBySlot.clear();
 
-        final ItemStack filler = createFillerItem(menuSection.getString("fill_material"));
+        final DesignTemplate designTemplate = resolveDesignTemplate();
+
+        final ItemStack filler = createFillerItem(resolveFillMaterial(designTemplate));
         if (filler != null) {
-            final List<Integer> fillSlots = menuSection.getIntegerList("fill_slots");
+            final List<Integer> fillSlots = resolveFillSlots(designTemplate);
             if (fillSlots == null || fillSlots.isEmpty()) {
                 for (int slot = 0; slot < inventory.getSize(); slot++) {
                     inventory.setItem(slot, filler.clone());
@@ -67,7 +71,8 @@ public class ConfiguredMenu implements Menu {
             }
         }
 
-        applyBorders(player);
+        applyBorders(player, designTemplate);
+        applyTemplateItems(player, designTemplate);
 
         final ConfigurationSection itemsSection = menuSection.getConfigurationSection("items");
         if (itemsSection != null) {
@@ -114,11 +119,14 @@ public class ConfiguredMenu implements Menu {
     }
 
     private Optional<Integer> createItem(final Player player, final ConfigurationSection itemSection) {
-        final String materialName = itemSection.getString("material", "STONE");
-        final Material material = Material.matchMaterial(materialName);
+        String materialName = itemSection.getString("material");
+        Material material = materialName != null ? Material.matchMaterial(materialName) : null;
+        final boolean headDefined = itemSection.contains("head") || itemSection.contains("head_id");
         if (material == null) {
-            LogUtils.warning(plugin, "Invalid material '" + materialName + "' in menu '" + menuId + "'.");
-            return Optional.empty();
+            if (materialName != null && !materialName.isBlank()) {
+                LogUtils.warning(plugin, "Invalid material '" + materialName + "' in menu '" + menuId + "'.");
+            }
+            material = headDefined ? Material.PLAYER_HEAD : Material.STONE;
         }
 
         final int amount = Math.max(1, itemSection.getInt("amount", 1));
@@ -149,6 +157,14 @@ public class ConfiguredMenu implements Menu {
                         .map(MessageUtils::colorize)
                         .toList();
                 meta.setLore(lore);
+            } else if (itemSection.isString("lore")) {
+                final String processedLore = PlaceholderUtils.applyPlaceholders(plugin, itemSection.getString("lore"), player);
+                if (processedLore != null && !processedLore.isBlank()) {
+                    final List<String> lore = Arrays.stream(processedLore.split("\\n"))
+                            .map(MessageUtils::colorize)
+                            .toList();
+                    meta.setLore(lore);
+                }
             }
 
             if (itemSection.contains("custom_model_data")) {
@@ -232,15 +248,36 @@ public class ConfiguredMenu implements Menu {
         if (processed == null || processed.isBlank()) {
             return null;
         }
+        final var templateManager = plugin.getUiTemplateManager();
+        if (templateManager != null) {
+            if (processed.startsWith("@")) {
+                final String identifier = processed.substring(1);
+                final String resolved = templateManager.resolveHead(identifier);
+                if (resolved != null && !resolved.isBlank()) {
+                    return resolved;
+                }
+            }
+            final String resolved = templateManager.resolveHead(processed);
+            if (resolved != null && !resolved.isBlank()) {
+                return resolved;
+            }
+        }
         return processed;
     }
 
-    private void applyBorders(final Player player) {
+    private void applyBorders(final Player player, final DesignTemplate designTemplate) {
         if (inventory == null) {
             return;
         }
-        final List<Map<?, ?>> borders = menuSection.getMapList("borders");
-        if (borders == null || borders.isEmpty()) {
+        final List<Map<?, ?>> borders = new ArrayList<>();
+        if (designTemplate != null) {
+            borders.addAll(designTemplate.getBorders());
+        }
+        final List<Map<?, ?>> menuBorders = menuSection.getMapList("borders");
+        if (menuBorders != null) {
+            borders.addAll(menuBorders);
+        }
+        if (borders.isEmpty()) {
             return;
         }
         for (Map<?, ?> definition : borders) {
@@ -261,6 +298,27 @@ public class ConfiguredMenu implements Menu {
                     inventory.setItem(index, borderItem.clone());
                 }
             }
+        }
+    }
+
+    private void applyTemplateItems(final Player player, final DesignTemplate designTemplate) {
+        if (designTemplate == null) {
+            return;
+        }
+        final ConfigurationSection templateItems = designTemplate.getItemsSection();
+        if (templateItems == null) {
+            return;
+        }
+        for (String key : templateItems.getKeys(false)) {
+            if (key == null) {
+                continue;
+            }
+            final ConfigurationSection itemSection = templateItems.getConfigurationSection(key);
+            if (itemSection == null) {
+                continue;
+            }
+            final Optional<Integer> slot = createItem(player, itemSection);
+            slot.ifPresent(index -> storeActions(index, itemSection));
         }
     }
 
@@ -326,6 +384,31 @@ public class ConfiguredMenu implements Menu {
         if (!sanitized.isEmpty()) {
             actionsBySlot.put(slot, List.copyOf(sanitized));
         }
+    }
+
+    private DesignTemplate resolveDesignTemplate() {
+        final String designName = menuSection.getString("design");
+        if (designName == null || designName.isBlank()) {
+            return null;
+        }
+        if (plugin.getUiTemplateManager() == null) {
+            return null;
+        }
+        return plugin.getUiTemplateManager().getDesignTemplate(designName);
+    }
+
+    private String resolveFillMaterial(final DesignTemplate designTemplate) {
+        if (menuSection.contains("fill_material")) {
+            return menuSection.getString("fill_material");
+        }
+        return designTemplate != null ? designTemplate.getFillMaterial() : null;
+    }
+
+    private List<Integer> resolveFillSlots(final DesignTemplate designTemplate) {
+        if (menuSection.contains("fill_slots")) {
+            return menuSection.getIntegerList("fill_slots");
+        }
+        return designTemplate != null ? designTemplate.getFillSlots() : List.of();
     }
 
     private int resolveSlot(final int slot, final ItemStack itemStack) {

--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -80,6 +80,10 @@ public class MenuManager implements Listener {
 
     public void reloadMenus() {
         menuDefinitions.clear();
+        final var templateManager = plugin.getUiTemplateManager();
+        if (templateManager != null) {
+            templateManager.reload();
+        }
         loadMenusFromMainConfig();
         loadMenusFromDirectory();
     }
@@ -181,7 +185,9 @@ public class MenuManager implements Listener {
                 "language_menu.yml",
                 "friends_menu.yml",
                 "groups_menu.yml",
-                "clan_menu.yml"
+                "clan_menu.yml",
+                "profile_main_redesigned.yml",
+                "confirmation_template.yml"
         );
         for (String fileName : defaults) {
             final File target = new File(directory, fileName);

--- a/src/main/java/com/lobby/menus/confirmation/ConfirmationManager.java
+++ b/src/main/java/com/lobby/menus/confirmation/ConfirmationManager.java
@@ -1,0 +1,133 @@
+package com.lobby.menus.confirmation;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.npcs.ActionProcessor;
+import com.lobby.utils.LogUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ConfirmationManager implements Listener {
+
+    private final LobbyPlugin plugin;
+    private final Map<UUID, ConfirmationRequest> requests = new ConcurrentHashMap<>();
+
+    public ConfirmationManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    public void openConfirmation(final Player player, final ConfirmationRequest request) {
+        if (player == null || request == null) {
+            return;
+        }
+        requests.put(player.getUniqueId(), request);
+        if (plugin.getMenuManager() == null) {
+            LogUtils.warning(plugin, "Attempted to open confirmation menu without MenuManager available.");
+            requests.remove(player.getUniqueId());
+            return;
+        }
+        Bukkit.getScheduler().runTask(plugin, () -> plugin.getMenuManager().openMenu(player, request.templateId()));
+    }
+
+    public void executeConfirmation(final Player player, final boolean confirmed) {
+        if (player == null) {
+            return;
+        }
+        final UUID uuid = player.getUniqueId();
+        final ConfirmationRequest request = requests.remove(uuid);
+        if (request == null) {
+            return;
+        }
+        Bukkit.getScheduler().runTask(plugin, player::closeInventory);
+        final ActionProcessor processor = resolveActionProcessor();
+        if (processor == null) {
+            return;
+        }
+        final List<String> actions = confirmed ? request.confirmActions() : request.cancelActions();
+        if (actions.isEmpty()) {
+            return;
+        }
+        processor.processActions(actions, player, null);
+    }
+
+    public ConfirmationRequest getRequest(final UUID uuid) {
+        if (uuid == null) {
+            return null;
+        }
+        return requests.get(uuid);
+    }
+
+    public void clearRequest(final UUID uuid) {
+        if (uuid == null) {
+            return;
+        }
+        requests.remove(uuid);
+    }
+
+    public void clearAll() {
+        requests.clear();
+    }
+
+    public String applyPlaceholders(final Player player, final String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        final ConfirmationRequest request = player == null ? null : requests.get(player.getUniqueId());
+        if (request == null) {
+            return text;
+        }
+        final Map<String, String> replacements = new HashMap<>();
+        replacements.put("%action_description%", defaultString(request.actionDescription(), ""));
+        replacements.put("%action_title%", defaultString(request.actionTitle(), "&cAction"));
+        replacements.put("%action_icon%", defaultString(request.actionIcon(), "hdb:5390"));
+        replacements.put("%action_details%", defaultString(request.joinedDetails(), ""));
+        replacements.put("%previous_menu%", defaultString(request.previousMenuId(), ""));
+        replacements.put("%confirmation_action%", "[CONFIRM_EXECUTE]");
+        String replaced = text;
+        for (Map.Entry<String, String> entry : replacements.entrySet()) {
+            replaced = replaced.replace(entry.getKey(), entry.getValue());
+        }
+        return replaced;
+    }
+
+    public List<String> applyPlaceholders(final Player player, final List<String> lines) {
+        if (lines == null || lines.isEmpty()) {
+            return List.of();
+        }
+        return lines.stream()
+                .map(line -> applyPlaceholders(player, line))
+                .toList();
+    }
+
+    @EventHandler
+    public void onInventoryClose(final InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player player)) {
+            return;
+        }
+        final UUID uuid = player.getUniqueId();
+        if (!requests.containsKey(uuid)) {
+            return;
+        }
+        requests.remove(uuid);
+    }
+
+    private ActionProcessor resolveActionProcessor() {
+        return plugin.getNpcManager() != null ? plugin.getNpcManager().getActionProcessor() : null;
+    }
+
+    private String defaultString(final String value, final String fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/lobby/menus/confirmation/ConfirmationRequest.java
+++ b/src/main/java/com/lobby/menus/confirmation/ConfirmationRequest.java
@@ -1,0 +1,156 @@
+package com.lobby.menus.confirmation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class ConfirmationRequest {
+
+    private final String templateId;
+    private final String previousMenuId;
+    private final String actionDescription;
+    private final String actionTitle;
+    private final String actionIcon;
+    private final List<String> actionDetails;
+    private final List<String> confirmActions;
+    private final List<String> cancelActions;
+
+    private ConfirmationRequest(final Builder builder) {
+        this.templateId = builder.templateId == null || builder.templateId.isBlank()
+                ? "confirmation_template"
+                : builder.templateId;
+        this.previousMenuId = builder.previousMenuId;
+        this.actionDescription = builder.actionDescription;
+        this.actionTitle = builder.actionTitle;
+        this.actionIcon = builder.actionIcon;
+        this.actionDetails = Collections.unmodifiableList(new ArrayList<>(builder.actionDetails));
+        this.confirmActions = Collections.unmodifiableList(new ArrayList<>(builder.confirmActions));
+        this.cancelActions = Collections.unmodifiableList(new ArrayList<>(builder.cancelActions));
+    }
+
+    public String templateId() {
+        return templateId;
+    }
+
+    public String previousMenuId() {
+        return previousMenuId;
+    }
+
+    public String actionDescription() {
+        return actionDescription;
+    }
+
+    public String actionTitle() {
+        return actionTitle;
+    }
+
+    public String actionIcon() {
+        return actionIcon;
+    }
+
+    public List<String> actionDetails() {
+        return actionDetails;
+    }
+
+    public List<String> confirmActions() {
+        return confirmActions;
+    }
+
+    public List<String> cancelActions() {
+        return cancelActions;
+    }
+
+    public String joinedDetails() {
+        if (actionDetails.isEmpty()) {
+            return "";
+        }
+        return String.join("\n", actionDetails);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String templateId;
+        private String previousMenuId;
+        private String actionDescription;
+        private String actionTitle;
+        private String actionIcon;
+        private final List<String> actionDetails = new ArrayList<>();
+        private final List<String> confirmActions = new ArrayList<>();
+        private final List<String> cancelActions = new ArrayList<>();
+
+        public Builder templateId(final String templateId) {
+            this.templateId = templateId;
+            return this;
+        }
+
+        public Builder previousMenuId(final String previousMenuId) {
+            this.previousMenuId = previousMenuId;
+            return this;
+        }
+
+        public Builder actionDescription(final String actionDescription) {
+            this.actionDescription = actionDescription;
+            return this;
+        }
+
+        public Builder actionTitle(final String actionTitle) {
+            this.actionTitle = actionTitle;
+            return this;
+        }
+
+        public Builder actionIcon(final String actionIcon) {
+            this.actionIcon = actionIcon;
+            return this;
+        }
+
+        public Builder addDetail(final String detail) {
+            if (detail != null) {
+                actionDetails.add(detail);
+            }
+            return this;
+        }
+
+        public Builder addDetails(final List<String> details) {
+            if (details != null) {
+                details.stream().filter(Objects::nonNull).forEach(actionDetails::add);
+            }
+            return this;
+        }
+
+        public Builder addConfirmAction(final String action) {
+            if (action != null && !action.isBlank()) {
+                confirmActions.add(action.trim());
+            }
+            return this;
+        }
+
+        public Builder addConfirmActions(final List<String> actions) {
+            if (actions != null) {
+                actions.stream().filter(Objects::nonNull).forEach(action -> addConfirmAction(action));
+            }
+            return this;
+        }
+
+        public Builder addCancelAction(final String action) {
+            if (action != null && !action.isBlank()) {
+                cancelActions.add(action.trim());
+            }
+            return this;
+        }
+
+        public Builder addCancelActions(final List<String> actions) {
+            if (actions != null) {
+                actions.stream().filter(Objects::nonNull).forEach(action -> addCancelAction(action));
+            }
+            return this;
+        }
+
+        public ConfirmationRequest build() {
+            return new ConfirmationRequest(this);
+        }
+    }
+}

--- a/src/main/java/com/lobby/menus/templates/DesignTemplate.java
+++ b/src/main/java/com/lobby/menus/templates/DesignTemplate.java
@@ -1,0 +1,75 @@
+package com.lobby.menus.templates;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DesignTemplate {
+
+    private final String name;
+    private final ConfigurationSection section;
+
+    public DesignTemplate(final String name, final ConfigurationSection section) {
+        this.name = name;
+        this.section = section;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getFillMaterial() {
+        if (section == null) {
+            return null;
+        }
+        final ConfigurationSection fillSection = section.getConfigurationSection("fill");
+        if (fillSection != null) {
+            return fillSection.getString("material");
+        }
+        return section.getString("fill_material");
+    }
+
+    public List<Integer> getFillSlots() {
+        if (section == null) {
+            return List.of();
+        }
+        final ConfigurationSection fillSection = section.getConfigurationSection("fill");
+        if (fillSection != null && fillSection.contains("slots")) {
+            return fillSection.getIntegerList("slots");
+        }
+        if (section.contains("fill_slots")) {
+            return section.getIntegerList("fill_slots");
+        }
+        return List.of();
+    }
+
+    public List<Map<?, ?>> getBorders() {
+        if (section == null) {
+            return List.of();
+        }
+        if (section.isList("borders")) {
+            return section.getMapList("borders");
+        }
+        final ConfigurationSection bordersSection = section.getConfigurationSection("borders");
+        if (bordersSection == null) {
+            return List.of();
+        }
+        return bordersSection.getMapList("layers");
+    }
+
+    public ConfigurationSection getItemsSection() {
+        if (section == null) {
+            return null;
+        }
+        return section.getConfigurationSection("items");
+    }
+
+    public Map<String, Object> getRawValues() {
+        if (section == null) {
+            return Collections.emptyMap();
+        }
+        return section.getValues(false);
+    }
+}

--- a/src/main/java/com/lobby/menus/templates/UITemplateManager.java
+++ b/src/main/java/com/lobby/menus/templates/UITemplateManager.java
@@ -1,0 +1,143 @@
+package com.lobby.menus.templates;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.utils.LogUtils;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class UITemplateManager {
+
+    private static final Set<String> DEFAULT_FILES = Set.of(
+            "social_heads.yml",
+            "social_designs.yml"
+    );
+
+    private final LobbyPlugin plugin;
+    private final Map<String, DesignTemplate> designTemplates = new ConcurrentHashMap<>();
+    private final Map<String, String> headTemplates = new ConcurrentHashMap<>();
+
+    public UITemplateManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        reload();
+    }
+
+    public void reload() {
+        loadTemplates();
+    }
+
+    public DesignTemplate getDesignTemplate(final String name) {
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        return designTemplates.get(name.toLowerCase(Locale.ROOT));
+    }
+
+    public String resolveHead(final String identifier) {
+        if (identifier == null || identifier.isBlank()) {
+            return null;
+        }
+        final String normalized = identifier.trim().toLowerCase(Locale.ROOT);
+        String value = headTemplates.get(normalized);
+        if (value != null) {
+            return value;
+        }
+        final int separator = normalized.lastIndexOf('.') + 1;
+        if (separator > 0 && separator < normalized.length()) {
+            final String simpleKey = normalized.substring(separator);
+            value = headTemplates.get(simpleKey);
+            if (value != null) {
+                return value;
+            }
+        }
+        return headTemplates.get(identifier.trim());
+    }
+
+    public Map<String, String> getHeadTemplates() {
+        return Collections.unmodifiableMap(headTemplates);
+    }
+
+    private void loadTemplates() {
+        designTemplates.clear();
+        headTemplates.clear();
+
+        final File directory = ensureTemplateDirectory();
+        final File[] files = directory.listFiles((dir, name) -> name.toLowerCase(Locale.ROOT).endsWith(".yml"));
+        if (files == null || files.length == 0) {
+            return;
+        }
+        for (File file : files) {
+            final YamlConfiguration configuration = YamlConfiguration.loadConfiguration(file);
+            loadHeadTemplates(configuration);
+            loadDesignTemplates(configuration);
+        }
+    }
+
+    private void loadHeadTemplates(final YamlConfiguration configuration) {
+        final ConfigurationSection headsRoot = configuration.getConfigurationSection("ui_heads");
+        if (headsRoot == null) {
+            return;
+        }
+        collectHeadEntries(headsRoot, "ui_heads");
+    }
+
+    private void collectHeadEntries(final ConfigurationSection section, final String pathPrefix) {
+        for (String key : section.getKeys(false)) {
+            if (key == null) {
+                continue;
+            }
+            final Object value = section.get(key);
+            final String path = pathPrefix == null || pathPrefix.isBlank()
+                    ? key
+                    : pathPrefix + "." + key;
+            if (value instanceof ConfigurationSection nested) {
+                collectHeadEntries(nested, path);
+                continue;
+            }
+            if (value instanceof String stringValue) {
+                final String normalizedPath = path.toLowerCase(Locale.ROOT);
+                headTemplates.put(normalizedPath, stringValue);
+                headTemplates.putIfAbsent(key.toLowerCase(Locale.ROOT), stringValue);
+            }
+        }
+    }
+
+    private void loadDesignTemplates(final YamlConfiguration configuration) {
+        final ConfigurationSection designsSection = configuration.getConfigurationSection("designs");
+        if (designsSection == null) {
+            return;
+        }
+        for (String key : designsSection.getKeys(false)) {
+            if (key == null) {
+                continue;
+            }
+            final ConfigurationSection designSection = designsSection.getConfigurationSection(key);
+            if (designSection == null) {
+                LogUtils.warning(plugin, "Design template '" + key + "' is invalid or empty.");
+                continue;
+            }
+            final String normalized = key.toLowerCase(Locale.ROOT);
+            designTemplates.put(normalized, new DesignTemplate(normalized, designSection));
+        }
+    }
+
+    private File ensureTemplateDirectory() {
+        final File directory = new File(plugin.getDataFolder(), "config/ui_templates");
+        if (!directory.exists() && !directory.mkdirs()) {
+            LogUtils.severe(plugin, "Unable to create config/ui_templates directory for UI templates.");
+        }
+        for (String fileName : DEFAULT_FILES) {
+            final File target = new File(directory, fileName);
+            if (!target.exists()) {
+                plugin.saveResource("config/ui_templates/" + fileName, false);
+            }
+        }
+        return directory;
+    }
+}

--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -2,6 +2,8 @@ package com.lobby.npcs;
 
 import com.lobby.LobbyPlugin;
 import com.lobby.menus.MenuManager;
+import com.lobby.menus.confirmation.ConfirmationManager;
+import com.lobby.menus.confirmation.ConfirmationRequest;
 import com.lobby.social.ChatInputManager;
 import com.lobby.social.clans.Clan;
 import com.lobby.social.clans.ClanManager;
@@ -20,8 +22,12 @@ import org.bukkit.entity.Player;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
 
 public class ActionProcessor {
@@ -85,6 +91,18 @@ public class ActionProcessor {
         }
         if (trimmed.equalsIgnoreCase("[TOGGLE_FRIEND_MESSAGES]")) {
             toggleAndRefresh(player, "friend_messages", "friend_settings_menu");
+            return;
+        }
+        if (startsWithIgnoreCase(trimmed, "[CONFIRM]")) {
+            handleConfirmationAction(player, processed.substring("[CONFIRM]".length()).trim());
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CONFIRM_EXECUTE]")) {
+            handleConfirmationExecution(player, true);
+            return;
+        }
+        if (trimmed.equalsIgnoreCase("[CONFIRM_CANCEL]")) {
+            handleConfirmationExecution(player, false);
             return;
         }
         if (trimmed.equalsIgnoreCase("[GROUP_CREATE]")) {
@@ -301,6 +319,99 @@ public class ActionProcessor {
                 menuManager.openMenu(player, "clan_menu");
             }
         });
+    }
+
+    private void handleConfirmationExecution(final Player player, final boolean confirmed) {
+        if (player == null) {
+            return;
+        }
+        final ConfirmationManager confirmationManager = plugin.getConfirmationManager();
+        if (confirmationManager == null) {
+            LogUtils.warning(plugin, "Confirmation execution requested but ConfirmationManager is unavailable.");
+            return;
+        }
+        confirmationManager.executeConfirmation(player, confirmed);
+    }
+
+    private void handleConfirmationAction(final Player player, final String parameterString) {
+        if (player == null) {
+            return;
+        }
+        final ConfirmationManager confirmationManager = plugin.getConfirmationManager();
+        if (confirmationManager == null) {
+            LogUtils.warning(plugin, "Confirmation requested but ConfirmationManager is unavailable.");
+            return;
+        }
+        final Map<String, String> parameters = parseConfirmationParameters(parameterString);
+        final ConfirmationRequest.Builder builder = ConfirmationRequest.builder();
+        builder.templateId(firstNonBlank(parameters.get("template"), parameters.get("menu_id")));
+        builder.previousMenuId(firstNonBlank(parameters.get("previous"), parameters.get("menu"), parameters.get("back"),
+                parameters.get("previous_menu")));
+        builder.actionDescription(firstNonBlank(parameters.get("description"), parameters.get("action"),
+                parameters.get("text")));
+        builder.actionTitle(firstNonBlank(parameters.get("title"), parameters.get("name")));
+        builder.actionIcon(firstNonBlank(parameters.get("icon"), parameters.get("head"), parameters.get("skull")));
+
+        splitValues(firstNonBlank(parameters.get("details"), parameters.get("detail"), parameters.get("info")))
+                .forEach(builder::addDetail);
+
+        List<String> confirmActions = new ArrayList<>(splitValues(parameters.get("confirm")));
+        if (confirmActions.isEmpty() && parameters.isEmpty()
+                && parameterString != null && !parameterString.isBlank()) {
+            confirmActions = new ArrayList<>(splitValues(parameterString));
+        }
+        if (confirmActions.isEmpty()) {
+            LogUtils.warning(plugin, "Confirmation action opened without any confirm actions defined.");
+        } else {
+            confirmActions.forEach(builder::addConfirmAction);
+        }
+
+        splitValues(parameters.get("cancel")).forEach(builder::addCancelAction);
+
+        confirmationManager.openConfirmation(player, builder.build());
+    }
+
+    private Map<String, String> parseConfirmationParameters(final String parameterString) {
+        final Map<String, String> parameters = new HashMap<>();
+        if (parameterString == null || parameterString.isBlank()) {
+            return parameters;
+        }
+        final String[] segments = parameterString.split(";");
+        for (String segment : segments) {
+            if (segment == null || segment.isBlank()) {
+                continue;
+            }
+            final int separator = segment.indexOf('=');
+            if (separator <= 0 || separator >= segment.length() - 1) {
+                continue;
+            }
+            final String key = segment.substring(0, separator).trim().toLowerCase(Locale.ROOT);
+            final String value = segment.substring(separator + 1).trim();
+            parameters.put(key, value);
+        }
+        return parameters;
+    }
+
+    private List<String> splitValues(final String raw) {
+        if (raw == null || raw.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(raw.split("\\|\\||\\n"))
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .toList();
+    }
+
+    private String firstNonBlank(final String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
     }
 
     private void toggleAndRefresh(final Player player, final String key, final String menuId) {

--- a/src/main/java/com/lobby/social/SocialPlaceholderManager.java
+++ b/src/main/java/com/lobby/social/SocialPlaceholderManager.java
@@ -75,6 +75,10 @@ public class SocialPlaceholderManager {
         replacements.put("%daily_reward_cooldown%", "Disponible");
         replacements.put("%daily_reward_name%", "Mystery Box");
         replacements.put("%daily_reward_streak%", "0 jour");
+        replacements.put("%player_level%", "1");
+        replacements.put("%player_experience%", "0");
+        replacements.put("%player_playtime_total%", "0s");
+        replacements.put("%luckperms_prefix%", "&7Joueur");
         return replaceAll(text, replacements);
     }
 
@@ -120,6 +124,8 @@ public class SocialPlaceholderManager {
         replacements.put("%friend_private_messages_status%", "Autorisés");
         replacements.put("%friend_max_friends%", "Illimité");
         replacements.put("%friends_free_slots%", "Illimité");
+        replacements.put("%friend_requests%", "0");
+        replacements.put("%friend_status%", "Disponible");
 
         if (player == null) {
             return replaceAll(text, replacements);
@@ -173,6 +179,7 @@ public class SocialPlaceholderManager {
 
         final int requestsReceived = friendManager.getPendingRequests(player.getUniqueId()).size();
         replacements.put("%friend_requests_received%", String.valueOf(requestsReceived));
+        replacements.put("%friend_requests%", String.valueOf(requestsReceived));
 
         final int requestsSent = friendManager.countSentRequests(player.getUniqueId());
         replacements.put("%friend_requests_sent%", String.valueOf(requestsSent));
@@ -195,6 +202,7 @@ public class SocialPlaceholderManager {
         final boolean visible = settings.isShowOnlineStatus();
         replacements.put("%friend_visibility%", visible ? "Visible" : "Caché");
         replacements.put("%friend_visibility_mode%", formatVisibilityMode(visible));
+        replacements.put("%friend_status%", visible ? "Disponible" : "Invisible");
 
         final boolean autoFavorites = settings.isAutoAcceptFavorites();
         replacements.put("%friend_auto_favorites%", autoFavorites ? "Activée" : "Désactivée");
@@ -238,6 +246,7 @@ public class SocialPlaceholderManager {
         replacements.put("%group_auto_accept%", "Désactivé");
         replacements.put("%group_preferred_mode%", "Automatique");
         replacements.put("%group_visibility%", "Public");
+        replacements.put("%group_role%", "Aucun");
         replacements.put("%group_invitations%", "0");
         replacements.put("%group_invites_sent%", "0");
         replacements.put("%groups_open%", "0");
@@ -281,6 +290,13 @@ public class SocialPlaceholderManager {
             replacements.put("%group_slots_free%", String.valueOf(Math.max(0, group.getMaxSize() - group.getSize())));
             replacements.put("%group_status%", group.isFull() ? "Complet" : "Ouvert");
             replacements.put("%group_preferred_mode%", "Toutes les files");
+            String role = "Membre";
+            if (group.isLeader(player.getUniqueId())) {
+                role = "Leader";
+            } else if (group.isModerator(player.getUniqueId())) {
+                role = "Modérateur";
+            }
+            replacements.put("%group_role%", role);
         }
 
         replacements.put("%group_invitations%", String.valueOf(groupManager.countPendingInvitations(player.getUniqueId())));
@@ -312,6 +328,7 @@ public class SocialPlaceholderManager {
         replacements.put("%clan_war_wins%", "0");
         replacements.put("%clan_war_losses%", "0");
         replacements.put("%clan_war_ratio%", formatRatio(0, 0));
+        replacements.put("%clan_status%", "Sans clan");
         replacements.put("%clans_open_count%", "0");
         replacements.put("%clans_invite_count%", "0");
         replacements.put("%clan_target_uuid%", "");
@@ -361,6 +378,9 @@ public class SocialPlaceholderManager {
             replacements.put("%clan_player_level%", member.getRankName());
             replacements.put("%clan_contributions%", String.valueOf(member.getTotalContributions()));
             replacements.put("%clan_last_activity%", formatRelativeTime(member.getJoinedAt()));
+            replacements.put("%clan_status%", member.getRankName());
+        } else {
+            replacements.put("%clan_status%", "Membre");
         }
 
         final ClanRank rank = member != null ? clan.getRank(member.getRankName()) : null;

--- a/src/main/java/com/lobby/utils/PlaceholderUtils.java
+++ b/src/main/java/com/lobby/utils/PlaceholderUtils.java
@@ -38,6 +38,14 @@ public final class PlaceholderUtils {
             }
         }
 
+        if (plugin.getSocialPlaceholderManager() != null) {
+            processed = plugin.getSocialPlaceholderManager().replacePlaceholders(player, processed);
+        }
+
+        if (plugin.getConfirmationManager() != null) {
+            processed = plugin.getConfirmationManager().applyPlaceholders(player, processed);
+        }
+
         if (player == null) {
             return processed;
         }
@@ -59,7 +67,8 @@ public final class PlaceholderUtils {
                 .replace("%player_tokens%", String.valueOf(data.tokens()))
                 .replace("%player_first_join%", formatInstant(data.firstJoin()))
                 .replace("%player_last_join%", formatInstant(data.lastJoin()))
-                .replace("%player_playtime%", formatPlaytime(data.totalPlaytime()));
+                .replace("%player_playtime%", formatPlaytime(data.totalPlaytime()))
+                .replace("%player_playtime_total%", formatPlaytime(data.totalPlaytime()));
 
         return processed;
     }

--- a/src/main/resources/config/lobby-items.yml
+++ b/src/main/resources/config/lobby-items.yml
@@ -27,7 +27,7 @@ lobby_items:
       lore:
         - "&7Consulte tes informations personnelles."
       actions:
-        - "[MENU] profil_menu"
+        - "[MENU] profile_main"
 
     shop:
       slot: 4

--- a/src/main/resources/config/menus.yml
+++ b/src/main/resources/config/menus.yml
@@ -417,7 +417,7 @@ menus:
         lore:
           - "&7Retourner au menu principal"
         actions:
-          - "[MENU] profil_menu"
+          - "[MENU] profile_main"
 
   friends_menu:
     title: "&8» &a&lGestion d'Amis"
@@ -525,7 +525,7 @@ menus:
         lore:
           - "&7Retourner au menu profil"
         actions:
-          - "[MENU] profil_menu"
+          - "[MENU] profile_main"
 
   groups_menu:
     title: "&8» &e&lGestion de Groupes"
@@ -672,7 +672,7 @@ menus:
         lore:
           - "&7Retourner au menu profil"
         actions:
-          - "[MENU] profil_menu"
+          - "[MENU] profile_main"
 
   clan_info_menu:
     title: "&8» &c&lMon Clan"
@@ -1512,7 +1512,7 @@ menus:
         lore:
           - "&7Retourner au profil"
         actions:
-          - "[MENU] profil_menu"
+          - "[MENU] profile_main"
       close:
         slot: 53
         material: BARRIER
@@ -1590,7 +1590,7 @@ menus:
         lore:
           - "&7Retourner au profil"
         actions:
-          - "[MENU] profil_menu"
+          - "[MENU] profile_main"
       close:
         slot: 53
         material: BARRIER
@@ -1648,7 +1648,7 @@ menus:
         lore:
           - "&7Retourner au profil"
         actions:
-          - "[MENU] profil_menu"
+          - "[MENU] profile_main"
       close:
         slot: 53
         material: BARRIER

--- a/src/main/resources/config/menus/clan_menu.yml
+++ b/src/main/resources/config/menus/clan_menu.yml
@@ -163,4 +163,4 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour revenir !"
       actions:
-        - "[MENU] profil_menu"
+        - "[MENU] profile_main"

--- a/src/main/resources/config/menus/confirmation_template.yml
+++ b/src/main/resources/config/menus/confirmation_template.yml
@@ -1,0 +1,40 @@
+confirmation_template:
+  title: "&8» &cConfirmation"
+  size: 27
+
+  items:
+    confirm_action:
+      slot: 11
+      material: "PLAYER_HEAD"
+      head: "@ui_heads.confirm_button"
+      name: "&a&lConfirmer"
+      lore:
+        - "&7Confirmer l'action :"
+        - "&e%action_description%"
+        - "&r"
+        - "&a▶ Cliquez pour confirmer !"
+      actions:
+        - "[CONFIRM_EXECUTE]"
+
+    cancel_action:
+      slot: 15
+      material: "PLAYER_HEAD"
+      head: "@ui_heads.cancel_button"
+      name: "&c&lAnnuler"
+      lore:
+        - "&7Annuler l'action et"
+        - "&7revenir au menu précédent."
+        - "&r"
+        - "&c▶ Cliquez pour annuler !"
+      actions:
+        - "[CONFIRM_CANCEL]"
+        - "[MENU] %previous_menu%"
+
+    info_display:
+      slot: 13
+      material: "PLAYER_HEAD"
+      head: "%action_icon%"
+      name: "%action_title%"
+      lore: "%action_details%"
+      actions:
+        - "[NONE]"

--- a/src/main/resources/config/menus/friends_menu.yml
+++ b/src/main/resources/config/menus/friends_menu.yml
@@ -114,4 +114,4 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour revenir !"
       actions:
-        - "[MENU] profil_menu"
+        - "[MENU] profile_main"

--- a/src/main/resources/config/menus/groups_menu.yml
+++ b/src/main/resources/config/menus/groups_menu.yml
@@ -117,4 +117,4 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour revenir !"
       actions:
-        - "[MENU] profil_menu"
+        - "[MENU] profile_main"

--- a/src/main/resources/config/menus/jeux_menu.yml
+++ b/src/main/resources/config/menus/jeux_menu.yml
@@ -178,7 +178,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour voir !"
       actions:
-        - "[MENU] profil_menu"
+        - "[MENU] profile_main"
 
     back:
       slot: 50

--- a/src/main/resources/config/menus/language_menu.yml
+++ b/src/main/resources/config/menus/language_menu.yml
@@ -58,4 +58,4 @@ menu:
       lore:
         - "&7Revenir au menu profil."
       actions:
-        - "[MENU] profil_menu"
+        - "[MENU] profile_main"

--- a/src/main/resources/config/menus/profile_main_redesigned.yml
+++ b/src/main/resources/config/menus/profile_main_redesigned.yml
@@ -1,0 +1,80 @@
+menu:
+  id: "profile_main"
+  title: "&8» &6Mon Profil"
+  size: 54
+  design: "social_template"
+
+  items:
+    player_head:
+      slot: 13
+      material: "PLAYER_HEAD"
+      head: "%player_name%"
+      name: "&6&l%player_name%"
+      lore:
+        - "&r"
+        - "&8▸ &7Grade: %luckperms_prefix%"
+        - "&8▸ &7Niveau: &e%player_level%"
+        - "&8▸ &7Expérience: &d%player_experience%"
+        - "&8▸ &7Temps de jeu: &f%player_playtime_total%"
+        - "&8▸ &7Première connexion: &f%player_first_join%"
+        - "&r"
+        - "&7Vos informations personnelles"
+      actions:
+        - "[NONE]"
+
+    friends_management:
+      slot: 29
+      material: "PLAYER_HEAD"
+      head: "@ui_heads.add_friend"
+      name: "&a&lAmis &8(&e%friends_online%&8/&7%friends_total%&8)"
+      lore:
+        - "&7Gérez votre liste d'amis,"
+        - "&7envoyez des invitations et"
+        - "&7voyez qui est en ligne."
+        - "&r"
+        - "&8▸ &7Amis en ligne: &a%friends_online%"
+        - "&8▸ &7Total d'amis: &7%friends_total%"
+        - "&8▸ &7Demandes en attente: &e%friend_requests%"
+        - "&8▸ &7Votre statut: %friend_status%"
+        - "&r"
+        - "&a▶ Cliquez pour gérer !"
+      actions:
+        - "[MENU] friends_menu"
+
+    group_management:
+      slot: 31
+      material: "PLAYER_HEAD"
+      head: "@ui_heads.invite_group"
+      name: "&e&lGroupe %group_status%"
+      lore:
+        - "&7Créez ou rejoignez un groupe"
+        - "&7pour jouer avec vos amis !"
+        - "&r"
+        - "&8▸ &7Groupe actuel: %group_name%"
+        - "&8▸ &7Membres: &a%group_members%&8/&7%group_max%"
+        - "&8▸ &7Votre rôle: &6%group_role%"
+        - "&8▸ &7Leader: &6%group_leader%"
+        - "&r"
+        - "&e▶ Cliquez pour gérer !"
+      actions:
+        - "[MENU] groups_menu"
+
+    clan_management:
+      slot: 33
+      material: "PLAYER_HEAD"
+      head: "@ui_heads.clan_moderator"
+      name: "&c&lClan %clan_status%"
+      lore:
+        - "&7Rejoignez un clan pour participer"
+        - "&7à des événements exclusifs et"
+        - "&7des guerres de clans !"
+        - "&r"
+        - "&8▸ &7Clan: %clan_name%"
+        - "&8▸ &7Votre rang: &6%clan_rank%"
+        - "&8▸ &7Membres: &a%clan_members%&8/&7%clan_max%"
+        - "&8▸ &7Points: &e%clan_points%"
+        - "&8▸ &7Niveau: &d%clan_level%"
+        - "&r"
+        - "&c▶ Cliquez pour gérer !"
+      actions:
+        - "[MENU] clan_menu"

--- a/src/main/resources/config/menus/settings_menu.yml
+++ b/src/main/resources/config/menus/settings_menu.yml
@@ -110,4 +110,4 @@ menu:
       lore:
         - "&7Revenir au menu profil."
       actions:
-        - "[MENU] profil_menu"
+        - "[MENU] profile_main"

--- a/src/main/resources/config/ui_templates/social_designs.yml
+++ b/src/main/resources/config/ui_templates/social_designs.yml
@@ -1,0 +1,11 @@
+designs:
+  social_template:
+    fill:
+      material: "BLACK_STAINED_GLASS_PANE"
+    borders:
+      - slots: [0,1,2,3,4,5,6,7,8,45,46,47,48,49,50,51,52,53]
+        material: "GRAY_STAINED_GLASS_PANE"
+        name: "&7"
+      - slots: [9,17,18,26,27,35,36,44]
+        material: "LIGHT_GRAY_STAINED_GLASS_PANE"
+        name: "&7"

--- a/src/main/resources/config/ui_templates/social_heads.yml
+++ b/src/main/resources/config/ui_templates/social_heads.yml
@@ -1,0 +1,34 @@
+ui_heads:
+  # Navigation
+  back_button: "hdb:9334"
+  close_button: "hdb:5152"
+  confirm_button: "hdb:5390"
+  cancel_button: "hdb:5393"
+
+  # Actions sociales
+  add_friend: "hdb:9945"
+  remove_friend: "hdb:9334"
+  block_player: "hdb:46237"
+  invite_group: "hdb:9723"
+  promote_member: "hdb:5390"
+  demote_member: "hdb:5393"
+  kick_member: "hdb:9334"
+  ban_member: "hdb:46237"
+  transfer_leadership: "hdb:50218"
+
+  # Statuts
+  online_status: "hdb:8664"
+  offline_status: "hdb:8665"
+  busy_status: "hdb:8666"
+  away_status: "hdb:8667"
+
+  # Paramètres
+  setting_enabled: "hdb:5390"
+  setting_disabled: "hdb:5393"
+  setting_partial: "hdb:8537"
+
+  # Rôles de clan
+  clan_leader: "hdb:50218"
+  clan_co_leader: "hdb:12654"
+  clan_moderator: "hdb:8971"
+  clan_member: "hdb:9945"


### PR DESCRIPTION
## Summary
- introduce a UI template manager and update menu loading to support shared designs and head aliases for consistent social UIs
- add a reusable confirmation workflow with dedicated manager, actions, and configuration
- refresh social placeholders, resources, and profile menu assets to adopt the new templates

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download maven-resources-plugin because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d048d64014832990701c7ecabe3bfe