### PR TITLE
Implement social action handlers and enable social menus

### DIFF
--- a/src/main/java/com/lobby/core/DatabaseManager.java
+++ b/src/main/java/com/lobby/core/DatabaseManager.java
@@ -879,6 +879,7 @@ public class DatabaseManager {
     private void createSocialTablesWithoutFK() throws SQLException {
         createFriendSettingsTable();
         createFriendsTable();
+        createFriendRequestsTable();
         createGroupSettingsTable();
         createGroupsTable();
         createGroupMembersTable();
@@ -937,6 +938,39 @@ public class DatabaseManager {
         }
         addColumnIfNotExists("friends", "blocked_at", "TIMESTAMP NULL");
         addColumnIfNotExists("friends", "is_favorite", "BOOLEAN DEFAULT FALSE NOT NULL");
+    }
+
+    private void createFriendRequestsTable() throws SQLException {
+        if (databaseType == DatabaseType.MYSQL) {
+            final String sql = """
+                    CREATE TABLE IF NOT EXISTS friend_requests (
+                        id INT AUTO_INCREMENT PRIMARY KEY,
+                        sender_uuid VARCHAR(36) NOT NULL,
+                        target_uuid VARCHAR(36) NOT NULL,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                        UNIQUE KEY unique_request (sender_uuid, target_uuid),
+                        INDEX idx_friend_requests_sender_uuid (sender_uuid),
+                        INDEX idx_friend_requests_target_uuid (target_uuid)
+                    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+                    """;
+            executeSQL(sql);
+            return;
+        }
+
+        final String sql = """
+                CREATE TABLE IF NOT EXISTS friend_requests (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    sender_uuid VARCHAR(36) NOT NULL,
+                    target_uuid VARCHAR(36) NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE (sender_uuid, target_uuid)
+                )
+                """;
+        executeSQL(sql);
+        if (createIndexes) {
+            executeSQL("CREATE INDEX IF NOT EXISTS idx_friend_requests_sender_uuid ON friend_requests(sender_uuid)");
+            executeSQL("CREATE INDEX IF NOT EXISTS idx_friend_requests_target_uuid ON friend_requests(target_uuid)");
+        }
     }
 
     private void createGroupSettingsTable() throws SQLException {

--- a/src/main/java/com/lobby/npcs/ActionProcessor.java
+++ b/src/main/java/com/lobby/npcs/ActionProcessor.java
@@ -1,6 +1,7 @@
 package com.lobby.npcs;
 
 import com.lobby.LobbyPlugin;
+import com.lobby.core.DatabaseManager;
 import com.lobby.menus.MenuManager;
 import com.lobby.menus.confirmation.ConfirmationManager;
 import com.lobby.menus.confirmation.ConfirmationRequest;
@@ -11,20 +12,26 @@ import com.lobby.settings.VisibilitySetting;
 import com.lobby.social.ChatInputManager;
 import com.lobby.social.clans.Clan;
 import com.lobby.social.clans.ClanManager;
+import com.lobby.social.friends.FriendManager;
+import com.lobby.social.groups.GroupManager;
 import com.lobby.social.menus.ClanMenus;
 import com.lobby.social.menus.FriendsMenus;
-import com.lobby.social.friends.FriendManager;
 import com.lobby.utils.LogUtils;
 import com.lobby.utils.MessageUtils;
 import com.lobby.utils.PlaceholderUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Sound;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -32,6 +39,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+import java.util.logging.Level;
 
 public class ActionProcessor {
 
@@ -72,8 +80,16 @@ public class ActionProcessor {
             FriendsMenus.openFriendRequestsMenu(player);
             return;
         }
-        if (trimmed.equalsIgnoreCase("[FRIEND_ADD]")) {
-            ChatInputManager.startFriendAddFlow(player);
+        if (startsWithIgnoreCase(trimmed, "[FRIEND_ADD]")) {
+            handleFriendAdd(player, extractArgument(processed, "[FRIEND_ADD]"));
+            return;
+        }
+        if (startsWithIgnoreCase(trimmed, "[FRIEND_ACCEPT]")) {
+            handleFriendAccept(player, extractArgument(processed, "[FRIEND_ACCEPT]"));
+            return;
+        }
+        if (startsWithIgnoreCase(trimmed, "[FRIEND_REMOVE]")) {
+            handleFriendRemove(player, extractArgument(processed, "[FRIEND_REMOVE]"));
             return;
         }
         if (trimmed.equalsIgnoreCase("[TOGGLE_FRIEND_NOTIFICATIONS]")) {
@@ -120,6 +136,14 @@ public class ActionProcessor {
         }
         if (trimmed.equalsIgnoreCase("[GROUP_CREATE]")) {
             ChatInputManager.startGroupCreateFlow(player);
+            return;
+        }
+        if (startsWithIgnoreCase(trimmed, "[GROUP_INVITE]")) {
+            handleGroupInvite(player, extractArgument(processed, "[GROUP_INVITE]"));
+            return;
+        }
+        if (startsWithIgnoreCase(trimmed, "[GROUP_KICK]")) {
+            handleGroupKick(player, extractArgument(processed, "[GROUP_KICK]"));
             return;
         }
         if (trimmed.equalsIgnoreCase("[TOGGLE_GROUP_AUTO_ACCEPT]")) {
@@ -169,7 +193,15 @@ public class ActionProcessor {
             return;
         }
         if (trimmed.equalsIgnoreCase("[CLAN_INVITE]")) {
-            ChatInputManager.startClanInviteFlow(player);
+            handleClanInvite(player, extractArgument(processed, "[CLAN_INVITE]"));
+            return;
+        }
+        if (startsWithIgnoreCase(trimmed, "[CLAN_PROMOTE]")) {
+            handleClanPromote(player, extractArgument(processed, "[CLAN_PROMOTE]"));
+            return;
+        }
+        if (startsWithIgnoreCase(trimmed, "[CLAN_KICK]")) {
+            handleClanKick(player, extractArgument(processed, "[CLAN_KICK]"));
             return;
         }
         if (trimmed.equalsIgnoreCase("[CLAN_DELETE_CONFIRM]")) {
@@ -679,6 +711,174 @@ public class ActionProcessor {
                 }
             }
         }
+    }
+
+    private void handleFriendAdd(final Player player, final String targetName) {
+        final FriendManager friendManager = plugin.getFriendManager();
+        if (friendManager == null) {
+            player.sendMessage("§cLe système d'amis est indisponible pour le moment.");
+            return;
+        }
+        if (targetName == null || targetName.isBlank()) {
+            ChatInputManager.startFriendAddFlow(player);
+            return;
+        }
+        friendManager.sendFriendRequest(player, targetName);
+    }
+
+    private void handleFriendAccept(final Player player, final String targetName) {
+        final FriendManager friendManager = plugin.getFriendManager();
+        if (friendManager == null) {
+            player.sendMessage("§cLe système d'amis est indisponible pour le moment.");
+            return;
+        }
+        if (targetName == null || targetName.isBlank()) {
+            player.sendMessage("§cAucun joueur spécifié.");
+            return;
+        }
+        friendManager.acceptFriendRequest(player, targetName);
+    }
+
+    private void handleFriendRemove(final Player player, final String targetName) {
+        final FriendManager friendManager = plugin.getFriendManager();
+        if (friendManager == null) {
+            player.sendMessage("§cLe système d'amis est indisponible pour le moment.");
+            return;
+        }
+        if (targetName == null || targetName.isBlank()) {
+            player.sendMessage("§cAucun joueur spécifié.");
+            return;
+        }
+        friendManager.removeFriend(player, targetName);
+    }
+
+    private void handleGroupInvite(final Player player, final String targetName) {
+        final GroupManager groupManager = plugin.getGroupManager();
+        if (groupManager == null) {
+            player.sendMessage("§cLe système de groupes est indisponible pour le moment.");
+            return;
+        }
+        if (targetName == null || targetName.isBlank()) {
+            player.sendMessage("§cAucun joueur spécifié.");
+            return;
+        }
+        groupManager.inviteToGroup(player, targetName);
+    }
+
+    private void handleGroupKick(final Player player, final String targetName) {
+        final GroupManager groupManager = plugin.getGroupManager();
+        if (groupManager == null) {
+            player.sendMessage("§cLe système de groupes est indisponible pour le moment.");
+            return;
+        }
+        if (targetName == null || targetName.isBlank()) {
+            player.sendMessage("§cAucun joueur spécifié.");
+            return;
+        }
+        groupManager.kickMember(player, targetName);
+    }
+
+    private void handleClanInvite(final Player player, final String targetName) {
+        final ClanManager clanManager = plugin.getClanManager();
+        if (clanManager == null) {
+            player.sendMessage("§cLe système de clans est indisponible pour le moment.");
+            return;
+        }
+        if (targetName == null || targetName.isBlank()) {
+            ChatInputManager.startClanInviteFlow(player);
+            return;
+        }
+        clanManager.inviteToClan(player, targetName, "");
+    }
+
+    private void handleClanPromote(final Player player, final String targetName) {
+        final ClanManager clanManager = plugin.getClanManager();
+        if (clanManager == null) {
+            player.sendMessage("§cLe système de clans est indisponible pour le moment.");
+            return;
+        }
+        if (targetName == null || targetName.isBlank()) {
+            player.sendMessage("§cAucun membre sélectionné.");
+            return;
+        }
+        final UUID targetUuid = resolvePlayerUuidByName(targetName);
+        if (targetUuid == null) {
+            player.sendMessage("§cJoueur introuvable.");
+            return;
+        }
+        final boolean success = clanManager.promoteMember(player.getUniqueId(), targetUuid);
+        final String resolved = resolvePlayerName(targetUuid);
+        if (success) {
+            player.sendMessage("§a" + (resolved != null ? resolved : targetName) + " a été promu dans le clan.");
+        } else {
+            player.sendMessage("§cImpossible de promouvoir " + (resolved != null ? resolved : targetName) + ".");
+        }
+    }
+
+    private void handleClanKick(final Player player, final String targetName) {
+        final ClanManager clanManager = plugin.getClanManager();
+        if (clanManager == null) {
+            player.sendMessage("§cLe système de clans est indisponible pour le moment.");
+            return;
+        }
+        if (targetName == null || targetName.isBlank()) {
+            player.sendMessage("§cAucun membre sélectionné.");
+            return;
+        }
+        final UUID targetUuid = resolvePlayerUuidByName(targetName);
+        if (targetUuid == null) {
+            player.sendMessage("§cJoueur introuvable.");
+            return;
+        }
+        if (!clanManager.kickMember(player.getUniqueId(), targetUuid)) {
+            final String resolved = resolvePlayerName(targetUuid);
+            player.sendMessage("§cImpossible d'expulser " + (resolved != null ? resolved : targetName) + ".");
+        }
+    }
+
+    private String extractArgument(final String processed, final String token) {
+        if (processed == null || token == null) {
+            return "";
+        }
+        if (processed.length() <= token.length()) {
+            return "";
+        }
+        final String argument = processed.substring(token.length()).trim();
+        if (argument.startsWith("\"") && argument.endsWith("\"") && argument.length() >= 2) {
+            return argument.substring(1, argument.length() - 1);
+        }
+        return argument;
+    }
+
+    private UUID resolvePlayerUuidByName(final String targetName) {
+        if (targetName == null || targetName.isBlank()) {
+            return null;
+        }
+        final Player online = Bukkit.getPlayerExact(targetName);
+        if (online != null) {
+            return online.getUniqueId();
+        }
+        final DatabaseManager databaseManager = plugin.getDatabaseManager();
+        if (databaseManager != null) {
+            final String query = "SELECT uuid FROM players WHERE LOWER(username) = ?";
+            try (Connection connection = databaseManager.getConnection();
+                 PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setString(1, targetName.toLowerCase(Locale.ROOT));
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    if (resultSet.next()) {
+                        return UUID.fromString(resultSet.getString("uuid"));
+                    }
+                }
+            } catch (final SQLException exception) {
+                plugin.getLogger().log(Level.SEVERE,
+                        "Failed to resolve player '" + targetName + "'", exception);
+            }
+        }
+        final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(targetName);
+        if (offlinePlayer != null && offlinePlayer.hasPlayedBefore()) {
+            return offlinePlayer.getUniqueId();
+        }
+        return null;
     }
 
     private void handleMusicToggle(final Player player, final boolean enabled) {

--- a/src/main/java/com/lobby/social/groups/GroupManager.java
+++ b/src/main/java/com/lobby/social/groups/GroupManager.java
@@ -224,6 +224,59 @@ public class GroupManager {
         player.sendMessage("§cInvitation refusée.");
     }
 
+    public void kickMember(final Player executor, final String targetName) {
+        if (executor == null) {
+            return;
+        }
+        final Group group = getPlayerGroup(executor.getUniqueId());
+        if (group == null) {
+            executor.sendMessage("§cVous n'êtes dans aucun groupe.");
+            return;
+        }
+        if (!group.isLeader(executor.getUniqueId()) && !group.isModerator(executor.getUniqueId())) {
+            executor.sendMessage("§cVous n'avez pas la permission d'expulser des membres.");
+            return;
+        }
+        if (targetName == null || targetName.isBlank()) {
+            executor.sendMessage("§cAucun joueur spécifié.");
+            return;
+        }
+
+        final Player onlineTarget = Bukkit.getPlayerExact(targetName);
+        final UUID targetUuid = onlineTarget != null ? onlineTarget.getUniqueId() : getUuidByName(targetName);
+        if (targetUuid == null) {
+            executor.sendMessage("§cJoueur introuvable.");
+            return;
+        }
+        if (!group.getMembers().contains(targetUuid)) {
+            executor.sendMessage("§c" + targetName + " ne fait pas partie de votre groupe.");
+            return;
+        }
+        if (group.isLeader(targetUuid)) {
+            executor.sendMessage("§cVous ne pouvez pas expulser le leader du groupe.");
+            return;
+        }
+        if (!group.isLeader(executor.getUniqueId()) && group.isModerator(targetUuid)) {
+            executor.sendMessage("§cVous ne pouvez pas expulser un autre modérateur.");
+            return;
+        }
+
+        removeMember(group.getId(), targetUuid);
+        group.removeMember(targetUuid);
+        playerGroups.remove(targetUuid);
+
+        final String resolvedName = onlineTarget != null ? onlineTarget.getName() : getNameByUuid(targetUuid);
+        executor.sendMessage("§cVous avez expulsé §6" + (resolvedName != null ? resolvedName : targetName)
+                + " §cdu groupe.");
+        broadcastGroupMessage(group, "§c" + executor.getName() + " a expulsé §6"
+                + (resolvedName != null ? resolvedName : targetName) + " §cdu groupe.");
+
+        if (onlineTarget != null) {
+            onlineTarget.sendMessage("§cVous avez été expulsé du groupe.");
+            onlineTarget.closeInventory();
+        }
+    }
+
     public void leaveGroup(final Player player) {
         final Group group = getPlayerGroup(player.getUniqueId());
         if (group == null) {
@@ -646,6 +699,18 @@ public class GroupManager {
                 player.sendMessage(message);
             }
         }
+    }
+
+    private String getNameByUuid(final UUID uuid) {
+        if (uuid == null) {
+            return null;
+        }
+        final Player player = Bukkit.getPlayer(uuid);
+        if (player != null) {
+            return player.getName();
+        }
+        final org.bukkit.OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(uuid);
+        return offlinePlayer.getName();
     }
 
     private UUID getUuidByName(final String name) {

--- a/src/main/resources/config/menus/clan_kick_confirm.yml
+++ b/src/main/resources/config/menus/clan_kick_confirm.yml
@@ -11,7 +11,7 @@ menu:
         - "&7Expulser &f%clan_target_name% &7du clan."
         - "&cCette action est immédiate !"
       actions:
-        - "[COMMAND] clan kick %clan_target_name%"
+        - "[CLAN_KICK] %clan_target_name%"
         - "[CLOSE_MENU]"
 
     cancel:

--- a/src/main/resources/config/menus/clan_member_management.yml
+++ b/src/main/resources/config/menus/clan_member_management.yml
@@ -16,7 +16,7 @@ menu:
         - "&r"
         - "&a▶ Cliquez pour promouvoir !"
       actions:
-        - "[COMMAND] clan promote %clan_target_name%"
+        - "[CLAN_PROMOTE] %clan_target_name%"
         - "[CLOSE_MENU]"
 
     member_demote:

--- a/src/main/resources/config/menus/profil_menu.yml
+++ b/src/main/resources/config/menus/profil_menu.yml
@@ -102,7 +102,7 @@ menu:
         - "&r"
         - "&c⚠ Fonctionnalité en développement"
       actions:
-        - "[MESSAGE] &cCette fonctionnalité n'est pas encore disponible !"
+        - "[MENU] friends_menu"
 
     groupe:
       slot: 4
@@ -120,7 +120,7 @@ menu:
         - "&r"
         - "&c⚠ Fonctionnalité en développement"
       actions:
-        - "[MESSAGE] &cCette fonctionnalité n'est pas encore disponible !"
+        - "[MENU] groups_menu"
 
     clan:
       slot: 5
@@ -140,7 +140,7 @@ menu:
         - "&r"
         - "&c⚠ Fonctionnalité en développement"
       actions:
-        - "[MESSAGE] &cCette fonctionnalité n'est pas encore disponible !"
+        - "[MENU] clan_menu"
 
     stats:
       slot: 20


### PR DESCRIPTION
## Summary
- add friend_requests table creation during database setup
- extend the action processor with direct friend, group, and clan interaction handlers
- enable profile social menu entries and update clan management menus to use the new actions

## Testing
- mvn -q -DskipTests package *(fails: Maven could not reach central repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a2ea37148329a70dc1c6a93a834c