### PR TITLE
Fix profile menu references and restore HeadDatabase design

### DIFF
--- a/src/main/resources/config/lobby-items.yml
+++ b/src/main/resources/config/lobby-items.yml
@@ -27,7 +27,7 @@ lobby_items:
       lore:
         - "&7Consulte tes informations personnelles."
       actions:
-        - "[MENU] profile_main"
+        - "[MENU] profil_menu"
 
     shop:
       slot: 4

--- a/src/main/resources/config/menus.yml
+++ b/src/main/resources/config/menus.yml
@@ -415,7 +415,7 @@ menus:
         lore:
           - "&7Retourner au menu principal"
         actions:
-          - "[MENU] profile_main"
+          - "[MENU] profil_menu"
 
   friends_menu:
     title: "&8» &a&lGestion d'Amis"
@@ -520,7 +520,7 @@ menus:
         lore:
           - "&7Retourner au menu profil"
         actions:
-          - "[MENU] profile_main"
+          - "[MENU] profil_menu"
 
   groups_menu:
     title: "&8» &e&lGestion de Groupes"
@@ -628,7 +628,7 @@ menus:
         lore:
           - "&7Retourner au menu profil"
         actions:
-          - "[MENU] profile_main"
+          - "[MENU] profil_menu"
 
   clan_info_menu:
     title: "&8» &c&lMon Clan"
@@ -1448,7 +1448,7 @@ menus:
         lore:
           - "&7Retourner au profil"
         actions:
-          - "[MENU] profile_main"
+          - "[MENU] profil_menu"
       close:
         slot: 53
         material: PLAYER_HEAD
@@ -1527,7 +1527,7 @@ menus:
         lore:
           - "&7Retourner au profil"
         actions:
-          - "[MENU] profile_main"
+          - "[MENU] profil_menu"
       close:
         slot: 53
         material: PLAYER_HEAD
@@ -1586,7 +1586,7 @@ menus:
         lore:
           - "&7Retourner au profil"
         actions:
-          - "[MENU] profile_main"
+          - "[MENU] profil_menu"
       close:
         slot: 53
         material: PLAYER_HEAD

--- a/src/main/resources/config/menus/clan_menu.yml
+++ b/src/main/resources/config/menus/clan_menu.yml
@@ -160,4 +160,4 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour revenir !"
       actions:
-        - "[MENU] profile_main"
+        - "[MENU] profil_menu"

--- a/src/main/resources/config/menus/friends_menu.yml
+++ b/src/main/resources/config/menus/friends_menu.yml
@@ -111,4 +111,4 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour revenir !"
       actions:
-        - "[MENU] profile_main"
+        - "[MENU] profil_menu"

--- a/src/main/resources/config/menus/groups_menu.yml
+++ b/src/main/resources/config/menus/groups_menu.yml
@@ -114,4 +114,4 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour revenir !"
       actions:
-        - "[MENU] profile_main"
+        - "[MENU] profil_menu"

--- a/src/main/resources/config/menus/jeux_menu.yml
+++ b/src/main/resources/config/menus/jeux_menu.yml
@@ -178,7 +178,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour voir !"
       actions:
-        - "[MENU] profile_main"
+        - "[MENU] profil_menu"
 
     back:
       slot: 50

--- a/src/main/resources/config/menus/language_menu.yml
+++ b/src/main/resources/config/menus/language_menu.yml
@@ -2,13 +2,9 @@ menu:
   id: "language_menu"
   title: "&8» &fSélection de Langue"
   size: 27
-  borders:
-    - slots: [0,1,2,6,7,8,9,17,18,26]
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
 
   items:
-    french:
+    francais:
       slot: 11
       material: "PLAYER_HEAD"
       head: "hdb:2736"
@@ -20,7 +16,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour sélectionner !"
       actions:
-        - "[COMMAND] language set fr"
+        - "[MESSAGE] &aLangue sélectionnée : &cFrançais"
 
     english:
       slot: 13
@@ -34,9 +30,9 @@ menu:
         - "&r"
         - "&a▶ Click to select!"
       actions:
-        - "[COMMAND] language set en"
+        - "[MESSAGE] &aLanguage selected: &fEnglish"
 
-    spanish:
+    espanol:
       slot: 15
       material: "PLAYER_HEAD"
       head: "hdb:2738"
@@ -48,9 +44,9 @@ menu:
         - "&r"
         - "&a▶ ¡Haz clic para seleccionar!"
       actions:
-        - "[COMMAND] language set es"
+        - "[MESSAGE] &aIdioma seleccionado: &eEspañol"
 
-    back:
+    retour:
       slot: 22
       material: "PLAYER_HEAD"
       head: "hdb:9334"
@@ -58,4 +54,4 @@ menu:
       lore:
         - "&7Revenir au menu profil."
       actions:
-        - "[MENU] profile_main"
+        - "[MENU] profil_menu"

--- a/src/main/resources/config/menus/profil_menu.yml
+++ b/src/main/resources/config/menus/profil_menu.yml
@@ -4,68 +4,56 @@ menu:
   size: 54
 
   items:
-    deco_1:
+    glass_1:
       slot: 0
       material: "BLUE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
-    deco_2:
+    glass_2:
       slot: 1
       material: "BLUE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
-    deco_3:
+    glass_3:
       slot: 2
       material: "BLUE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
-    deco_4:
+    glass_4:
       slot: 6
       material: "BLUE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
-    deco_5:
+    glass_5:
       slot: 7
       material: "BLUE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
-    deco_6:
+    glass_6:
       slot: 8
       material: "BLUE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
-    deco_7:
-      slot: 9
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-    deco_8:
-      slot: 17
-      material: "BLUE_STAINED_GLASS_PANE"
-      name: "&7"
-      actions:
-        - "[NONE]"
-    deco_9:
+    glass_7:
       slot: 45
       material: "BLUE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
-    deco_10:
+    glass_8:
       slot: 53
       material: "BLUE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
 
-    player_info:
+    player_head:
       slot: 13
       material: "PLAYER_HEAD"
       head: "%player_name%"
@@ -73,66 +61,70 @@ menu:
       lore:
         - "&r"
         - "&8▸ &7Grade: %luckperms_prefix%"
+        - "&8▸ &7Niveau: &e%player_level%"
+        - "&8▸ &7Expérience: &d%player_experience%"
         - "&8▸ &7Temps de jeu: &f%player_playtime_total%"
         - "&8▸ &7Première connexion: &f%player_first_join%"
-        - "&8▸ &7Dernière connexion: &f%player_last_join%"
         - "&r"
         - "&8▸ &7Coins: &e%player_coins%"
         - "&8▸ &7Tokens: &b%player_tokens%"
         - "&r"
-        - "&7Vos informations de profil"
+        - "&7Vos informations personnelles"
       actions:
         - "[NONE]"
 
-    friends:
-      slot: 29
+    amis:
+      slot: 3
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjk2ODlkNDczY2Y2MGI4YWY5ZWRiNzZkOGY0N2U0MTgwYmFhNWY2ZjYzNTBjNTc1ZDNmZjEwYjUxMjUwM2E2OSJ9fX0="
-      name: "&a&lAmis"
+      head: "hdb:9945"
+      name: "&a&lAmis &8(&e%friends_online%&8/&7%friends_total%&8)"
       lore:
         - "&7Gérez votre liste d'amis,"
         - "&7envoyez des invitations et"
         - "&7voyez qui est en ligne."
         - "&r"
-        - "&8▸ &7Amis en ligne: &a0&8/&70"
-        - "&8▸ &7Demandes en attente: &e0"
-        - "&8▸ &7Statut: &aEn ligne"
+        - "&8▸ &7Amis en ligne: &a%friends_online%"
+        - "&8▸ &7Total d'amis: &7%friends_total%"
+        - "&8▸ &7Demandes en attente: &e%friend_requests%"
+        - "&8▸ &7Votre statut: %friend_status%"
         - "&r"
         - "&c⚠ Fonctionnalité en développement"
       actions:
         - "[MESSAGE] &cCette fonctionnalité n'est pas encore disponible !"
 
-    group:
-      slot: 31
+    groupe:
+      slot: 4
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTQzMjY5ZDVhOTM4MWE0ZjE5N2ExMzNlZjBjNGEzMzBmYzllMmMwNGI1YWEzMzNkZGFkMmUyMTEwNTNkYzE5MiJ9fX0="
-      name: "&e&lGroupe"
+      head: "hdb:9723"
+      name: "&e&lGroupe %group_status%"
       lore:
         - "&7Créez ou rejoignez un groupe"
         - "&7pour jouer avec vos amis !"
         - "&r"
-        - "&8▸ &7Groupe actuel: &cAucun"
-        - "&8▸ &7Membres: &a0&8/&78"
-        - "&8▸ &7Leader: &6-"
+        - "&8▸ &7Groupe actuel: %group_name%"
+        - "&8▸ &7Membres: &a%group_members%&8/&7%group_max%"
+        - "&8▸ &7Votre rôle: &6%group_role%"
+        - "&8▸ &7Leader: &6%group_leader%"
         - "&r"
         - "&c⚠ Fonctionnalité en développement"
       actions:
         - "[MESSAGE] &cCette fonctionnalité n'est pas encore disponible !"
 
     clan:
-      slot: 33
+      slot: 5
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWE0ZjY4Yzg3YTkyMjg1ZGUyODNjNGVkODMwZjM4OTBiZjNhOWE3MjMxZDlhYWMzNmNhNzk3ZTVjOTE4YzI5YyJ9fX0="
-      name: "&c&lClan"
+      head: "hdb:8971"
+      name: "&c&lClan %clan_status%"
       lore:
         - "&7Rejoignez un clan pour participer"
         - "&7à des événements exclusifs et"
         - "&7des guerres de clans !"
         - "&r"
-        - "&8▸ &7Clan: &cAucun"
-        - "&8▸ &7Rang: &6-"
-        - "&8▸ &7Membres: &a0&8/&750"
-        - "&8▸ &7Points: &e0"
+        - "&8▸ &7Clan: %clan_name%"
+        - "&8▸ &7Votre rang: &6%clan_rank%"
+        - "&8▸ &7Membres: &a%clan_members%&8/&7%clan_max%"
+        - "&8▸ &7Points: &e%clan_points%"
+        - "&8▸ &7Niveau: &d%clan_level%"
         - "&r"
         - "&c⚠ Fonctionnalité en développement"
       actions:
@@ -141,33 +133,52 @@ menu:
     stats:
       slot: 20
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzY5MTk2YjMzMGM2Yjg5NjE2MjNmNzI4NDM5ZDQxZGE0YzgwOTBiNzNkOWM1ODM5ZTczOGE5ZGE4ZDM0YzNjMCJ9fX0="
+      head: "hdb:2736"
       name: "&b&lMes Statistiques"
       lore:
         - "&7Consultez toutes vos performances"
         - "&7détaillées par mode de jeu."
         - "&r"
-        - "&8▸ &7Parties jouées: &e0"
-        - "&8▸ &7Victoires: &a0"
-        - "&8▸ &7Ratio V/D: &60.0"
-        - "&8▸ &7Expérience: &d0"
+        - "&8▸ &7Parties jouées: &e%player_games_total%"
+        - "&8▸ &7Victoires: &a%player_wins_total%"
+        - "&8▸ &7Ratio V/D: &6%player_ratio%"
+        - "&8▸ &7Expérience: &d%player_experience%"
         - "&r"
         - "&a▶ Cliquez pour voir le détail !"
       actions:
-        - "[MESSAGE] &cLes statistiques détaillées ne sont pas encore disponibles !"
+        - "[MENU] stats_menu"
 
-    settings:
+    langue:
+      slot: 22
+      material: "PLAYER_HEAD"
+      head: "hdb:2736"
+      name: "&f&lLangue &8- &cFrançais"
+      lore:
+        - "&7Changez la langue d'affichage"
+        - "&7de l'interface et des messages."
+        - "&r"
+        - "&8▸ &7Langue actuelle: &c🇫🇷 Français"
+        - "&8▸ &7Langues disponibles:"
+        - "&8  ▸ &c🇫🇷 Français"
+        - "&8  ▸ &f🇬🇧 English"
+        - "&8  ▸ &e🇪🇸 Español"
+        - "&r"
+        - "&a▶ Cliquez pour changer !"
+      actions:
+        - "[MENU] language_menu"
+
+    parametres:
       slot: 24
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjcwNWZkOTRhMGM0MzE5MjdmYjRlNjM5YjBmY2ZiNDk3MTdlNDEyMjg1YTAyYjQzOWI2OTZhMjE4MGViNTkxNSJ9fX0="
+      head: "hdb:1218"
       name: "&d&lParamètres"
       lore:
         - "&7Personnalisez votre expérience"
         - "&7de jeu selon vos préférences."
         - "&r"
-        - "&8▸ &7Messages privés: &aActivés"
-        - "&8▸ &7Demandes d'amis: &aActivées"
-        - "&8▸ &7Visibilité: &aTous"
+        - "&8▸ &7Messages privés: %setting_private_messages%"
+        - "&8▸ &7Demandes d'amis: %setting_friend_requests%"
+        - "&8▸ &7Visibilité: %setting_visibility%"
         - "&r"
         - "&a▶ Cliquez pour configurer !"
       actions:
@@ -176,25 +187,25 @@ menu:
     daily_reward:
       slot: 26
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZDM0ZTA2M2NhZjY5N2QyZTVmZGQ0YmE5Yjg3YjZjZGI0MDU5M2M0OGFiOTAzZjJiZDVlOGZhNjU1Y2QzYzMxMCJ9fX0="
+      head: "hdb:12654"
       name: "&6&lRécompense Journalière"
       lore:
         - "&7Réclamez votre récompense"
         - "&7quotidienne gratuite !"
         - "&r"
-        - "&8▸ &7Statut: &aDisponible"
-        - "&8▸ &7Série actuelle: &e1 jour"
-        - "&8▸ &7Prochaine récompense: &e100 coins"
-        - "&8▸ &7Temps restant: &b23h 59m"
+        - "&8▸ &7Statut: %daily_reward_status%"
+        - "&8▸ &7Série actuelle: &e%daily_streak% jours"
+        - "&8▸ &7Prochaine récompense: %daily_next_reward%"
+        - "&8▸ &7Temps restant: &b%daily_cooldown%"
         - "&r"
         - "&a▶ Cliquez pour réclamer !"
       actions:
         - "[MESSAGE] &cLes récompenses journalières ne sont pas encore disponibles !"
 
-    back:
+    retour:
       slot: 49
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzI0MzE5MTFmNDE3OGI0ZDJiNDEzYWE3ZjVjNzhhZTI1MTUyOTI4MjVmYzk2NGEwNmVmOGZmNmM3MzcyYzZlYiJ9fX0="
+      head: "hdb:9334"
       name: "&c&lRetour"
       lore:
         - "&7Retourner au menu principal"

--- a/src/main/resources/config/menus/settings_menu.yml
+++ b/src/main/resources/config/menus/settings_menu.yml
@@ -4,37 +4,37 @@ menu:
   size: 45
 
   items:
-    deco_1:
+    glass_1:
       slot: 0
       material: "PURPLE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
-    deco_2:
+    glass_2:
       slot: 1
       material: "PURPLE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
-    deco_3:
+    glass_3:
       slot: 7
       material: "PURPLE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
-    deco_4:
+    glass_4:
       slot: 8
       material: "PURPLE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
-    deco_5:
+    glass_5:
       slot: 36
       material: "PURPLE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
-    deco_6:
+    glass_6:
       slot: 44
       material: "PURPLE_STAINED_GLASS_PANE"
       name: "&7"
@@ -44,13 +44,13 @@ menu:
     private_messages:
       slot: 11
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDA2MjYyZjJiM2QwMzU3NjNkYjEzMDUzOTVmMzMxZmYzOTZjN2Q4YTE4OGU4OWNiNzFlNGQyYjc0MzkxYWQ5OSJ9fX0="
+      head: "hdb:3581"
       name: "&a&lMessages Privés"
       lore:
         - "&7Autorisez ou bloquez la réception"
         - "&7de messages privés d'autres joueurs."
         - "&r"
-        - "&8▸ &7Statut actuel: &aActivé"
+        - "&8▸ &7Statut actuel: %setting_private_messages_status%"
         - "&r"
         - "&a▶ Cliquez pour basculer !"
       actions:
@@ -59,29 +59,45 @@ menu:
     friend_requests:
       slot: 13
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDMxMmNhNDYzMmRlZjVmZmFmMmViMGQ5ZDdjYWE4MWE2M2M2NGQ2NGY3NGNiMzE5YjUzNWJmM2YzMDQzMWMxYSJ9fX0="
+      head: "hdb:13389"
       name: "&e&lDemandes d'Amis"
       lore:
         - "&7Gérez qui peut vous envoyer"
         - "&7des demandes d'ajout en ami."
         - "&r"
-        - "&8▸ &7Statut actuel: &aTous"
+        - "&8▸ &7Statut actuel: %setting_friend_requests_status%"
         - "&8▸ &7Options: Tous / Amis d'amis / Personne"
         - "&r"
         - "&a▶ Cliquez pour modifier !"
       actions:
         - "[MESSAGE] &eParamètre changé ! Demandes d'amis: &6Amis d'amis uniquement"
 
-    visibility:
+    group_requests:
       slot: 15
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzFiYzJiY2ZiMmJkMzc1OWU2YjJlM2Y0ZGNjMmVmMTMxNTJlMjBkNTIyNjBhNzU3NjZjZjQ0YWVmYTY5Y2IwNiJ9fX0="
-      name: "&b&lVisibilité"
+      head: "hdb:8537"
+      name: "&b&lDemandes de Groupe"
+      lore:
+        - "&7Contrôlez qui peut vous inviter"
+        - "&7dans des groupes de jeu."
+        - "&r"
+        - "&8▸ &7Statut actuel: %setting_group_requests_status%"
+        - "&8▸ &7Options: Tous / Amis seulement / Personne"
+        - "&r"
+        - "&a▶ Cliquez pour ajuster !"
+      actions:
+        - "[MESSAGE] &eParamètre changé ! Demandes de groupe: &6Amis seulement"
+
+    visibility:
+      slot: 20
+      material: "PLAYER_HEAD"
+      head: "hdb:32010"
+      name: "&f&lVisibilité des Joueurs"
       lore:
         - "&7Choisissez quels joueurs vous"
         - "&7voulez voir dans le lobby."
         - "&r"
-        - "&8▸ &7Mode actuel: &aTous"
+        - "&8▸ &7Mode actuel: %setting_visibility_status%"
         - "&8▸ &7Options: Tous / Amis / Personne"
         - "&r"
         - "&a▶ Cliquez pour changer !"
@@ -89,62 +105,43 @@ menu:
         - "[MESSAGE] &eParamètre changé ! Visibilité: &6Amis uniquement"
 
     notifications:
-      slot: 29
+      slot: 22
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGNmMmE3YzhhYTdjYjMyYzQyYTVkOGNhODM4YTVjNDUzNWM5NmY4M2Y0NzgyN2Y5OWJlNDBhODdhYTkxMWI3NSJ9fX0="
+      head: "hdb:1455"
       name: "&c&lNotifications"
       lore:
         - "&7Gérez les types de notifications"
         - "&7que vous souhaitez recevoir."
         - "&r"
-        - "&8▸ &7Notifications d'amis: &aActivées"
-        - "&8▸ &7Notifications de clan: &aActivées"
-        - "&8▸ &7Notifications système: &aActivées"
+        - "&8▸ &7Notifications d'amis: %notif_friends%"
+        - "&8▸ &7Notifications de clan: %notif_clan%"
+        - "&8▸ &7Notifications système: %notif_system%"
         - "&r"
         - "&a▶ Cliquez pour personnaliser !"
       actions:
         - "[MESSAGE] &eGestion des notifications en cours de développement !"
 
     audio:
-      slot: 31
+      slot: 24
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjEzMTE2YzNjZTcwZTY3MjhkNzQ3OGE1Y2ZiNWZkOTNhZDY5YjMzYWQyOGRjZDNkZGE0NDQ3Nzg2NDIyZDdlOCJ9fX0="
+      head: "hdb:7439"
       name: "&6&lSons et Effets"
       lore:
         - "&7Activez ou désactivez les sons"
         - "&7et effets visuels du lobby."
         - "&r"
-        - "&8▸ &7Sons d'interface: &aActivés"
-        - "&8▸ &7Effets de particules: &aActivés"
-        - "&8▸ &7Musique d'ambiance: &cDésactivée"
+        - "&8▸ &7Sons d'interface: %setting_ui_sounds%"
+        - "&8▸ &7Effets de particules: %setting_particles%"
+        - "&8▸ &7Musique d'ambiance: %setting_music%"
         - "&r"
         - "&a▶ Cliquez pour ajuster !"
       actions:
         - "[MESSAGE] &eParamètres audio en cours de développement !"
 
-    language:
-      slot: 33
-      material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzRlZDI0OWJhOGM0N2M1ZmZjOTdiMjczZjkzNTIyY2YxNmQzOGM4YzJlNWMxZTIzZGI1ZGIzMWRjMjQ5NDg3MSJ9fX0="
-      name: "&f&lLangue &8- &cFrançais"
-      lore:
-        - "&7Changez la langue d'affichage"
-        - "&7de l'interface et des messages."
-        - "&r"
-        - "&8▸ &7Langue actuelle: &c🇫🇷 Français"
-        - "&8▸ &7Langues disponibles:"
-        - "&8  ▸ &c🇫🇷 Français"
-        - "&8  ▸ &f🇬🇧 English"
-        - "&8  ▸ &e🇪🇸 Español"
-        - "&r"
-        - "&a▶ Cliquez pour changer !"
-      actions:
-        - "[MESSAGE] &eLangue changée ! Interface en &fEnglish"
-
     back:
       slot: 40
       material: "PLAYER_HEAD"
-      head: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzI0MzE5MTFmNDE3OGI0ZDJiNDEzYWE3ZjVjNzhhZTI1MTUyOTI4MjVmYzk2NGEwNmVmOGZmNmM3MzcyYzZlYiJ9fX0="
+      head: "hdb:9334"
       name: "&c&lRetour"
       lore:
         - "&7Revenir au menu profil."

--- a/src/main/resources/config/menus/stats_menu.yml
+++ b/src/main/resources/config/menus/stats_menu.yml
@@ -1,0 +1,153 @@
+menu:
+  id: "stats_menu"
+  title: "&8» &bMes Statistiques"
+  size: 54
+
+  items:
+    glass_1:
+      slot: 0
+      material: "CYAN_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_2:
+      slot: 1
+      material: "CYAN_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_3:
+      slot: 2
+      material: "CYAN_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_4:
+      slot: 6
+      material: "CYAN_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_5:
+      slot: 7
+      material: "CYAN_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_6:
+      slot: 8
+      material: "CYAN_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_7:
+      slot: 45
+      material: "CYAN_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_8:
+      slot: 53
+      material: "CYAN_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+
+    general_stats:
+      slot: 13
+      material: "PLAYER_HEAD"
+      head: "hdb:2736"
+      name: "&6&lStatistiques Générales"
+      lore:
+        - "&7Vos performances globales"
+        - "&7sur le serveur."
+        - "&r"
+        - "&8▸ &7Parties jouées: &e%player_games_total%"
+        - "&8▸ &7Victoires: &a%player_wins_total%"
+        - "&8▸ &7Défaites: &c%player_losses_total%"
+        - "&8▸ &7Ratio V/D: &6%player_ratio%"
+        - "&8▸ &7Expérience: &d%player_experience%"
+        - "&r"
+        - "&7Cliquez pour plus de détails"
+      actions:
+        - "[MESSAGE] &eStatistiques détaillées en cours de développement !"
+
+    bedwars_stats:
+      slot: 20
+      material: "PLAYER_HEAD"
+      head: "hdb:67957"
+      name: "&c&lBedWars"
+      lore:
+        - "&7Vos statistiques BedWars"
+        - "&r"
+        - "&8▸ &7Parties: &e%bedwars_games%"
+        - "&8▸ &7Victoires: &a%bedwars_wins%"
+        - "&8▸ &7Kills: &c%bedwars_kills%"
+        - "&8▸ &7Morts: &7%bedwars_deaths%"
+        - "&8▸ &7Lits cassés: &6%bedwars_beds_broken%"
+        - "&r"
+        - "&a▶ Cliquez pour détails !"
+      actions:
+        - "[MESSAGE] &eStatistiques BedWars en cours de développement !"
+
+    nexus_stats:
+      slot: 22
+      material: "PLAYER_HEAD"
+      head: "hdb:38878"
+      name: "&b&lNexus"
+      lore:
+        - "&7Vos statistiques Nexus"
+        - "&r"
+        - "&8▸ &7Parties: &e%nexus_games%"
+        - "&8▸ &7Victoires: &a%nexus_wins%"
+        - "&8▸ &7Kills: &c%nexus_kills%"
+        - "&8▸ &7Morts: &7%nexus_deaths%"
+        - "&8▸ &7Nexus détruits: &6%nexus_destroyed%"
+        - "&r"
+        - "&a▶ Cliquez pour détails !"
+      actions:
+        - "[MESSAGE] &eStatistiques Nexus en cours de développement !"
+
+    zombie_stats:
+      slot: 24
+      material: "PLAYER_HEAD"
+      head: "hdb:23022"
+      name: "&2&lZombie"
+      lore:
+        - "&7Vos statistiques Zombie"
+        - "&r"
+        - "&8▸ &7Parties: &e%zombie_games%"
+        - "&8▸ &7Record: &6%zombie_record% vagues"
+        - "&8▸ &7Zombies tués: &c%zombie_kills%"
+        - "&8▸ &7Temps de survie: &a%zombie_survival_time%"
+        - "&r"
+        - "&a▶ Cliquez pour détails !"
+      actions:
+        - "[MESSAGE] &eStatistiques Zombie en cours de développement !"
+
+    custom_stats:
+      slot: 26
+      material: "PLAYER_HEAD"
+      head: "hdb:60776"
+      name: "&6&lJeux Inédits"
+      lore:
+        - "&7Vos statistiques dans les"
+        - "&7modes de jeu exclusifs."
+        - "&r"
+        - "&8▸ &7Parties: &e%custom_games%"
+        - "&8▸ &7Victoires: &a%custom_wins%"
+        - "&8▸ &7Mode favori: &6%custom_favorite%"
+        - "&r"
+        - "&a▶ Cliquez pour détails !"
+      actions:
+        - "[MESSAGE] &eStatistiques Jeux Inédits en cours de développement !"
+
+    retour:
+      slot: 49
+      material: "PLAYER_HEAD"
+      head: "hdb:9334"
+      name: "&c&lRetour"
+      lore:
+        - "&7Revenir au menu profil."
+      actions:
+        - "[MENU] profil_menu"


### PR DESCRIPTION
## Summary
- update the profil, settings, language, and new stats menus to match the original HeadDatabase layout and placeholders
- point the lobby profile item, game selector, and social menus at the restored `profil_menu`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d05bf05228832981c60e23528bc1c2