### PR TITLE
Prevent menu clicks from triggering default actions

### DIFF
--- a/src/main/java/com/lobby/shop/ShopManager.java
+++ b/src/main/java/com/lobby/shop/ShopManager.java
@@ -406,11 +406,11 @@ public class ShopManager implements Listener {
         if (context == null) {
             return;
         }
+        event.setCancelled(true);
         final Inventory topInventory = event.getView().getTopInventory();
         if (topInventory == null || !topInventory.equals(context.inventory())) {
             return;
         }
-        event.setCancelled(true);
         final ItemStack clicked = event.getCurrentItem();
         if (clicked == null || clicked.getType() == Material.AIR) {
             return;

--- a/src/main/java/com/lobby/social/menus/MenuClickHandler.java
+++ b/src/main/java/com/lobby/social/menus/MenuClickHandler.java
@@ -55,10 +55,11 @@ public final class MenuClickHandler implements Listener {
         Bukkit.getScheduler().runTaskLater(plugin, (Runnable) () -> clickCooldown.remove(playerId), CLICK_DELAY_TICKS);
 
         final String title = event.getView().getTitle();
-        final boolean menuTitle = title.contains("»");
-        if (menuTitle) {
-            event.setCancelled(true);
+        if (!title.contains("»")) {
+            return;
         }
+
+        event.setCancelled(true);
         if (ClanMenus.CLAN_MEMBERS_TITLE.equals(title)) {
             handleClanMembersClick(event, player);
             return;


### PR DESCRIPTION
## Summary
- cancel social menu clicks before handling slots to avoid default inventory behavior
- cancel shop menu clicks as soon as the custom interface is detected to prevent packet spam

## Testing
- `mvn -q -DskipTests package` *(fails: network unreachable while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b1385bac8329bcd3fd3e4dac78a3