### PR TITLE
Optimize profile menu loading and rendering

### DIFF
--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -54,14 +54,15 @@ public class ConfiguredMenu implements Menu {
         inventory = Bukkit.createInventory(null, size, title);
         actionsBySlot.clear();
 
+        final ItemStack[] contents = new ItemStack[size];
         final DesignTemplate designTemplate = resolveDesignTemplate();
 
         final ItemStack filler = createFillerItem(resolveFillMaterial(designTemplate));
         if (filler != null) {
             final List<Integer> fillSlots = resolveFillSlots(designTemplate);
             if (fillSlots == null || fillSlots.isEmpty()) {
-                for (int slot = 0; slot < inventory.getSize(); slot++) {
-                    inventory.setItem(slot, filler.clone());
+                for (int slot = 0; slot < contents.length; slot++) {
+                    contents[slot] = filler.clone();
                 }
             } else {
                 for (Integer slot : fillSlots) {
@@ -69,14 +70,14 @@ public class ConfiguredMenu implements Menu {
                         continue;
                     }
                     final int index = slot;
-                    if (index >= 0 && index < inventory.getSize()) {
-                        inventory.setItem(index, filler.clone());
+                    if (index >= 0 && index < contents.length) {
+                        contents[index] = filler.clone();
                     }
                 }
             }
         }
 
-        applyDesignTemplate(player);
+        applyDesignTemplate(player, contents);
 
         final ConfigurationSection itemsSection = menuSection.getConfigurationSection("items");
         if (itemsSection != null) {
@@ -85,16 +86,17 @@ public class ConfiguredMenu implements Menu {
                 if (itemSection == null) {
                     continue;
                 }
-                final Optional<Integer> slot = createItem(player, itemSection);
+                final Optional<Integer> slot = createItem(player, itemSection, contents);
                 slot.ifPresent(index -> storeActions(index, itemSection));
             }
         }
 
+        inventory.setContents(contents);
         player.openInventory(inventory);
     }
 
-    private void applyDesignTemplate(final Player player) {
-        if (inventory == null || menuDesignProvider == null) {
+    private void applyDesignTemplate(final Player player, final ItemStack[] contents) {
+        if (contents == null || menuDesignProvider == null) {
             return;
         }
         final String templateName = menuSection.getString("design_template");
@@ -112,8 +114,8 @@ public class ConfiguredMenu implements Menu {
                 continue;
             }
             final int index = slot;
-            if (index >= 0 && index < inventory.getSize()) {
-                inventory.setItem(index, decorative.clone());
+            if (index >= 0 && index < contents.length) {
+                contents[index] = decorative.clone();
             }
         }
         final ItemStack border = design.createBorderItem();
@@ -122,8 +124,8 @@ public class ConfiguredMenu implements Menu {
                 continue;
             }
             final int index = slot;
-            if (index >= 0 && index < inventory.getSize()) {
-                inventory.setItem(index, border.clone());
+            if (index >= 0 && index < contents.length) {
+                contents[index] = border.clone();
             }
         }
     }
@@ -157,7 +159,9 @@ public class ConfiguredMenu implements Menu {
         return inventory;
     }
 
-    private Optional<Integer> createItem(final Player player, final ConfigurationSection itemSection) {
+    private Optional<Integer> createItem(final Player player,
+                                         final ConfigurationSection itemSection,
+                                         final ItemStack[] contents) {
         String materialName = itemSection.getString("material");
         Material material = materialName != null ? Material.matchMaterial(materialName) : null;
         final boolean headDefined = itemSection.contains("head") || itemSection.contains("head_id");
@@ -223,7 +227,7 @@ public class ConfiguredMenu implements Menu {
         }
 
         final int slot = itemSection.getInt("slot", -1);
-        final int targetSlot = resolveSlot(slot, itemStack);
+        final int targetSlot = resolveSlot(slot, itemStack, contents);
         if (targetSlot < 0) {
             return Optional.empty();
         }
@@ -304,8 +308,10 @@ public class ConfiguredMenu implements Menu {
         return processed;
     }
 
-    private void applyBorders(final Player player, final DesignTemplate designTemplate) {
-        if (inventory == null) {
+    private void applyBorders(final Player player,
+                               final DesignTemplate designTemplate,
+                               final ItemStack[] contents) {
+        if (contents == null) {
             return;
         }
         final List<Map<?, ?>> borders = new ArrayList<>();
@@ -333,14 +339,16 @@ public class ConfiguredMenu implements Menu {
                     continue;
                 }
                 final int index = slot;
-                if (index >= 0 && index < inventory.getSize()) {
-                    inventory.setItem(index, borderItem.clone());
+                if (index >= 0 && index < contents.length) {
+                    contents[index] = borderItem.clone();
                 }
             }
         }
     }
 
-    private void applyTemplateItems(final Player player, final DesignTemplate designTemplate) {
+    private void applyTemplateItems(final Player player,
+                                     final DesignTemplate designTemplate,
+                                     final ItemStack[] contents) {
         if (designTemplate == null) {
             return;
         }
@@ -356,7 +364,7 @@ public class ConfiguredMenu implements Menu {
             if (itemSection == null) {
                 continue;
             }
-            final Optional<Integer> slot = createItem(player, itemSection);
+            final Optional<Integer> slot = createItem(player, itemSection, contents);
             slot.ifPresent(index -> storeActions(index, itemSection));
         }
     }
@@ -450,20 +458,25 @@ public class ConfiguredMenu implements Menu {
         return designTemplate != null ? designTemplate.getFillSlots() : List.of();
     }
 
-    private int resolveSlot(final int slot, final ItemStack itemStack) {
-        if (inventory == null) {
+    private int resolveSlot(final int slot, final ItemStack itemStack, final ItemStack[] contents) {
+        if (contents == null || itemStack == null) {
             return -1;
         }
-        if (slot >= 0 && slot < inventory.getSize()) {
-            inventory.setItem(slot, itemStack);
+        if (slot >= 0 && slot < contents.length) {
+            contents[slot] = itemStack;
             return slot;
         }
-        final int firstEmpty = inventory.firstEmpty();
-        if (firstEmpty >= 0) {
-            inventory.setItem(firstEmpty, itemStack);
-            return firstEmpty;
+        for (int index = 0; index < contents.length; index++) {
+            if (isEmpty(contents[index])) {
+                contents[index] = itemStack;
+                return index;
+            }
         }
         return -1;
+    }
+
+    private boolean isEmpty(final ItemStack itemStack) {
+        return itemStack == null || itemStack.getType() == Material.AIR;
     }
 
     private int normalizeSize(final int requested) {

--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -17,6 +17,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.Inventory;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -53,10 +54,31 @@ public class MenuManager implements Listener {
         }
 
         final Menu menu = new ConfiguredMenu(plugin, normalizedId, menuSection, menuDesignProvider);
-        openMenus.put(player.getUniqueId(), menu);
+        final UUID uuid = player.getUniqueId();
+        if (shouldPreloadAsync(menuSection)) {
+            openMenus.put(uuid, menu);
+            player.closeInventory();
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                preloadMenuData(uuid, menuSection);
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    final Player target = Bukkit.getPlayer(uuid);
+                    if (target == null || !target.isOnline()) {
+                        openMenus.remove(uuid);
+                        return;
+                    }
+                    menu.open(target);
+                    if (menu.getInventory() == null) {
+                        openMenus.remove(uuid);
+                    }
+                });
+            });
+            return true;
+        }
+
+        openMenus.put(uuid, menu);
         menu.open(player);
         if (menu.getInventory() == null) {
-            openMenus.remove(player.getUniqueId());
+            openMenus.remove(uuid);
             return false;
         }
         return true;
@@ -166,6 +188,125 @@ public class MenuManager implements Listener {
             }
             menuDefinitions.put(id.toLowerCase(java.util.Locale.ROOT), menuSection);
         }
+    }
+
+    private boolean shouldPreloadAsync(final ConfigurationSection menuSection) {
+        return menuSection != null && menuSection.getBoolean("async_preload", false);
+    }
+
+    private void preloadMenuData(final UUID uuid, final ConfigurationSection menuSection) {
+        if (uuid == null || menuSection == null) {
+            return;
+        }
+        final Set<String> sources = collectPlaceholderSources(menuSection);
+        if (sources.isEmpty()) {
+            return;
+        }
+        final Set<String> placeholders = extractPlaceholders(sources);
+        if (placeholders.isEmpty()) {
+            return;
+        }
+
+        preloadEconomy(uuid, placeholders);
+        preloadStats(uuid, placeholders);
+        preloadSettings(uuid, placeholders);
+    }
+
+    private void preloadEconomy(final UUID uuid, final Set<String> placeholders) {
+        if (placeholders.stream().noneMatch(placeholder -> placeholder.startsWith("%player_")
+                && (placeholder.contains("coins")
+                || placeholder.contains("tokens")
+                || placeholder.contains("playtime")
+                || placeholder.contains("first_join")
+                || placeholder.contains("last_join")))) {
+            return;
+        }
+        if (plugin.getEconomyManager() != null) {
+            plugin.getEconomyManager().getPlayerData(uuid);
+        }
+    }
+
+    private void preloadStats(final UUID uuid, final Set<String> placeholders) {
+        if (placeholders.stream().noneMatch(placeholder -> placeholder.startsWith("%stats_"))) {
+            return;
+        }
+        final var statsManager = plugin.getStatsManager();
+        if (statsManager == null) {
+            return;
+        }
+        boolean globalRequested = false;
+        final Set<String> gameTypes = new HashSet<>();
+        for (String placeholder : placeholders) {
+            if (!placeholder.startsWith("%stats_")) {
+                continue;
+            }
+            final String trimmed = placeholder.substring(1, placeholder.length() - 1);
+            final String[] parts = trimmed.split("_");
+            if (parts.length < 3) {
+                continue;
+            }
+            final String scope = parts[1];
+            if ("global".equalsIgnoreCase(scope)) {
+                globalRequested = true;
+            } else {
+                gameTypes.add(scope.toUpperCase(java.util.Locale.ROOT));
+            }
+        }
+        if (globalRequested) {
+            statsManager.getGlobalStats(uuid);
+        }
+        for (String gameType : gameTypes) {
+            statsManager.getPlayerStats(uuid, gameType);
+        }
+    }
+
+    private void preloadSettings(final UUID uuid, final Set<String> placeholders) {
+        if (placeholders.stream().noneMatch(placeholder -> placeholder.startsWith("%setting_")
+                || placeholder.startsWith("%lang_"))) {
+            return;
+        }
+        if (plugin.getPlayerSettingsManager() != null) {
+            plugin.getPlayerSettingsManager().getPlayerSettings(uuid);
+        }
+    }
+
+    private Set<String> collectPlaceholderSources(final ConfigurationSection section) {
+        final Set<String> values = new HashSet<>();
+        collectValues(section, values);
+        return values;
+    }
+
+    private void collectValues(final Object value, final Set<String> sink) {
+        if (value == null) {
+            return;
+        }
+        if (value instanceof ConfigurationSection configurationSection) {
+            for (String key : configurationSection.getKeys(false)) {
+                collectValues(configurationSection.get(key), sink);
+            }
+            return;
+        }
+        if (value instanceof Iterable<?> iterable) {
+            for (Object element : iterable) {
+                collectValues(element, sink);
+            }
+            return;
+        }
+        if (value instanceof String string && string.contains("%")) {
+            sink.add(string);
+        }
+    }
+
+    private Set<String> extractPlaceholders(final Set<String> values) {
+        final Set<String> placeholders = new HashSet<>();
+        final java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("%([^%]+)%");
+        for (String value : values) {
+            final java.util.regex.Matcher matcher = pattern.matcher(value);
+            while (matcher.find()) {
+                placeholders.add('%' + matcher.group(1) + '%');
+            }
+        }
+        return placeholders;
     }
 
     private File ensureMenusDirectory() {

--- a/src/main/resources/config/menus/profil_menu.yml
+++ b/src/main/resources/config/menus/profil_menu.yml
@@ -2,6 +2,7 @@ menu:
   id: "profil_menu"
   title: "&8» &6Mon Profil"
   size: 54
+  async_preload: true
 
   items:
     glass_1:


### PR DESCRIPTION
## Summary
- build menu inventories using precomputed contents arrays so they are applied in a single batch
- allow menus to flag asynchronous data preloading and warm economy/stats/settings caches before opening heavy menus
- enable async preloading for the profile menu configuration

## Testing
- `mvn -DskipTests package` *(fails: Maven central unreachable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b4a7f3c483299e9220ec70e288d8