### PR TITLE
Fix friend request settings enforcement and settings menu UI

### DIFF
--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -638,6 +638,9 @@ public class ActionProcessor {
             case SYSTEM_NOTIFICATIONS -> prefix + "Notifications système " + settings.getSystemNotificationsDisplay() + "&7 !";
         };
         player.sendMessage(MessageUtils.colorize(message));
+        if (type == SettingType.FRIEND_REQUESTS) {
+            player.sendMessage(MessageUtils.colorize("&7Cette restriction est maintenant active pour toutes les futures demandes."));
+        }
     }
 
     private void applyVisibilitySetting(final Player player, final VisibilitySetting setting) {

--- a/src/main/java/com/lobby/social/friends/FriendManager.java
+++ b/src/main/java/com/lobby/social/friends/FriendManager.java
@@ -5,6 +5,7 @@ import com.lobby.core.DatabaseManager;
 import com.lobby.servers.ServerInfo;
 import com.lobby.servers.ServerManager;
 import com.lobby.velocity.VelocityManager;
+import com.lobby.settings.PlayerSettingsManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -20,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,10 +35,15 @@ public class FriendManager {
     private final Map<UUID, Set<UUID>> favoritesCache = new ConcurrentHashMap<>();
     private final Map<UUID, Set<UUID>> pendingRequests = new ConcurrentHashMap<>();
     private final Map<UUID, FriendSettings> settingsCache = new ConcurrentHashMap<>();
+    private final FriendRequestValidator friendRequestValidator;
 
     public FriendManager(final LobbyPlugin plugin) {
         this.plugin = plugin;
         this.databaseManager = plugin.getDatabaseManager();
+        final PlayerSettingsManager playerSettingsManager = plugin.getPlayerSettingsManager();
+        this.friendRequestValidator = playerSettingsManager != null
+                ? new FriendRequestValidator(playerSettingsManager, this)
+                : null;
     }
 
     public void reload() {
@@ -106,6 +113,14 @@ public class FriendManager {
                     : FriendRequestResult.DATABASE_ERROR;
         }
 
+        if (friendRequestValidator != null) {
+            final FriendRequestValidator.ValidationResult validationResult =
+                    friendRequestValidator.canSendFriendRequest(senderUuid, targetUuid);
+            if (!validationResult.isAllowed()) {
+                return validationResult.getFailureResult();
+            }
+        }
+
         final FriendSettings settings = getFriendSettings(targetUuid);
         final AcceptMode acceptMode = settings.getAcceptRequests();
         if (acceptMode == AcceptMode.NONE) {
@@ -148,12 +163,12 @@ public class FriendManager {
                                                final FriendRequestResult result) {
         switch (result) {
             case SELF_REQUEST -> sender.sendMessage("§cVous ne pouvez pas vous ajouter vous-même !");
-            case ALREADY_FRIENDS -> sender.sendMessage("§cVous êtes déjà amis avec " + targetName + " !");
-            case BLOCKED -> sender.sendMessage("§cImpossible d'envoyer une demande : relation bloquée.");
-            case REQUEST_ALREADY_SENT -> sender.sendMessage("§cVous avez déjà envoyé une demande d'ami à " + targetName + " !");
+            case ALREADY_FRIENDS -> sender.sendMessage("§cVous êtes déjà amis avec ce joueur.");
+            case BLOCKED -> sender.sendMessage("§cCe joueur vous a bloqué.");
+            case REQUEST_ALREADY_SENT -> sender.sendMessage("§cUne demande d'ami est déjà en attente.");
             case INCOMING_REQUEST_PENDING -> sender.sendMessage("§e" + targetName + " §cvous a déjà envoyé une demande. Tapez §a/friend accept " + targetName + " §cpour l'accepter.");
             case SETTINGS_DISABLED -> sender.sendMessage("§c" + targetName + " n'accepte pas les demandes d'amis.");
-            case MUTUAL_FRIENDS_REQUIRED -> sender.sendMessage("§cVous devez avoir des amis en commun avec " + targetName + " pour envoyer une demande.");
+            case MUTUAL_FRIENDS_REQUIRED -> sender.sendMessage("§cCe joueur n'accepte que les demandes d'amis d'amis.");
             case DATABASE_ERROR -> sender.sendMessage("§cImpossible d'envoyer la demande pour le moment. Veuillez réessayer plus tard.");
             default -> {
             }
@@ -351,9 +366,16 @@ public class FriendManager {
         return friends.contains(player2);
     }
 
-    private boolean hasPendingRequest(final UUID sender, final UUID target) {
+    public boolean hasPendingRequest(final UUID sender, final UUID target) {
         final Set<UUID> requests = pendingRequests.computeIfAbsent(target, this::loadPendingRequests);
         return requests.contains(sender);
+    }
+
+    public Set<UUID> getFriends(final UUID playerUUID) {
+        if (playerUUID == null) {
+            return Collections.emptySet();
+        }
+        return Collections.unmodifiableSet(friendsCache.computeIfAbsent(playerUUID, this::loadFriendsFromDatabase));
     }
 
     private void removePendingRequest(final UUID sender, final UUID target) {

--- a/src/main/java/com/lobby/social/friends/FriendRequestValidator.java
+++ b/src/main/java/com/lobby/social/friends/FriendRequestValidator.java
@@ -1,0 +1,112 @@
+package com.lobby.social.friends;
+
+import com.lobby.settings.PlayerSettings;
+import com.lobby.settings.PlayerSettingsManager;
+import com.lobby.settings.FriendRequestSetting;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Validates whether a friend request can be sent between two players based on their settings
+ * and existing social relations.
+ */
+public class FriendRequestValidator {
+
+    private final PlayerSettingsManager settingsManager;
+    private final FriendManager friendManager;
+
+    public FriendRequestValidator(final PlayerSettingsManager settingsManager,
+                                  final FriendManager friendManager) {
+        this.settingsManager = settingsManager;
+        this.friendManager = friendManager;
+    }
+
+    /**
+     * Determines if a friend request is allowed between the sender and the target player.
+     *
+     * @param sender the UUID of the player sending the request
+     * @param target the UUID of the player receiving the request
+     * @return the validation result describing whether the request is allowed
+     */
+    public ValidationResult canSendFriendRequest(final UUID sender, final UUID target) {
+        if (sender == null || target == null) {
+            return ValidationResult.denied(FriendRequestResult.DATABASE_ERROR);
+        }
+        if (settingsManager == null) {
+            return ValidationResult.allowed();
+        }
+
+        final PlayerSettings targetSettings = settingsManager.getPlayerSettings(target);
+        final FriendRequestSetting setting = targetSettings.getFriendRequestSetting();
+
+        switch (setting) {
+            case DISABLED:
+                return ValidationResult.denied(FriendRequestResult.SETTINGS_DISABLED);
+            case FRIENDS_OF_FRIENDS:
+                if (!haveMutualFriends(sender, target)) {
+                    return ValidationResult.denied(FriendRequestResult.MUTUAL_FRIENDS_REQUIRED);
+                }
+                break;
+            case EVERYONE:
+                break;
+        }
+
+        if (friendManager.areFriends(sender, target)) {
+            return ValidationResult.denied(FriendRequestResult.ALREADY_FRIENDS);
+        }
+        if (friendManager.hasPendingRequest(sender, target)) {
+            return ValidationResult.denied(FriendRequestResult.REQUEST_ALREADY_SENT);
+        }
+        if (friendManager.isBlocked(target, sender)) {
+            return ValidationResult.denied(FriendRequestResult.BLOCKED);
+        }
+
+        return ValidationResult.allowed();
+    }
+
+    private boolean haveMutualFriends(final UUID player1, final UUID player2) {
+        final Set<UUID> friends1 = safeFriends(player1);
+        final Set<UUID> friends2 = safeFriends(player2);
+        for (final UUID friend : friends1) {
+            if (friends2.contains(friend)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Set<UUID> safeFriends(final UUID uuid) {
+        if (uuid == null) {
+            return Collections.emptySet();
+        }
+        return friendManager.getFriends(uuid);
+    }
+
+    public static class ValidationResult {
+        private final boolean allowed;
+        private final FriendRequestResult failureResult;
+
+        private ValidationResult(final boolean allowed, final FriendRequestResult failureResult) {
+            this.allowed = allowed;
+            this.failureResult = failureResult;
+        }
+
+        public static ValidationResult allowed() {
+            return new ValidationResult(true, null);
+        }
+
+        public static ValidationResult denied(final FriendRequestResult result) {
+            return new ValidationResult(false, result);
+        }
+
+        public boolean isAllowed() {
+            return allowed;
+        }
+
+        public FriendRequestResult getFailureResult() {
+            return failureResult;
+        }
+    }
+}

--- a/src/main/resources/config/menus/settings_menu.yml
+++ b/src/main/resources/config/menus/settings_menu.yml
@@ -29,12 +29,24 @@ menu:
       actions:
         - "[NONE]"
     glass_5:
-      slot: 36
+      slot: 9
       material: "PURPLE_STAINED_GLASS_PANE"
       name: "&7"
       actions:
         - "[NONE]"
     glass_6:
+      slot: 17
+      material: "PURPLE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_7:
+      slot: 36
+      material: "PURPLE_STAINED_GLASS_PANE"
+      name: "&7"
+      actions:
+        - "[NONE]"
+    glass_8:
       slot: 44
       material: "PURPLE_STAINED_GLASS_PANE"
       name: "&7"
@@ -177,30 +189,6 @@ menu:
         - "&a▶ Cliquez pour ajuster !"
       actions:
         - "[MENU] audio_settings_menu"
-        - "[SOUND] BLOCK_NOTE_BLOCK_PLING"
-
-    language:
-      slot: 31
-      material: "PLAYER_HEAD"
-      head: "hdb:2736"
-      name: "&f&lLangue &8- &c%setting_language_flag% %setting_language_name%"
-      lore:
-        - "&7Changez la langue d'affichage"
-        - "&7de l'interface et des messages."
-        - "&r"
-        - "&8▸ &7Langue actuelle: %setting_language_display%"
-        - "&8▸ &7Langues disponibles:"
-        - "&8  ▸ &c🇫🇷 Français (complet)"
-        - "&8  ▸ &f🇬🇧 English (complet)"
-        - "&8  ▸ &e🇪🇸 Español (partiel)"
-        - "&r"
-        - "&e⚡ Effet immédiat :"
-        - "&7- Tous les menus traduits"
-        - "&7- Messages du serveur traduits"
-        - "&r"
-        - "&a▶ Cliquez pour changer !"
-      actions:
-        - "[MENU] language_menu"
         - "[SOUND] BLOCK_NOTE_BLOCK_PLING"
 
     back:


### PR DESCRIPTION
## Summary
- add a FriendRequestValidator to enforce player-defined restrictions before sending friend requests and wire it into FriendManager with clearer error feedback
- show an additional confirmation message after toggling the friend request setting in the settings menu
- fill the missing glass decoration in the settings menu and remove the redundant language entry

## Testing
- mvn -q -DskipTests package *(fails: repository download blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68d19a16dbe08329ae312e6796be5b6b