### PR TITLE
Fix menu toggles and proxy presence handling

### DIFF
--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -76,7 +76,7 @@ public class ConfiguredMenu implements Menu {
             }
         }
 
-
+        applyDesignTemplate(player);
 
         final ConfigurationSection itemsSection = menuSection.getConfigurationSection("items");
         if (itemsSection != null) {

--- a/src/main/java/com/lobby/social/friends/FriendManager.java
+++ b/src/main/java/com/lobby/social/friends/FriendManager.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -290,6 +291,11 @@ public class FriendManager {
 
     public List<FriendInfo> getFriendsList(final UUID playerUUID) {
         final List<FriendInfo> friends = new ArrayList<>();
+        final VelocityManager velocityManager = plugin.getVelocityManager();
+        final boolean velocityEnabled = velocityManager != null && velocityManager.isEnabled();
+        if (velocityEnabled) {
+            velocityManager.requestServerInfo();
+        }
         final String query = "SELECT friend_uuid, accepted_at, is_favorite FROM friends WHERE player_uuid = ? AND status = 'ACCEPTED'";
         try (Connection connection = databaseManager.getConnection();
              PreparedStatement statement = connection.prepareStatement(query)) {
@@ -299,13 +305,15 @@ public class FriendManager {
                     final UUID friendUUID = UUID.fromString(resultSet.getString("friend_uuid"));
                     final String name = getNameByUuid(friendUUID);
                     final Player friendPlayer = Bukkit.getPlayer(friendUUID);
-                    final boolean online = friendPlayer != null && friendPlayer.isOnline();
+                    boolean online = friendPlayer != null && friendPlayer.isOnline();
                     String serverName = null;
                     if (online) {
-                        final ServerManager serverManager = plugin.getServerManager();
-                        if (serverManager != null) {
-                            final ServerInfo info = serverManager.getServer(friendPlayer.getWorld().getName());
-                            serverName = info != null ? info.getDisplayName() : friendPlayer.getWorld().getName();
+                        serverName = resolveLocalServerName(friendPlayer);
+                    } else if (velocityEnabled) {
+                        final Optional<String> proxyServer = velocityManager.findPlayerServerDisplayName(friendUUID, name);
+                        if (proxyServer.isPresent()) {
+                            online = true;
+                            serverName = proxyServer.get();
                         }
                     }
                     final Timestamp acceptedTimestamp = resultSet.getTimestamp("accepted_at");
@@ -721,10 +729,22 @@ public class FriendManager {
 
     public List<UUID> getOnlineFriends(final UUID uuid) {
         final List<UUID> online = new ArrayList<>();
+        final VelocityManager velocityManager = plugin.getVelocityManager();
+        final boolean velocityEnabled = velocityManager != null && velocityManager.isEnabled();
+        if (velocityEnabled) {
+            velocityManager.requestServerInfo();
+        }
         for (final UUID friendUUID : friendsCache.computeIfAbsent(uuid, this::loadFriendsFromDatabase)) {
             final Player player = Bukkit.getPlayer(friendUUID);
             if (player != null && player.isOnline()) {
                 online.add(friendUUID);
+                continue;
+            }
+            if (velocityEnabled) {
+                final String friendName = getNameByUuid(friendUUID);
+                if (velocityManager.isPlayerOnlineProxy(friendUUID, friendName)) {
+                    online.add(friendUUID);
+                }
             }
         }
         return online;
@@ -734,8 +754,26 @@ public class FriendManager {
         if (uuid == null) {
             return;
         }
+        final VelocityManager velocityManager = plugin.getVelocityManager();
+        if (velocityManager != null && velocityManager.isEnabled()) {
+            velocityManager.requestServerInfo();
+        }
         final Set<UUID> refreshed = loadFriendsFromDatabase(uuid);
         friendsCache.put(uuid, refreshed);
+    }
+
+    private String resolveLocalServerName(final Player player) {
+        if (player == null) {
+            return null;
+        }
+        final ServerManager serverManager = plugin.getServerManager();
+        if (serverManager != null) {
+            final ServerInfo info = serverManager.getServer(player.getWorld().getName());
+            if (info != null) {
+                return info.getDisplayName();
+            }
+        }
+        return player.getWorld().getName();
     }
 
     public List<UUID> getFavoriteFriends(final UUID uuid) {

--- a/src/main/java/com/lobby/social/menus/MenuClickHandler.java
+++ b/src/main/java/com/lobby/social/menus/MenuClickHandler.java
@@ -5,7 +5,6 @@ import com.lobby.menus.MenuManager;
 import com.lobby.social.ChatInputManager;
 import com.lobby.social.friends.FriendManager;
 import com.lobby.social.friends.FriendRequest;
-import com.lobby.social.groups.GroupManager;
 import com.lobby.social.clans.ClanManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -24,8 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public final class MenuClickHandler implements Listener {
 
-    private static final String FRIEND_SETTINGS_TITLE = "§8» §dParamètres d'Amis";
-    private static final String GROUP_SETTINGS_TITLE = "§8» §eParamètres de Groupe";
     private static final String CLAN_MEMBER_MANAGEMENT_PREFIX = "§8» §eGestion";
 
     private static final long CLICK_DELAY_TICKS = 10L;
@@ -35,14 +32,12 @@ public final class MenuClickHandler implements Listener {
     private final LobbyPlugin plugin;
     private final MenuManager menuManager;
     private final FriendManager friendManager;
-    private final GroupManager groupManager;
     private final ClanManager clanManager;
 
     public MenuClickHandler(final LobbyPlugin plugin) {
         this.plugin = plugin;
         this.menuManager = plugin.getMenuManager();
         this.friendManager = plugin.getFriendManager();
-        this.groupManager = plugin.getGroupManager();
         this.clanManager = plugin.getClanManager();
     }
 
@@ -66,14 +61,6 @@ public final class MenuClickHandler implements Listener {
         }
         if (ClanMenus.CLAN_MEMBERS_TITLE.equals(title)) {
             handleClanMembersClick(event, player);
-            return;
-        }
-        if (FRIEND_SETTINGS_TITLE.equals(title)) {
-            handleFriendSettings(event, player);
-            return;
-        }
-        if (GROUP_SETTINGS_TITLE.equals(title)) {
-            handleGroupSettings(event, player);
             return;
         }
         if (!Objects.equals(event.getView().getTopInventory(), event.getClickedInventory())) {
@@ -135,52 +122,6 @@ public final class MenuClickHandler implements Listener {
                 friendManager.acceptFriendRequest(player, request.getSender());
             }
             FriendsMenus.openFriendRequestsMenu(player);
-        }
-    }
-
-    private void handleFriendSettings(final InventoryClickEvent event, final Player player) {
-        final int slot = event.getSlot();
-        switch (slot) {
-            case 19 -> {
-                cycleFriendRequests(player);
-                scheduleMenuReopen(player, "friend_settings_menu", 1000L);
-            }
-            case 21 -> {
-                toggleFriendNotifications(player);
-                scheduleMenuReopen(player, "friend_settings_menu", 1000L);
-            }
-            case 23 -> {
-                cycleFriendVisibility(player);
-                scheduleMenuReopen(player, "friend_settings_menu", 1000L);
-            }
-            case 25 -> {
-                toggleAutoFavorites(player);
-                scheduleMenuReopen(player, "friend_settings_menu", 1000L);
-            }
-            case 31 -> {
-                togglePrivateMessages(player);
-                scheduleMenuReopen(player, "friend_settings_menu", 1000L);
-            }
-            case 49 -> reopenMenu(player, "friends_menu");
-            default -> {
-            }
-        }
-    }
-
-    private void handleGroupSettings(final InventoryClickEvent event, final Player player) {
-        switch (event.getSlot()) {
-            case 19 -> {
-                toggleGroupAutoAccept(player);
-                scheduleMenuReopen(player, "group_settings_menu", 1000L);
-            }
-            case 21 -> {
-                cycleGroupVisibility(player);
-                scheduleMenuReopen(player, "group_settings_menu", 1000L);
-            }
-            case 23 -> reopenMenu(player, "group_manage_menu");
-            case 49 -> reopenMenu(player, "groups_menu");
-            default -> {
-            }
         }
     }
 
@@ -288,78 +229,6 @@ public final class MenuClickHandler implements Listener {
         if (menuManager != null) {
             menuManager.openMenu(player, menuId);
         }
-    }
-
-    private void cycleFriendRequests(final Player player) {
-        final String mode = friendManager.cycleRequestAcceptance(player.getUniqueId());
-        player.sendMessage("§aDemandes d'amis: §f" + mode);
-    }
-
-    private void toggleFriendNotifications(final Player player) {
-        final boolean enabled = friendManager.toggleNotifications(player.getUniqueId());
-        player.sendMessage(enabled
-                ? "§aNotifications d'amis activées"
-                : "§cNotifications d'amis désactivées");
-    }
-
-    private void cycleFriendVisibility(final Player player) {
-        final String visibility = friendManager.cycleFriendVisibility(player.getUniqueId());
-        player.sendMessage("§aVisibilité: §f" + visibility);
-    }
-
-    private void toggleAutoFavorites(final Player player) {
-        final boolean enabled = friendManager.toggleAutoAcceptFavorites(player.getUniqueId());
-        player.sendMessage(enabled
-                ? "§aAcceptation auto des favoris activée"
-                : "§cAcceptation auto des favoris désactivée");
-    }
-
-    private void togglePrivateMessages(final Player player) {
-        final boolean enabled = friendManager.togglePrivateMessages(player.getUniqueId());
-        player.sendMessage(enabled
-                ? "§aMessages privés autorisés"
-                : "§cMessages privés désactivés");
-    }
-
-    private void toggleGroupAutoAccept(final Player player) {
-        if (groupManager == null) {
-            return;
-        }
-        final boolean enabled = groupManager.toggleAutoAccept(player.getUniqueId());
-        player.sendMessage(enabled
-                ? "§aInvitations automatiques activées"
-                : "§cInvitations automatiques désactivées");
-    }
-
-    private void cycleGroupVisibility(final Player player) {
-        if (groupManager == null) {
-            return;
-        }
-        final String visibility = groupManager.cycleGroupVisibility(player.getUniqueId());
-        player.sendMessage("§aVisibilité du groupe: §f" + visibility);
-    }
-
-    private void reopenMenu(final Player player, final String menuId) {
-        if (menuManager == null || player == null) {
-            return;
-        }
-        Bukkit.getScheduler().runTask(plugin, (Runnable) () -> {
-            if (player.isOnline()) {
-                menuManager.openMenu(player, menuId);
-            }
-        });
-    }
-
-    private void scheduleMenuReopen(final Player player, final String menuId, final long delayMs) {
-        if (menuManager == null || player == null) {
-            return;
-        }
-        final long ticks = Math.max(0L, delayMs / 50L);
-        Bukkit.getScheduler().runTaskLater(plugin, (Runnable) () -> {
-            if (player.isOnline()) {
-                menuManager.openMenu(player, menuId);
-            }
-        }, ticks);
     }
 
     private void openClanMemberManagement(final Player player, final UUID target) {

--- a/src/main/java/com/lobby/velocity/VelocityManager.java
+++ b/src/main/java/com/lobby/velocity/VelocityManager.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -30,7 +31,10 @@ public class VelocityManager {
 
     private final LobbyPlugin plugin;
     private final Map<String, VelocityServerInfo> servers = new ConcurrentHashMap<>();
+    private final Map<String, VelocityServerInfo> serversByProxyName = new ConcurrentHashMap<>();
     private final Map<String, Integer> serverPlayerCounts = new ConcurrentHashMap<>();
+    private final Map<String, Set<String>> serverPlayerLists = new ConcurrentHashMap<>();
+    private final Map<String, String> playerServerIndex = new ConcurrentHashMap<>();
     private final VelocityMessageListener velocityMessageListener;
     private final SyncMessageListener syncMessageListener;
     private final String messagingChannel;
@@ -75,6 +79,9 @@ public class VelocityManager {
 
     private void loadServerConfiguration(final ConfigurationSection section) {
         servers.clear();
+        serversByProxyName.clear();
+        serverPlayerLists.clear();
+        playerServerIndex.clear();
         if (section == null) {
             plugin.getLogger().warning("No servers defined in velocity configuration.");
             return;
@@ -86,6 +93,7 @@ public class VelocityManager {
             }
             final VelocityServerInfo info = new VelocityServerInfo(key, serverSection);
             servers.put(info.getId(), info);
+            serversByProxyName.put(normalize(info.getName()), info);
         }
         plugin.getLogger().info("Loaded " + servers.size() + " proxy servers from velocity configuration.");
     }
@@ -187,6 +195,11 @@ public class VelocityManager {
             out.writeUTF("PlayerCount");
             out.writeUTF(info.getName());
             anyPlayer.sendPluginMessage(plugin, LEGACY_CHANNEL, out.toByteArray());
+
+            final ByteArrayDataOutput listRequest = ByteStreams.newDataOutput();
+            listRequest.writeUTF("PlayerList");
+            listRequest.writeUTF(info.getName());
+            anyPlayer.sendPluginMessage(plugin, LEGACY_CHANNEL, listRequest.toByteArray());
         }
     }
 
@@ -211,6 +224,35 @@ public class VelocityManager {
         }
     }
 
+    public void updateServerPlayerList(final String serverName, final String players) {
+        if (serverName == null) {
+            return;
+        }
+        final String normalizedServer = normalize(serverName);
+        final Set<String> parsedPlayers = ConcurrentHashMap.newKeySet();
+        if (players != null && !players.isBlank()) {
+            final String[] split = players.split(",\\s*");
+            for (final String raw : split) {
+                final String trimmed = raw == null ? "" : raw.trim();
+                if (!trimmed.isEmpty()) {
+                    parsedPlayers.add(trimmed.toLowerCase(Locale.ROOT));
+                }
+            }
+        }
+        final Set<String> previous = serverPlayerLists.get(normalizedServer);
+        if (previous != null) {
+            for (final String name : previous) {
+                if (!parsedPlayers.contains(name)) {
+                    playerServerIndex.remove(name, normalizedServer);
+                }
+            }
+        }
+        serverPlayerLists.put(normalizedServer, parsedPlayers);
+        for (final String playerName : parsedPlayers) {
+            playerServerIndex.put(playerName, normalizedServer);
+        }
+    }
+
     public int getServerPlayerCount(final String serverId) {
         return serverPlayerCounts.getOrDefault(normalize(serverId), 0);
     }
@@ -218,6 +260,36 @@ public class VelocityManager {
     public boolean isServerOnline(final String serverId) {
         final VelocityServerInfo info = servers.get(normalize(serverId));
         return info != null && info.isEnabled();
+    }
+
+    public Optional<String> findPlayerServerDisplayName(final UUID playerUuid, final String playerName) {
+        if (!enabled) {
+            return Optional.empty();
+        }
+        final String key = normalizePlayerKey(playerUuid, playerName);
+        if (key == null) {
+            return Optional.empty();
+        }
+        final String serverKey = playerServerIndex.get(key);
+        if (serverKey == null) {
+            return Optional.empty();
+        }
+        final VelocityServerInfo info = resolveServerInfo(serverKey);
+        if (info != null) {
+            return Optional.of(info.getDisplayName());
+        }
+        return Optional.of(serverKey);
+    }
+
+    public boolean isPlayerOnlineProxy(final UUID playerUuid, final String playerName) {
+        if (!enabled) {
+            return false;
+        }
+        final String key = normalizePlayerKey(playerUuid, playerName);
+        if (key == null) {
+            return false;
+        }
+        return playerServerIndex.containsKey(key);
     }
 
     public void broadcastEconomyUpdate(final Player player, final long coins, final long tokens) {
@@ -327,5 +399,37 @@ public class VelocityManager {
 
     private String normalize(final String value) {
         return value == null ? "" : value.toLowerCase(Locale.ROOT);
+    }
+
+    private String normalizePlayerKey(final UUID playerUuid, final String playerName) {
+        if (playerName != null && !playerName.isBlank()) {
+            return playerName.trim().toLowerCase(Locale.ROOT);
+        }
+        if (playerUuid != null) {
+            final Player online = Bukkit.getPlayer(playerUuid);
+            if (online != null) {
+                return online.getName().toLowerCase(Locale.ROOT);
+            }
+        }
+        return null;
+    }
+
+    private VelocityServerInfo resolveServerInfo(final String key) {
+        if (key == null || key.isBlank()) {
+            return null;
+        }
+        final String normalized = normalize(key);
+        VelocityServerInfo info = servers.get(normalized);
+        if (info != null) {
+            return info;
+        }
+        info = serversByProxyName.get(normalized);
+        if (info != null) {
+            return info;
+        }
+        return servers.values().stream()
+                .filter(server -> server.getName().equalsIgnoreCase(key))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/com/lobby/velocity/VelocityMessageListener.java
+++ b/src/main/java/com/lobby/velocity/VelocityMessageListener.java
@@ -28,6 +28,12 @@ public class VelocityMessageListener implements PluginMessageListener {
             velocityManager.updateServerPlayerCount(serverName, count);
             return;
         }
+        if ("PlayerList".equalsIgnoreCase(subChannel)) {
+            final String serverName = input.readUTF();
+            final String players = input.readUTF();
+            velocityManager.updateServerPlayerList(serverName, players);
+            return;
+        }
         if ("GetServers".equalsIgnoreCase(subChannel)) {
             final String[] servers = input.readUTF().split(", ?");
             velocityManager.updateAvailableServers(Arrays.asList(servers));

--- a/src/main/resources/config/menus.yml
+++ b/src/main/resources/config/menus.yml
@@ -1639,7 +1639,7 @@ menus:
         actions:
           - "[TOGGLE_FRIEND_MESSAGES]"
       back:
-        slot: 45
+        slot: 48
         material: "PLAYER_HEAD"
         head: "hdb:9334"
         name: "&c&lRetour"
@@ -1656,15 +1656,6 @@ menus:
           - "&7Accédez à la liste complète de vos amis"
         actions:
           - "[MENU] friends_all_menu"
-      close:
-        slot: 53
-        material: PLAYER_HEAD
-        head: "hdb:60776"
-        name: "&cFermer"
-        lore:
-          - "&7Fermer le menu"
-        actions:
-          - "[CLOSE]"
 
   friends_favorites_menu:
     title: "&8» &6Mes Favoris"
@@ -1713,7 +1704,7 @@ menus:
         actions:
           - "[TOGGLE_FRIEND_NOTIFICATIONS]"
       back:
-        slot: 45
+        slot: 48
         material: "PLAYER_HEAD"
         head: "hdb:9334"
         name: "&a&lRetour"
@@ -1730,14 +1721,6 @@ menus:
           - "&7Configurer les préférences d'amis"
         actions:
           - "[MENU] friend_settings_menu"
-      close:
-        slot: 53
-        material: BARRIER
-        name: "&cFermer"
-        lore:
-          - "&7Fermer le menu"
-        actions:
-          - "[CLOSE]"
 
   group_manage_menu:
     title: "&8» &eMon Groupe"

--- a/src/main/resources/config/menus/clan_ban_confirm.yml
+++ b/src/main/resources/config/menus/clan_ban_confirm.yml
@@ -2,6 +2,7 @@ menu:
   id: "clan_ban_confirm"
   title: "&8» &8Bannir un Membre"
   size: 27
+  design_template: "social"
   items:
     confirm:
       slot: 11

--- a/src/main/resources/config/menus/clan_kick_confirm.yml
+++ b/src/main/resources/config/menus/clan_kick_confirm.yml
@@ -2,6 +2,7 @@ menu:
   id: "clan_kick_confirm"
   title: "&8» &4Confirmer l'Expulsion"
   size: 27
+  design_template: "social"
   items:
     confirm:
       slot: 11

--- a/src/main/resources/config/menus/clan_member_management.yml
+++ b/src/main/resources/config/menus/clan_member_management.yml
@@ -2,6 +2,7 @@ menu:
   id: "clan_member_management_menu"
   title: "&8» &cGestion des Membres"
   size: 54
+  design_template: "social"
   items:
     member_promote:
       slot: 20

--- a/src/main/resources/config/menus/clan_transfer_confirm.yml
+++ b/src/main/resources/config/menus/clan_transfer_confirm.yml
@@ -2,6 +2,7 @@ menu:
   id: "clan_transfer_confirm"
   title: "&8» &6Transférer le Leadership"
   size: 27
+  design_template: "social"
   items:
     confirm:
       slot: 11

--- a/src/main/resources/config/menus/friend_management.yml
+++ b/src/main/resources/config/menus/friend_management.yml
@@ -2,6 +2,7 @@ menu:
   id: "friend_management"
   title: "&8» &aGestion des Amis"
   size: 45
+  design_template: "social"
 
   items:
     friend_remove:


### PR DESCRIPTION
## Summary
- prevent duplicate handling of social setting toggles and rely on configured menu actions
- track proxy player locations via plugin messaging to expose accurate friend presence in menus
- apply consistent social menu glass styling and navigation layout updates across related configs

## Testing
- `mvn -q -DskipTests package` *(fails: repository unreachable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ab28b514832989502150d5abda6f