### PR TITLE
Improve NPC sound resolution reliability

### DIFF
--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -181,10 +181,15 @@ public class ActionProcessor {
         if (startsWithIgnoreCase(trimmed, "[SOUND]")) {
             final String soundName = processed.substring(7).trim();
             final Sound sound = resolveSound(soundName);
-            if (sound != null) {
-                player.playSound(player.getLocation(), sound, 1.0f, 1.0f);
-            } else {
+            if (sound == null) {
                 LogUtils.warning(plugin, "Unknown sound in NPC action: " + soundName);
+                return;
+            }
+            try {
+                player.playSound(player.getLocation(), sound, 1.0f, 1.0f);
+            } catch (final Exception exception) {
+                LogUtils.warning(plugin, "Failed to play sound '" + soundName + "' for player '"
+                        + player.getName() + "': " + exception.getMessage());
             }
             return;
         }
@@ -963,37 +968,65 @@ public class ActionProcessor {
     }
 
     private Sound resolveSound(final String soundName) {
-        if (soundName == null || soundName.isBlank()) {
+        if (soundName == null) {
             return null;
         }
-        final String trimmed = soundName.trim();
-        final String lower = trimmed.toLowerCase(Locale.ROOT);
 
-        final Sound namespacedMatch = lookupSound(lower);
-        if (namespacedMatch != null) {
-            return namespacedMatch;
+        final String trimmed = soundName.trim();
+        if (trimmed.isEmpty()) {
+            return null;
         }
 
-        if (lower.startsWith("minecraft:")) {
-            final Sound minecraftMatch = lookupSound(lower.substring("minecraft:".length()));
-            if (minecraftMatch != null) {
-                return minecraftMatch;
+        final String sanitized = sanitizeSoundInput(trimmed);
+        final String normalized = normalizeSoundName(sanitized);
+        boolean fallbackDueToUnknown = false;
+
+        final Sound directMatch = lookupSound(sanitized.toLowerCase(Locale.ROOT));
+        if (directMatch != null) {
+            return directMatch;
+        }
+
+        if (sanitized.indexOf(':') >= 0) {
+            final int separator = sanitized.indexOf(':');
+            final String namespace = sanitized.substring(0, separator);
+            final String value = sanitized.substring(separator + 1).replace('_', '.');
+            final Sound namespacedDotted = lookupSound(namespace + ":" + value);
+            if (namespacedDotted != null) {
+                return namespacedDotted;
             }
         }
 
-        if (!lower.contains(".")) {
-            final String dotted = lower.replace('_', '.');
+        final Sound normalizedMatch = lookupSound(normalized.toLowerCase(Locale.ROOT));
+        if (normalizedMatch != null) {
+            return normalizedMatch;
+        }
+
+        if (!normalized.contains(":")) {
+            final String dotted = normalized.toLowerCase(Locale.ROOT).replace('_', '.');
             final Sound dottedMatch = lookupSound(dotted);
             if (dottedMatch != null) {
                 return dottedMatch;
             }
+
+            try {
+                final String enumKey = normalized.replace('.', '_');
+                return Enum.valueOf(Sound.class, enumKey);
+            } catch (final IllegalArgumentException exception) {
+                LogUtils.warning(plugin, "Unknown sound in NPC action: '" + soundName + "'. "
+                        + exception.getMessage());
+                fallbackDueToUnknown = true;
+            } catch (final Exception exception) {
+                LogUtils.severe(plugin, "Unexpected error while resolving sound '" + soundName + "'.",
+                        exception);
+                fallbackDueToUnknown = true;
+            }
         }
 
-        try {
-            return Sound.valueOf(trimmed.toUpperCase(Locale.ROOT));
-        } catch (final IllegalArgumentException ignored) {
-            return null;
+        if (!fallbackDueToUnknown) {
+            LogUtils.warning(plugin, "Unknown sound in NPC action: '" + soundName
+                    + "'. Using default fallback sound.");
         }
+        return getDefaultSound();
     }
 
     private Sound lookupSound(final String key) {
@@ -1010,6 +1043,46 @@ public class ActionProcessor {
             }
             return Registry.SOUNDS.get(NamespacedKey.minecraft(key));
         } catch (final IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private String sanitizeSoundInput(final String soundName) {
+        final String replaced = soundName.replace(' ', '_').replace('-', '_');
+        final int separatorIndex = replaced.indexOf(':');
+        if (separatorIndex >= 0) {
+            final String namespace = replaced.substring(0, separatorIndex).toLowerCase(Locale.ROOT);
+            final String value = replaced.substring(separatorIndex + 1).toLowerCase(Locale.ROOT);
+            return namespace + ":" + value;
+        }
+        return replaced;
+    }
+
+    private String normalizeSoundName(final String soundName) {
+        final String base = soundName.contains(":")
+                ? soundName.substring(soundName.indexOf(':') + 1)
+                : soundName;
+        final String upper = base.toUpperCase(Locale.ROOT);
+        return switch (upper) {
+            case "CLICK", "BUTTON_CLICK" -> "UI_BUTTON_CLICK";
+            case "PLING", "NOTE_PLING" -> "BLOCK_NOTE_BLOCK_PLING";
+            case "POP" -> "ENTITY_ITEM_PICKUP";
+            case "VILLAGER_YES" -> "ENTITY_VILLAGER_YES";
+            case "VILLAGER_NO" -> "ENTITY_VILLAGER_NO";
+            case "ANVIL_USE" -> "BLOCK_ANVIL_USE";
+            case "CHEST_OPEN" -> "BLOCK_CHEST_OPEN";
+            case "CHEST_CLOSE" -> "BLOCK_CHEST_CLOSE";
+            case "DOOR_OPEN" -> "BLOCK_WOODEN_DOOR_OPEN";
+            case "DOOR_CLOSE" -> "BLOCK_WOODEN_DOOR_CLOSE";
+            default -> upper;
+        };
+    }
+
+    private Sound getDefaultSound() {
+        try {
+            return Sound.UI_BUTTON_CLICK;
+        } catch (final Exception exception) {
+            LogUtils.severe(plugin, "Failed to resolve default fallback sound.", exception);
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- Harden NPC sound action handling to avoid runtime errors and guard playSound invocations
- Normalize configured sound names, resolve aliases, and fall back to a default tone when lookups fail

## Testing
- mvn clean package *(fails: network is unreachable when downloading maven-clean-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d12534b0b4832985cc238276bec1c8