### PR TITLE
Fix Bukkit scheduler overload ambiguity

### DIFF
--- a/src/main/java/com/lobby/menus/confirmation/ConfirmationManager.java
+++ b/src/main/java/com/lobby/menus/confirmation/ConfirmationManager.java
@@ -47,7 +47,7 @@ public class ConfirmationManager implements Listener {
         if (request == null) {
             return;
         }
-        Bukkit.getScheduler().runTask(plugin, player::closeInventory);
+        Bukkit.getScheduler().runTask(plugin, (Runnable) player::closeInventory);
         final ActionProcessor processor = resolveActionProcessor();
         if (processor == null) {
             return;

--- a/src/main/java/com/lobby/social/ChatInputManager.java
+++ b/src/main/java/com/lobby/social/ChatInputManager.java
@@ -194,7 +194,7 @@ public final class ChatInputManager implements Listener {
         waitingInputs.put(uuid, session);
         session.scheduleTimeout(plugin, () -> {
             if (waitingInputs.remove(uuid, session)) {
-                Bukkit.getScheduler().runTask(plugin, onTimeout);
+                Bukkit.getScheduler().runTask(plugin, (Runnable) onTimeout);
             }
         });
     }
@@ -208,7 +208,7 @@ public final class ChatInputManager implements Listener {
         }
 
         private void scheduleTimeout(final LobbyPlugin plugin, final Runnable timeoutCallback) {
-            timeoutTask = Bukkit.getScheduler().runTaskLater(plugin, timeoutCallback, 600L);
+            timeoutTask = Bukkit.getScheduler().runTaskLater(plugin, (Runnable) timeoutCallback, 600L);
         }
 
         private void cancelTimeout() {


### PR DESCRIPTION
## Summary
- cast scheduler lambdas and method references to Runnable to avoid Paper's overloaded runTask ambiguity
- ensure chat input timeout scheduling uses Runnable overload explicitly

## Testing
- `mvn -q compile` *(fails: network is unreachable when resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d052281bdc8329a018580f8f7dd2b2