### PR TITLE
Fix sound resolution enum lookup

### DIFF
--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -1010,7 +1010,7 @@ public class ActionProcessor {
 
             try {
                 final String enumKey = normalized.replace('.', '_');
-                return Enum.valueOf(Sound.class, enumKey);
+                return Sound.valueOf(enumKey);
             } catch (final IllegalArgumentException exception) {
                 LogUtils.warning(plugin, "Unknown sound in NPC action: '" + soundName + "'. "
                         + exception.getMessage());


### PR DESCRIPTION
## Summary
- replace the generic Enum.valueOf call with Sound.valueOf when resolving a fallback sound
- prevent the type inference error triggered during sound resolution compilation

## Testing
- `mvn -q compile` *(fails: network is unreachable while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d1271fb2148329ba5536cc6925ce63