### PR TITLE
Fix profile menu layout and remove legacy menu references

### DIFF
--- a/src/main/java/com/lobby/commands/PlayerCommands.java
+++ b/src/main/java/com/lobby/commands/PlayerCommands.java
@@ -23,7 +23,7 @@ public class PlayerCommands implements CommandExecutor, TabExecutor {
 
     private static final Map<String, String> MENU_COMMANDS = Map.of(
             "serveurs", "servers_menu",
-            "profil", "profile_menu"
+            "profil", "profil_menu"
     );
 
     private static final Map<String, String> LOBBY_MENU_SUBCOMMANDS = Map.of(

--- a/src/main/resources/config/menus.yml
+++ b/src/main/resources/config/menus.yml
@@ -1,48 +1,4 @@
 menus:
-  main_menu:
-    title: "&6Menu Principal"
-    size: 27
-    items:
-      profile:
-        slot: 11
-        material: PLAYER_HEAD
-        head: "%player_name%"
-        name: "&bProfil de %player_name%"
-        lore:
-          - "&7Coins: &6%player_coins%"
-          - "&7Tokens: &d%player_tokens%"
-          - "&7Temps de jeu: &f%player_playtime%"
-          - ""
-          - "&eClique pour consulter ton profil"
-        actions:
-          - "[MENU] profile_menu"
-      shop:
-        slot: 13
-        material: EMERALD
-        name: "&aBoutique"
-        lore:
-          - "&7Découvre des offres exclusives"
-          - "&7Solde disponible: &6%player_coins%"
-        actions:
-          - "[MENU] shop_menu"
-      servers:
-        slot: 15
-        material: COMPASS
-        name: "&eSélecteur de serveurs"
-        lore:
-          - "&7Joueurs sur le réseau: &f%server_online%"
-          - "&7Clique pour choisir une destination"
-        actions:
-          - "[MENU] servers_menu"
-      close:
-        slot: 26
-        material: PLAYER_HEAD
-        head: "hdb:60776"
-        name: "&cFermer"
-        lore:
-          - "&7Fermer le menu"
-        actions:
-          - "[CLOSE]"
 
   shop_menu:
     title: "&aBoutique"
@@ -81,7 +37,7 @@ menus:
         lore:
           - "&7Revenir au menu principal"
         actions:
-          - "[MENU] main_menu"
+          - "[MENU] jeux_menu"
       close:
         slot: 26
         material: BARRIER
@@ -138,7 +94,7 @@ menus:
         lore:
           - "&7Retour au menu principal"
         actions:
-          - "[MENU] main_menu"
+          - "[MENU] jeux_menu"
       close:
         slot: 35
         material: BARRIER
@@ -231,7 +187,7 @@ menus:
         lore:
           - "&7Retour au menu principal"
         actions:
-          - "[MENU] main_menu"
+          - "[MENU] jeux_menu"
       close:
         slot: 44
         material: BARRIER

--- a/src/main/resources/config/menus/profil_menu.yml
+++ b/src/main/resources/config/menus/profil_menu.yml
@@ -41,12 +41,24 @@ menu:
       actions:
         - "[NONE]"
     glass_7:
-      slot: 45
+      slot: 9
       material: "BLUE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
     glass_8:
+      slot: 17
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_9:
+      slot: 45
+      material: "BLUE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_10:
       slot: 53
       material: "BLUE_STAINED_GLASS_PANE"
       name: "&7"
@@ -83,10 +95,10 @@ menu:
         - "&7envoyez des invitations et"
         - "&7voyez qui est en ligne."
         - "&r"
-        - "&8▸ &7Amis en ligne: &a%friends_online%"
-        - "&8▸ &7Total d'amis: &7%friends_total%"
-        - "&8▸ &7Demandes en attente: &e%friend_requests%"
-        - "&8▸ &7Votre statut: %friend_status%"
+        - "&8▸ &7Amis en ligne: &a0"
+        - "&8▸ &7Total d'amis: &70"
+        - "&8▸ &7Demandes en attente: &e0"
+        - "&8▸ &7Votre statut: &aEn ligne"
         - "&r"
         - "&c⚠ Fonctionnalité en développement"
       actions:
@@ -96,15 +108,15 @@ menu:
       slot: 4
       material: "PLAYER_HEAD"
       head: "hdb:9723"
-      name: "&e&lGroupe %group_status%"
+      name: "&e&lGroupe"
       lore:
         - "&7Créez ou rejoignez un groupe"
         - "&7pour jouer avec vos amis !"
         - "&r"
-        - "&8▸ &7Groupe actuel: %group_name%"
-        - "&8▸ &7Membres: &a%group_members%&8/&7%group_max%"
-        - "&8▸ &7Votre rôle: &6%group_role%"
-        - "&8▸ &7Leader: &6%group_leader%"
+        - "&8▸ &7Groupe actuel: &cAucun"
+        - "&8▸ &7Membres: &a0&8/&78"
+        - "&8▸ &7Votre rôle: &6-"
+        - "&8▸ &7Leader: &6-"
         - "&r"
         - "&c⚠ Fonctionnalité en développement"
       actions:
@@ -114,17 +126,17 @@ menu:
       slot: 5
       material: "PLAYER_HEAD"
       head: "hdb:8971"
-      name: "&c&lClan %clan_status%"
+      name: "&c&lClan"
       lore:
         - "&7Rejoignez un clan pour participer"
         - "&7à des événements exclusifs et"
         - "&7des guerres de clans !"
         - "&r"
-        - "&8▸ &7Clan: %clan_name%"
-        - "&8▸ &7Votre rang: &6%clan_rank%"
-        - "&8▸ &7Membres: &a%clan_members%&8/&7%clan_max%"
-        - "&8▸ &7Points: &e%clan_points%"
-        - "&8▸ &7Niveau: &d%clan_level%"
+        - "&8▸ &7Clan: &cAucun"
+        - "&8▸ &7Votre rang: &6-"
+        - "&8▸ &7Membres: &a0&8/&750"
+        - "&8▸ &7Points: &e0"
+        - "&8▸ &7Niveau: &d1"
         - "&r"
         - "&c⚠ Fonctionnalité en développement"
       actions:
@@ -139,10 +151,10 @@ menu:
         - "&7Consultez toutes vos performances"
         - "&7détaillées par mode de jeu."
         - "&r"
-        - "&8▸ &7Parties jouées: &e%player_games_total%"
-        - "&8▸ &7Victoires: &a%player_wins_total%"
-        - "&8▸ &7Ratio V/D: &6%player_ratio%"
-        - "&8▸ &7Expérience: &d%player_experience%"
+        - "&8▸ &7Parties jouées: &e0"
+        - "&8▸ &7Victoires: &a0"
+        - "&8▸ &7Ratio V/D: &60.0"
+        - "&8▸ &7Expérience: &d0"
         - "&r"
         - "&a▶ Cliquez pour voir le détail !"
       actions:
@@ -176,9 +188,9 @@ menu:
         - "&7Personnalisez votre expérience"
         - "&7de jeu selon vos préférences."
         - "&r"
-        - "&8▸ &7Messages privés: %setting_private_messages%"
-        - "&8▸ &7Demandes d'amis: %setting_friend_requests%"
-        - "&8▸ &7Visibilité: %setting_visibility%"
+        - "&8▸ &7Messages privés: &aActivés"
+        - "&8▸ &7Demandes d'amis: &aActivées"
+        - "&8▸ &7Visibilité: &aTous"
         - "&r"
         - "&a▶ Cliquez pour configurer !"
       actions:
@@ -193,10 +205,10 @@ menu:
         - "&7Réclamez votre récompense"
         - "&7quotidienne gratuite !"
         - "&r"
-        - "&8▸ &7Statut: %daily_reward_status%"
-        - "&8▸ &7Série actuelle: &e%daily_streak% jours"
-        - "&8▸ &7Prochaine récompense: %daily_next_reward%"
-        - "&8▸ &7Temps restant: &b%daily_cooldown%"
+        - "&8▸ &7Statut: &aDisponible"
+        - "&8▸ &7Série actuelle: &e1 jour"
+        - "&8▸ &7Prochaine récompense: &e100 coins"
+        - "&8▸ &7Temps restant: &b23h 59m"
         - "&r"
         - "&a▶ Cliquez pour réclamer !"
       actions:

--- a/src/main/resources/config/menus/stats_menu.yml
+++ b/src/main/resources/config/menus/stats_menu.yml
@@ -41,12 +41,24 @@ menu:
       actions:
         - "[NONE]"
     glass_7:
-      slot: 45
+      slot: 9
       material: "CYAN_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
     glass_8:
+      slot: 17
+      material: "CYAN_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_9:
+      slot: 45
+      material: "CYAN_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_10:
       slot: 53
       material: "CYAN_STAINED_GLASS_PANE"
       name: "&7"
@@ -62,11 +74,11 @@ menu:
         - "&7Vos performances globales"
         - "&7sur le serveur."
         - "&r"
-        - "&8▸ &7Parties jouées: &e%player_games_total%"
-        - "&8▸ &7Victoires: &a%player_wins_total%"
-        - "&8▸ &7Défaites: &c%player_losses_total%"
-        - "&8▸ &7Ratio V/D: &6%player_ratio%"
-        - "&8▸ &7Expérience: &d%player_experience%"
+        - "&8▸ &7Parties jouées: &e0"
+        - "&8▸ &7Victoires: &a0"
+        - "&8▸ &7Défaites: &c0"
+        - "&8▸ &7Ratio V/D: &60.0"
+        - "&8▸ &7Expérience: &d0"
         - "&r"
         - "&7Cliquez pour plus de détails"
       actions:
@@ -80,11 +92,11 @@ menu:
       lore:
         - "&7Vos statistiques BedWars"
         - "&r"
-        - "&8▸ &7Parties: &e%bedwars_games%"
-        - "&8▸ &7Victoires: &a%bedwars_wins%"
-        - "&8▸ &7Kills: &c%bedwars_kills%"
-        - "&8▸ &7Morts: &7%bedwars_deaths%"
-        - "&8▸ &7Lits cassés: &6%bedwars_beds_broken%"
+        - "&8▸ &7Parties: &e0"
+        - "&8▸ &7Victoires: &a0"
+        - "&8▸ &7Kills: &c0"
+        - "&8▸ &7Morts: &70"
+        - "&8▸ &7Lits cassés: &60"
         - "&r"
         - "&a▶ Cliquez pour détails !"
       actions:
@@ -98,11 +110,11 @@ menu:
       lore:
         - "&7Vos statistiques Nexus"
         - "&r"
-        - "&8▸ &7Parties: &e%nexus_games%"
-        - "&8▸ &7Victoires: &a%nexus_wins%"
-        - "&8▸ &7Kills: &c%nexus_kills%"
-        - "&8▸ &7Morts: &7%nexus_deaths%"
-        - "&8▸ &7Nexus détruits: &6%nexus_destroyed%"
+        - "&8▸ &7Parties: &e0"
+        - "&8▸ &7Victoires: &a0"
+        - "&8▸ &7Kills: &c0"
+        - "&8▸ &7Morts: &70"
+        - "&8▸ &7Nexus détruits: &60"
         - "&r"
         - "&a▶ Cliquez pour détails !"
       actions:
@@ -116,10 +128,10 @@ menu:
       lore:
         - "&7Vos statistiques Zombie"
         - "&r"
-        - "&8▸ &7Parties: &e%zombie_games%"
-        - "&8▸ &7Record: &6%zombie_record% vagues"
-        - "&8▸ &7Zombies tués: &c%zombie_kills%"
-        - "&8▸ &7Temps de survie: &a%zombie_survival_time%"
+        - "&8▸ &7Parties: &e0"
+        - "&8▸ &7Record: &60 vagues"
+        - "&8▸ &7Zombies tués: &c0"
+        - "&8▸ &7Temps de survie: &a0 min"
         - "&r"
         - "&a▶ Cliquez pour détails !"
       actions:
@@ -134,9 +146,9 @@ menu:
         - "&7Vos statistiques dans les"
         - "&7modes de jeu exclusifs."
         - "&r"
-        - "&8▸ &7Parties: &e%custom_games%"
-        - "&8▸ &7Victoires: &a%custom_wins%"
-        - "&8▸ &7Mode favori: &6%custom_favorite%"
+        - "&8▸ &7Parties: &e0"
+        - "&8▸ &7Victoires: &a0"
+        - "&8▸ &7Mode favori: &6Aucun"
         - "&r"
         - "&a▶ Cliquez pour détails !"
       actions:


### PR DESCRIPTION
## Summary
- remove the legacy main menu definition and point back buttons in menu configs to the jeux menu
- update the profil and stats menus with the requested glass panes and placeholder lore
- align the /profil command so it opens the updated profil_menu definition

## Testing
- mvn -q -DskipTests package *(fails: unable to reach repo.maven.apache.org to download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d060f8c3f883299c473acdff1e58e3