### PR TITLE
Fix ambiguous scheduler lambda overloads

### DIFF
--- a/src/main/java/com/lobby/commands/FriendCommand.java
+++ b/src/main/java/com/lobby/commands/FriendCommand.java
@@ -225,7 +225,7 @@ public class FriendCommand implements CommandExecutor, TabCompleter {
         if (menuManager == null) {
             return;
         }
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+        Bukkit.getScheduler().runTaskLater(plugin, (Runnable) () -> {
             if (player.isOnline()) {
                 menuManager.openMenu(player, "friend_settings_menu");
             }

--- a/src/main/java/com/lobby/holograms/HologramManager.java
+++ b/src/main/java/com/lobby/holograms/HologramManager.java
@@ -592,7 +592,7 @@ public class HologramManager implements Listener, PluginMessageListener {
 
     @EventHandler
     public void onEconomyTransaction(final EconomyTransactionEvent event) {
-        Bukkit.getScheduler().runTask(plugin, () -> holograms.values().stream()
+        Bukkit.getScheduler().runTask(plugin, (Runnable) () -> holograms.values().stream()
                 .filter(hologram -> hasEconomyPlaceholder(hologram.getData().lines()))
                 .forEach(Hologram::updateLines));
     }

--- a/src/main/java/com/lobby/lobby/items/LobbyItemManager.java
+++ b/src/main/java/com/lobby/lobby/items/LobbyItemManager.java
@@ -135,7 +135,7 @@ public class LobbyItemManager {
         }
 
         if (heldSlot >= 0 && heldSlot < 9) {
-            Bukkit.getScheduler().runTask(plugin, () -> player.getInventory().setHeldItemSlot(heldSlot));
+            Bukkit.getScheduler().runTask(plugin, (Runnable) () -> player.getInventory().setHeldItemSlot(heldSlot));
         }
 
         player.updateInventory();

--- a/src/main/java/com/lobby/menus/confirmation/ConfirmationManager.java
+++ b/src/main/java/com/lobby/menus/confirmation/ConfirmationManager.java
@@ -35,7 +35,7 @@ public class ConfirmationManager implements Listener {
             requests.remove(player.getUniqueId());
             return;
         }
-        Bukkit.getScheduler().runTask(plugin, () -> plugin.getMenuManager().openMenu(player, request.templateId()));
+        Bukkit.getScheduler().runTask(plugin, (Runnable) () -> plugin.getMenuManager().openMenu(player, request.templateId()));
     }
 
     public void executeConfirmation(final Player player, final boolean confirmed) {

--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -311,7 +311,7 @@ public class ActionProcessor {
             }
 
             if (menuManager != null) {
-                Bukkit.getScheduler().runTaskLater(plugin, () -> menuManager.openMenu(player, "clan_menu"), 40L);
+                Bukkit.getScheduler().runTaskLater(plugin, (Runnable) () -> menuManager.openMenu(player, "clan_menu"), 40L);
             }
         }, () -> {
             player.sendMessage("§cTemps écoulé - Suppression annulée.");
@@ -672,7 +672,7 @@ public class ActionProcessor {
         if (player == null) {
             return;
         }
-        Bukkit.getScheduler().runTask(plugin, () -> ClanMenus.openClanMembersMenu(player));
+        Bukkit.getScheduler().runTask(plugin, (Runnable) () -> ClanMenus.openClanMembersMenu(player));
     }
 
     private void reopenMenu(final Player player, final String menuId) {
@@ -683,7 +683,7 @@ public class ActionProcessor {
         if (menuManager == null) {
             return;
         }
-        Bukkit.getScheduler().runTask(plugin, () -> {
+        Bukkit.getScheduler().runTask(plugin, (Runnable) () -> {
             if (player.isOnline()) {
                 menuManager.openMenu(player, menuId);
             }

--- a/src/main/java/com/lobby/shop/ShopManager.java
+++ b/src/main/java/com/lobby/shop/ShopManager.java
@@ -161,7 +161,7 @@ public class ShopManager implements Listener {
                 continue;
             }
             final String parsed = command.replace("%player%", player.getName());
-            Bukkit.getScheduler().runTask(plugin, () ->
+            Bukkit.getScheduler().runTask(plugin, (Runnable) () ->
                     Bukkit.dispatchCommand(Bukkit.getConsoleSender(), parsed));
         }
 
@@ -423,7 +423,7 @@ public class ShopManager implements Listener {
         if (context.type() == MenuType.MAIN) {
             final String categoryId = container.get(categoryKey, PersistentDataType.STRING);
             if (categoryId != null && !categoryId.isBlank()) {
-                Bukkit.getScheduler().runTask(plugin, () -> openCategoryMenu(player, categoryId));
+                Bukkit.getScheduler().runTask(plugin, (Runnable) () -> openCategoryMenu(player, categoryId));
             }
             return;
         }

--- a/src/main/java/com/lobby/social/ChatInputManager.java
+++ b/src/main/java/com/lobby/social/ChatInputManager.java
@@ -173,7 +173,7 @@ public final class ChatInputManager implements Listener {
         }
         event.setCancelled(true);
         session.cancelTimeout();
-        Bukkit.getScheduler().runTask(plugin, () -> session.accept(event.getMessage()));
+        Bukkit.getScheduler().runTask(plugin, (Runnable) () -> session.accept(event.getMessage()));
     }
 
     @EventHandler

--- a/src/main/java/com/lobby/social/clans/ClanManager.java
+++ b/src/main/java/com/lobby/social/clans/ClanManager.java
@@ -1087,7 +1087,7 @@ public class ClanManager {
         }
         final long delay = Math.max(0L, invitation.getExpiresAt() - System.currentTimeMillis());
         final long ticks = Math.max(1L, delay / 50L);
-        Bukkit.getScheduler().runTaskLater(plugin, () -> updateInvitationStatus(invitation.getId(), "EXPIRED"), ticks);
+        Bukkit.getScheduler().runTaskLater(plugin, (Runnable) () -> updateInvitationStatus(invitation.getId(), "EXPIRED"), ticks);
     }
 
     /**

--- a/src/main/java/com/lobby/social/groups/GroupManager.java
+++ b/src/main/java/com/lobby/social/groups/GroupManager.java
@@ -636,7 +636,7 @@ public class GroupManager {
         }
         final long delay = Math.max(0L, invitation.getExpiresAt() - System.currentTimeMillis());
         final long ticks = Math.max(1L, delay / 50L);
-        Bukkit.getScheduler().runTaskLater(plugin, () -> markInvitationStatus(invitation.getId(), "EXPIRED"), ticks);
+        Bukkit.getScheduler().runTaskLater(plugin, (Runnable) () -> markInvitationStatus(invitation.getId(), "EXPIRED"), ticks);
     }
 
     private void broadcastGroupMessage(final Group group, final String message) {

--- a/src/main/java/com/lobby/social/menus/MenuClickHandler.java
+++ b/src/main/java/com/lobby/social/menus/MenuClickHandler.java
@@ -57,7 +57,7 @@ public final class MenuClickHandler implements Listener {
             return;
         }
         clickCooldown.add(playerId);
-        Bukkit.getScheduler().runTaskLater(plugin, () -> clickCooldown.remove(playerId), CLICK_DELAY_TICKS);
+        Bukkit.getScheduler().runTaskLater(plugin, (Runnable) () -> clickCooldown.remove(playerId), CLICK_DELAY_TICKS);
 
         final String title = event.getView().getTitle();
         final boolean menuTitle = title.contains("»");
@@ -343,7 +343,7 @@ public final class MenuClickHandler implements Listener {
         if (menuManager == null || player == null) {
             return;
         }
-        Bukkit.getScheduler().runTask(plugin, () -> {
+        Bukkit.getScheduler().runTask(plugin, (Runnable) () -> {
             if (player.isOnline()) {
                 menuManager.openMenu(player, menuId);
             }
@@ -355,7 +355,7 @@ public final class MenuClickHandler implements Listener {
             return;
         }
         final long ticks = Math.max(0L, delayMs / 50L);
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+        Bukkit.getScheduler().runTaskLater(plugin, (Runnable) () -> {
             if (player.isOnline()) {
                 menuManager.openMenu(player, menuId);
             }


### PR DESCRIPTION
## Summary
- cast scheduler lambdas to Runnable in confirmation, shop, lobby item, hologram, chat, and NPC flows to resolve Paper 1.21 overload ambiguity
- update delayed scheduler calls in menu, friend, and invitation workflows to explicitly target the Runnable overload

## Testing
- ⚠️ `mvn -q -DskipTests compile` *(fails: Network is unreachable when resolving Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68d0509f7700832998adcc924a171a46