### PR TITLE
Fix async menu preload lambda variable capture

### DIFF
--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -55,11 +55,12 @@ public class MenuManager implements Listener {
 
         final Menu menu = new ConfiguredMenu(plugin, normalizedId, menuSection, menuDesignProvider);
         final UUID uuid = player.getUniqueId();
+        final ConfigurationSection finalMenuSection = menuSection;
         if (shouldPreloadAsync(menuSection)) {
             openMenus.put(uuid, menu);
             player.closeInventory();
             Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-                preloadMenuData(uuid, menuSection);
+                preloadMenuData(uuid, finalMenuSection);
                 Bukkit.getScheduler().runTask(plugin, () -> {
                     final Player target = Bukkit.getPlayer(uuid);
                     if (target == null || !target.isOnline()) {


### PR DESCRIPTION
## Summary
- ensure the menu configuration section captured by the async preload task is final
- use the final reference when invoking the preload logic inside the asynchronous lambda

## Testing
- `mvn -q package` *(fails: Network is unreachable when downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b7e2e4388329813803ad28c8e771