### PR TITLE
Disable NPC sound actions and adjust shading configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.3-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -74,7 +74,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>21</release>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -88,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -97,16 +98,41 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.bstats</pattern>
+                                    <shadedPattern>com.lobby.bstats</shadedPattern>
+                                </relocation>
+                            </relocations>
                             <filters>
                                 <filter>
-                                    <artifact>mysql:mysql-connector-java</artifact>
+                                    <artifact>*:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>io.papermc.paper:paper-api</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.bukkit:bukkit</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.lobby.LobbyPlugin</mainClass>
+                                </transformer>
+                            </transformers>
+                            <minimizeJar>false</minimizeJar>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -19,8 +19,6 @@ import com.lobby.utils.MessageUtils;
 import com.lobby.utils.PlaceholderUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
-import org.bukkit.Registry;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
@@ -180,17 +178,7 @@ public class ActionProcessor {
         }
         if (startsWithIgnoreCase(trimmed, "[SOUND]")) {
             final String soundName = processed.substring(7).trim();
-            final Sound sound = resolveSound(soundName);
-            if (sound == null) {
-                LogUtils.warning(plugin, "Unknown sound in NPC action: " + soundName);
-                return;
-            }
-            try {
-                player.playSound(player.getLocation(), sound, 1.0f, 1.0f);
-            } catch (final Exception exception) {
-                LogUtils.warning(plugin, "Failed to play sound '" + soundName + "' for player '"
-                        + player.getName() + "': " + exception.getMessage());
-            }
+            LogUtils.info(plugin, "Sound action ignored temporarily: " + (soundName.isEmpty() ? "<empty>" : soundName));
             return;
         }
         if (startsWithIgnoreCase(trimmed, "[CLOSE]")) {
@@ -968,122 +956,9 @@ public class ActionProcessor {
     }
 
     private Sound resolveSound(final String soundName) {
-        if (soundName == null) {
-            return null;
-        }
-
-        final String trimmed = soundName.trim();
-        if (trimmed.isEmpty()) {
-            return null;
-        }
-
-        final String sanitized = sanitizeSoundInput(trimmed);
-        final String normalized = normalizeSoundName(sanitized);
-        boolean fallbackDueToUnknown = false;
-
-        final Sound directMatch = lookupSound(sanitized.toLowerCase(Locale.ROOT));
-        if (directMatch != null) {
-            return directMatch;
-        }
-
-        if (sanitized.indexOf(':') >= 0) {
-            final int separator = sanitized.indexOf(':');
-            final String namespace = sanitized.substring(0, separator);
-            final String value = sanitized.substring(separator + 1).replace('_', '.');
-            final Sound namespacedDotted = lookupSound(namespace + ":" + value);
-            if (namespacedDotted != null) {
-                return namespacedDotted;
-            }
-        }
-
-        final Sound normalizedMatch = lookupSound(normalized.toLowerCase(Locale.ROOT));
-        if (normalizedMatch != null) {
-            return normalizedMatch;
-        }
-
-        if (!normalized.contains(":")) {
-            final String dotted = normalized.toLowerCase(Locale.ROOT).replace('_', '.');
-            final Sound dottedMatch = lookupSound(dotted);
-            if (dottedMatch != null) {
-                return dottedMatch;
-            }
-
-            try {
-                final String enumKey = normalized.replace('.', '_');
-                return Sound.valueOf(enumKey);
-            } catch (final IllegalArgumentException exception) {
-                LogUtils.warning(plugin, "Unknown sound in NPC action: '" + soundName + "'. "
-                        + exception.getMessage());
-                fallbackDueToUnknown = true;
-            } catch (final Exception exception) {
-                LogUtils.severe(plugin, "Unexpected error while resolving sound '" + soundName + "'.",
-                        exception);
-                fallbackDueToUnknown = true;
-            }
-        }
-
-        if (!fallbackDueToUnknown) {
-            LogUtils.warning(plugin, "Unknown sound in NPC action: '" + soundName
-                    + "'. Using default fallback sound.");
-        }
-        return getDefaultSound();
+        LogUtils.info(plugin, "Sound resolution skipped (temporarily disabled): "
+                + (soundName == null || soundName.isBlank() ? "<empty>" : soundName.trim()));
+        return null;
     }
 
-    private Sound lookupSound(final String key) {
-        try {
-            final NamespacedKey directKey = NamespacedKey.fromString(key);
-            if (directKey != null) {
-                final Sound sound = Registry.SOUNDS.get(directKey);
-                if (sound != null) {
-                    return sound;
-                }
-            }
-            if (key.indexOf(':') >= 0) {
-                return null;
-            }
-            return Registry.SOUNDS.get(NamespacedKey.minecraft(key));
-        } catch (final IllegalArgumentException ignored) {
-            return null;
-        }
-    }
-
-    private String sanitizeSoundInput(final String soundName) {
-        final String replaced = soundName.replace(' ', '_').replace('-', '_');
-        final int separatorIndex = replaced.indexOf(':');
-        if (separatorIndex >= 0) {
-            final String namespace = replaced.substring(0, separatorIndex).toLowerCase(Locale.ROOT);
-            final String value = replaced.substring(separatorIndex + 1).toLowerCase(Locale.ROOT);
-            return namespace + ":" + value;
-        }
-        return replaced;
-    }
-
-    private String normalizeSoundName(final String soundName) {
-        final String base = soundName.contains(":")
-                ? soundName.substring(soundName.indexOf(':') + 1)
-                : soundName;
-        final String upper = base.toUpperCase(Locale.ROOT);
-        return switch (upper) {
-            case "CLICK", "BUTTON_CLICK" -> "UI_BUTTON_CLICK";
-            case "PLING", "NOTE_PLING" -> "BLOCK_NOTE_BLOCK_PLING";
-            case "POP" -> "ENTITY_ITEM_PICKUP";
-            case "VILLAGER_YES" -> "ENTITY_VILLAGER_YES";
-            case "VILLAGER_NO" -> "ENTITY_VILLAGER_NO";
-            case "ANVIL_USE" -> "BLOCK_ANVIL_USE";
-            case "CHEST_OPEN" -> "BLOCK_CHEST_OPEN";
-            case "CHEST_CLOSE" -> "BLOCK_CHEST_CLOSE";
-            case "DOOR_OPEN" -> "BLOCK_WOODEN_DOOR_OPEN";
-            case "DOOR_CLOSE" -> "BLOCK_WOODEN_DOOR_CLOSE";
-            default -> upper;
-        };
-    }
-
-    private Sound getDefaultSound() {
-        try {
-            return Sound.UI_BUTTON_CLICK;
-        } catch (final Exception exception) {
-            LogUtils.severe(plugin, "Failed to resolve default fallback sound.", exception);
-            return null;
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- disable NPC sound actions and resolution to avoid runtime sound errors
- update the Maven Shade configuration to exclude Bukkit APIs, add relocation, and disable minimization
- align compiler settings and Paper API dependency with safe defaults for Paper 1.21

## Testing
- mvn clean package *(fails: network is unreachable when resolving maven-clean-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d12a7c9e0c832980b8db5f11073e6f