### PR TITLE
Fix trailing comma causing MenuManager compilation error

### DIFF
--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -184,8 +184,7 @@ public class MenuManager implements Listener {
                 "friends_menu.yml",
                 "friend_management.yml",
                 "groups_menu.yml",
-                "clan_menu.yml",
-
+                "clan_menu.yml"
         );
         for (String fileName : defaults) {
             final File target = new File(directory, fileName);


### PR DESCRIPTION
## Summary
- remove the trailing comma from the default menu list so MenuManager compiles again

## Testing
- mvn -q -DskipTests package *(fails: network unreachable while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d04f9cfbe083298ff2ff67461a6c61