### PR TITLE
Implement animated lobby scoreboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>net.luckperms</groupId>
+            <artifactId>api</artifactId>
+            <version>5.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.5</version>

--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -25,6 +25,7 @@ import com.lobby.lobby.LobbyManager;
 import com.lobby.lobby.listeners.LobbyItemListener;
 import com.lobby.lobby.listeners.LobbyPlayerListener;
 import com.lobby.lobby.listeners.LobbyProtectionListener;
+import com.lobby.scoreboard.LobbyScoreboardManager;
 import com.lobby.servers.ServerManager;
 import com.lobby.servers.ServerPlaceholderCache;
 import com.lobby.settings.PlayerSettingsManager;
@@ -69,6 +70,7 @@ public final class LobbyPlugin extends JavaPlugin {
     private ChatInputManager chatInputManager;
     private StatsManager statsManager;
     private PlayerSettingsManager playerSettingsManager;
+    private LobbyScoreboardManager scoreboardManager;
 
     public static LobbyPlugin getInstance() {
         return instance;
@@ -121,6 +123,9 @@ public final class LobbyPlugin extends JavaPlugin {
         shopCommands = new ShopCommands(this, shopManager);
         chatInputManager = new ChatInputManager(this);
 
+        scoreboardManager = new LobbyScoreboardManager(this);
+        getServer().getPluginManager().registerEvents(scoreboardManager, this);
+
         registerCommands();
 
         getServer().getPluginManager().registerEvents(new PlayerJoinLeaveEvent(this, playerDataManager, economyManager), this);
@@ -137,6 +142,9 @@ public final class LobbyPlugin extends JavaPlugin {
     @Override
     public void onDisable() {
         getServer().getMessenger().unregisterOutgoingPluginChannel(this);
+        if (scoreboardManager != null) {
+            scoreboardManager.shutdown();
+        }
         if (hologramManager != null) {
             hologramManager.shutdown();
         }
@@ -266,6 +274,10 @@ public final class LobbyPlugin extends JavaPlugin {
         return lobbyManager;
     }
 
+    public LobbyScoreboardManager getScoreboardManager() {
+        return scoreboardManager;
+    }
+
     public void reloadLobbyConfig() {
         if (configManager != null) {
             configManager.reloadConfigs();
@@ -309,6 +321,9 @@ public final class LobbyPlugin extends JavaPlugin {
         }
         if (playerSettingsManager != null) {
             playerSettingsManager.clearCache();
+        }
+        if (scoreboardManager != null) {
+            scoreboardManager.reload();
         }
     }
 

--- a/src/main/java/com/lobby/scoreboard/LobbyScoreboardManager.java
+++ b/src/main/java/com/lobby/scoreboard/LobbyScoreboardManager.java
@@ -1,0 +1,312 @@
+package com.lobby.scoreboard;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.economy.EconomyManager;
+import com.lobby.servers.ServerPlaceholderCache;
+import com.lobby.velocity.VelocityManager;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.scoreboard.Criteria;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
+
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class LobbyScoreboardManager implements Listener {
+
+    private static final String SCOREBOARD_TITLE = "      §6§l· §f§lHENERIA §6§l·";
+    private static final String SCOREBOARD_OBJECTIVE = "lobby";
+    private static final String PROFILE_HEADER = "§f→ §d§lProfil";
+    private static final String SERVER_HEADER = "§f→ §6§lServeur";
+    private static final String SEPARATOR_PRIMARY = "§r§0";
+    private static final String SEPARATOR_SECONDARY = "§r§1";
+    private static final String DEFAULT_PREFIX = "§7Joueur";
+    private static final int FOOTER_LINE_INDEX = 10;
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection();
+
+    private final LobbyPlugin plugin;
+    private final EconomyManager economyManager;
+    private final ServerPlaceholderCache serverPlaceholderCache;
+    private final LuckPermsPrefixResolver prefixResolver;
+    private final UrlAnimation urlAnimation = new UrlAnimation();
+    private final Set<UUID> trackedPlayers = ConcurrentHashMap.newKeySet();
+    private final Map<UUID, PlayerScoreboardData> dataCache = new ConcurrentHashMap<>();
+    private final Map<UUID, PlayerScoreboardView> views = new ConcurrentHashMap<>();
+    private final Map<UUID, String> lastKnownNames = new ConcurrentHashMap<>();
+
+    private BukkitTask dataTask;
+    private BukkitTask refreshTask;
+    private BukkitTask animationTask;
+    private String serverId = "1";
+
+    public LobbyScoreboardManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        this.economyManager = plugin.getEconomyManager();
+        this.serverPlaceholderCache = plugin.getServerPlaceholderCache();
+        this.prefixResolver = new LuckPermsPrefixResolver(plugin, DEFAULT_PREFIX);
+        reload();
+        start();
+    }
+
+    public void reload() {
+        final String configuredServerId = plugin.getConfig().getString("lobby.server_id", "1");
+        serverId = (configuredServerId == null || configuredServerId.isBlank()) ? "1" : configuredServerId.trim();
+        Bukkit.getScheduler().runTask(plugin, this::updateScoreboards);
+    }
+
+    public void shutdown() {
+        cancelTasks();
+        prefixResolver.clear();
+        trackedPlayers.clear();
+        dataCache.clear();
+        lastKnownNames.clear();
+        views.forEach((uuid, view) -> {
+            final Player player = Bukkit.getPlayer(uuid);
+            if (player != null && player.isOnline()) {
+                view.clear(player);
+            }
+        });
+        views.clear();
+    }
+
+    @EventHandler
+    public void onPlayerJoin(final PlayerJoinEvent event) {
+        final Player player = event.getPlayer();
+        Bukkit.getScheduler().runTaskLater(plugin, () -> initializePlayer(player), 2L);
+    }
+
+    @EventHandler
+    public void onPlayerQuit(final PlayerQuitEvent event) {
+        handleQuit(event.getPlayer());
+    }
+
+    private void start() {
+        cancelTasks();
+        dataTask = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, this::refreshPlayerData, 20L, 100L);
+        refreshTask = Bukkit.getScheduler().runTaskTimer(plugin, this::updateScoreboards, 20L, 20L);
+        animationTask = Bukkit.getScheduler().runTaskTimer(plugin, this::advanceAnimation, 3L, 3L);
+        Bukkit.getScheduler().runTask(plugin, () -> Bukkit.getOnlinePlayers().forEach(this::initializePlayer));
+    }
+
+    private void cancelTasks() {
+        if (dataTask != null) {
+            dataTask.cancel();
+            dataTask = null;
+        }
+        if (refreshTask != null) {
+            refreshTask.cancel();
+            refreshTask = null;
+        }
+        if (animationTask != null) {
+            animationTask.cancel();
+            animationTask = null;
+        }
+    }
+
+    private void initializePlayer(final Player player) {
+        if (player == null || !player.isOnline()) {
+            return;
+        }
+        final UUID uuid = player.getUniqueId();
+        trackedPlayers.add(uuid);
+        lastKnownNames.put(uuid, player.getName());
+        dataCache.putIfAbsent(uuid, PlayerScoreboardData.empty());
+        prefixResolver.forceRefresh(uuid, player.getName());
+        final PlayerScoreboardView view = views.computeIfAbsent(uuid, id -> createView(player));
+        final PlayerScoreboardData data = dataCache.getOrDefault(uuid, PlayerScoreboardData.empty());
+        view.apply(buildLines(player, data, resolveNetworkPlayerCount(), urlAnimation.getCurrentFrame()));
+    }
+
+    private void handleQuit(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final UUID uuid = player.getUniqueId();
+        trackedPlayers.remove(uuid);
+        dataCache.remove(uuid);
+        lastKnownNames.remove(uuid);
+        prefixResolver.invalidate(uuid);
+        final PlayerScoreboardView view = views.remove(uuid);
+        if (view != null) {
+            view.clear(player);
+        }
+    }
+
+    private void refreshPlayerData() {
+        if (trackedPlayers.isEmpty()) {
+            return;
+        }
+        for (final UUID uuid : trackedPlayers) {
+            final String username = lastKnownNames.getOrDefault(uuid, uuid.toString());
+            try {
+                final long coins = economyManager != null ? economyManager.getCoins(uuid) : 0L;
+                final long tokens = economyManager != null ? economyManager.getTokens(uuid) : 0L;
+                final String prefix = prefixResolver.getPrefix(uuid, username);
+                dataCache.put(uuid, new PlayerScoreboardData(prefix, coins, tokens));
+            } catch (final Exception exception) {
+                plugin.getLogger().warning("Failed to refresh scoreboard data for " + username + ": " + exception.getMessage());
+            }
+        }
+    }
+
+    private void updateScoreboards() {
+        if (trackedPlayers.isEmpty()) {
+            return;
+        }
+        final String footerFrame = urlAnimation.getCurrentFrame();
+        final int networkPlayers = resolveNetworkPlayerCount();
+        for (final UUID uuid : trackedPlayers) {
+            final Player player = Bukkit.getPlayer(uuid);
+            if (player == null || !player.isOnline()) {
+                cleanup(uuid);
+                continue;
+            }
+            lastKnownNames.put(uuid, player.getName());
+            final PlayerScoreboardView view = views.computeIfAbsent(uuid, id -> createView(player));
+            final PlayerScoreboardData data = dataCache.getOrDefault(uuid, PlayerScoreboardData.empty());
+            view.apply(buildLines(player, data, networkPlayers, footerFrame));
+        }
+    }
+
+    private void advanceAnimation() {
+        if (trackedPlayers.isEmpty()) {
+            return;
+        }
+        final String nextFrame = urlAnimation.nextFrame();
+        for (final UUID uuid : trackedPlayers) {
+            final Player player = Bukkit.getPlayer(uuid);
+            if (player == null || !player.isOnline()) {
+                cleanup(uuid);
+                continue;
+            }
+            final PlayerScoreboardView view = views.get(uuid);
+            if (view != null) {
+                view.updateLine(FOOTER_LINE_INDEX, nextFrame);
+            }
+        }
+    }
+
+    private void cleanup(final UUID uuid) {
+        trackedPlayers.remove(uuid);
+        dataCache.remove(uuid);
+        lastKnownNames.remove(uuid);
+        prefixResolver.invalidate(uuid);
+        views.remove(uuid);
+    }
+
+    private List<String> buildLines(final Player player, final PlayerScoreboardData data, final int networkPlayers,
+                                    final String footerFrame) {
+        final List<String> lines = new ArrayList<>(11);
+        lines.add(PROFILE_HEADER);
+        lines.add("  §7Compte: §f" + player.getName());
+        final String prefix = data.prefix().isBlank() ? DEFAULT_PREFIX : data.prefix();
+        lines.add("  §7Grade: " + prefix);
+        lines.add("  §7Coins: §e" + formatNumber(data.coins()) + " ⛁");
+        lines.add("  §7Tokens: §b" + formatNumber(data.tokens()) + " ✪");
+        lines.add(SEPARATOR_PRIMARY);
+        lines.add(SERVER_HEADER);
+        lines.add("  §7Lobby: §f#" + serverId);
+        lines.add("  §7En ligne: §a" + formatNumber(networkPlayers));
+        lines.add(SEPARATOR_SECONDARY);
+        lines.add(footerFrame);
+        return lines;
+    }
+
+    private String formatNumber(final long value) {
+        return NumberFormat.getInstance(Locale.FRANCE).format(value);
+    }
+
+    private int resolveNetworkPlayerCount() {
+        int total = 0;
+        if (serverPlaceholderCache != null) {
+            total = Math.max(total, serverPlaceholderCache.getTotalPlayerCount());
+        }
+        final VelocityManager velocityManager = plugin.getVelocityManager();
+        if (velocityManager != null) {
+            total = Math.max(total, velocityManager.getTotalPlayerCount());
+        }
+        return Math.max(total, Bukkit.getOnlinePlayers().size());
+    }
+
+    private PlayerScoreboardView createView(final Player player) {
+        final org.bukkit.scoreboard.ScoreboardManager manager = Bukkit.getScoreboardManager();
+        if (manager == null) {
+            throw new IllegalStateException("Scoreboard manager is not available");
+        }
+        final Scoreboard scoreboard = manager.getNewScoreboard();
+        final String objectiveName = SCOREBOARD_OBJECTIVE + "_" + player.getEntityId();
+        final Component displayName = LEGACY_SERIALIZER.deserialize(SCOREBOARD_TITLE);
+        final Objective objective = scoreboard.registerNewObjective(objectiveName, Criteria.DUMMY, displayName);
+        objective.setDisplaySlot(DisplaySlot.SIDEBAR);
+        player.setScoreboard(scoreboard);
+        return new PlayerScoreboardView(scoreboard, objective);
+    }
+
+    private static final class PlayerScoreboardView {
+
+        private final Scoreboard scoreboard;
+        private final Objective objective;
+        private final List<String> lines = new ArrayList<>();
+
+        private PlayerScoreboardView(final Scoreboard scoreboard, final Objective objective) {
+            this.scoreboard = scoreboard;
+            this.objective = objective;
+        }
+
+        private void apply(final List<String> newLines) {
+            final Set<String> currentEntries = Set.copyOf(lines);
+            for (final String entry : currentEntries) {
+                if (!newLines.contains(entry)) {
+                    scoreboard.resetScores(entry);
+                }
+            }
+            lines.clear();
+            lines.addAll(newLines);
+            final int size = newLines.size();
+            for (int index = 0; index < size; index++) {
+                final String line = newLines.get(index);
+                objective.getScore(line).setScore(size - index);
+            }
+        }
+
+        private void updateLine(final int index, final String value) {
+            if (index < 0 || index >= lines.size()) {
+                return;
+            }
+            final String current = lines.get(index);
+            if (current.equals(value)) {
+                return;
+            }
+            scoreboard.resetScores(current);
+            final int score = lines.size() - index;
+            objective.getScore(value).setScore(score);
+            lines.set(index, value);
+        }
+
+        private void clear(final Player player) {
+            for (final String entry : lines) {
+                scoreboard.resetScores(entry);
+            }
+            lines.clear();
+            final org.bukkit.scoreboard.ScoreboardManager manager = Bukkit.getScoreboardManager();
+            if (manager != null) {
+                player.setScoreboard(manager.getNewScoreboard());
+            }
+        }
+    }
+}

--- a/src/main/java/com/lobby/scoreboard/LuckPermsPrefixResolver.java
+++ b/src/main/java/com/lobby/scoreboard/LuckPermsPrefixResolver.java
@@ -1,0 +1,117 @@
+package com.lobby.scoreboard;
+
+import com.lobby.LobbyPlugin;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.cacheddata.CachedMetaData;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.query.QueryOptions;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class LuckPermsPrefixResolver {
+
+    private static final long REFRESH_INTERVAL_MILLIS = 30_000L;
+
+    private final LobbyPlugin plugin;
+    private final LuckPerms luckPerms;
+    private final QueryOptions queryOptions;
+    private final Map<UUID, String> cache = new ConcurrentHashMap<>();
+    private final Map<UUID, Long> lastRequest = new ConcurrentHashMap<>();
+    private final String defaultPrefix;
+
+    public LuckPermsPrefixResolver(final LobbyPlugin plugin, final String defaultPrefix) {
+        this.plugin = plugin;
+        this.luckPerms = Bukkit.getServicesManager().load(LuckPerms.class);
+        this.queryOptions = luckPerms != null ? luckPerms.getContextManager().getStaticQueryOptions() : null;
+        this.defaultPrefix = Objects.requireNonNullElse(defaultPrefix, "§7Joueur");
+    }
+
+    public String getPrefix(final UUID uuid, final String username) {
+        if (uuid == null) {
+            return defaultPrefix;
+        }
+        if (shouldRefresh(uuid)) {
+            refresh(uuid, username);
+        }
+        final String cached = cache.get(uuid);
+        if (cached == null || cached.isBlank()) {
+            return defaultPrefix;
+        }
+        return cached;
+    }
+
+    public void forceRefresh(final UUID uuid, final String username) {
+        if (uuid == null) {
+            return;
+        }
+        lastRequest.put(uuid, System.currentTimeMillis());
+        refresh(uuid, username);
+    }
+
+    private boolean shouldRefresh(final UUID uuid) {
+        final long now = System.currentTimeMillis();
+        final Long last = lastRequest.get(uuid);
+        if (last == null || (now - last) >= REFRESH_INTERVAL_MILLIS) {
+            lastRequest.put(uuid, now);
+            return true;
+        }
+        return false;
+    }
+
+    private void refresh(final UUID uuid, final String username) {
+        if (uuid == null) {
+            return;
+        }
+        if (luckPerms == null) {
+            cache.put(uuid, defaultPrefix);
+            return;
+        }
+        luckPerms.getUserManager().loadUser(uuid, username).thenAccept(user -> {
+            try {
+                cache.put(uuid, resolvePrefix(user));
+            } catch (final Exception exception) {
+                plugin.getLogger().warning("Failed to resolve LuckPerms prefix for " + username + ": " + exception.getMessage());
+            } finally {
+                if (user != null) {
+                    luckPerms.getUserManager().saveUser(user);
+                }
+            }
+        }).exceptionally(throwable -> {
+            plugin.getLogger().warning("Failed to load LuckPerms data for " + username + ": " + throwable.getMessage());
+            return null;
+        });
+    }
+
+    private String resolvePrefix(final User user) {
+        if (user == null || queryOptions == null) {
+            return defaultPrefix;
+        }
+        final CachedMetaData metaData = user.getCachedData().getMetaData(queryOptions);
+        if (metaData == null) {
+            return defaultPrefix;
+        }
+        final String prefix = metaData.getPrefix();
+        if (prefix == null || prefix.isBlank()) {
+            return defaultPrefix;
+        }
+        return ChatColor.translateAlternateColorCodes('&', prefix);
+    }
+
+    public void invalidate(final UUID uuid) {
+        if (uuid == null) {
+            return;
+        }
+        cache.remove(uuid);
+        lastRequest.remove(uuid);
+    }
+
+    public void clear() {
+        cache.clear();
+        lastRequest.clear();
+    }
+}

--- a/src/main/java/com/lobby/scoreboard/PlayerScoreboardData.java
+++ b/src/main/java/com/lobby/scoreboard/PlayerScoreboardData.java
@@ -1,0 +1,12 @@
+package com.lobby.scoreboard;
+
+public record PlayerScoreboardData(String prefix, long coins, long tokens) {
+
+    public PlayerScoreboardData {
+        this.prefix = prefix == null ? "" : prefix;
+    }
+
+    public static PlayerScoreboardData empty() {
+        return new PlayerScoreboardData("", 0L, 0L);
+    }
+}

--- a/src/main/java/com/lobby/scoreboard/UrlAnimation.java
+++ b/src/main/java/com/lobby/scoreboard/UrlAnimation.java
@@ -1,0 +1,51 @@
+package com.lobby.scoreboard;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class UrlAnimation {
+
+    private static final String URL_TEXT = "heneria.com";
+    private static final char[] PALETTE = {'6', '6', 'c', 'c', 'e', '6', '6', 'c', 'c', 'e', '6', '6', 'c', 'c', 'e'};
+
+    private final List<String> frames;
+    private int index;
+
+    public UrlAnimation() {
+        this.frames = buildFrames();
+        this.index = 0;
+    }
+
+    public String getCurrentFrame() {
+        if (frames.isEmpty()) {
+            return "    §7→ §eheneria.com";
+        }
+        return frames.get(index);
+    }
+
+    public String nextFrame() {
+        if (frames.isEmpty()) {
+            return "    §7→ §eheneria.com";
+        }
+        index = (index + 1) % frames.size();
+        return frames.get(index);
+    }
+
+    private List<String> buildFrames() {
+        if (URL_TEXT.isEmpty()) {
+            return List.of("    §7→ §eheneria.com");
+        }
+        final int paletteLength = PALETTE.length;
+        final List<String> generated = new ArrayList<>(paletteLength);
+        for (int offset = 0; offset < paletteLength; offset++) {
+            final StringBuilder builder = new StringBuilder("    §7→ ");
+            for (int index = 0; index < URL_TEXT.length(); index++) {
+                final char color = PALETTE[(index + offset) % paletteLength];
+                builder.append('§').append(color).append(URL_TEXT.charAt(index));
+            }
+            generated.add(builder.toString());
+        }
+        return Collections.unmodifiableList(generated);
+    }
+}

--- a/src/main/java/com/lobby/servers/ServerPlaceholderCache.java
+++ b/src/main/java/com/lobby/servers/ServerPlaceholderCache.java
@@ -87,6 +87,12 @@ public class ServerPlaceholderCache {
         return activeGames.getOrDefault(normalize(serverId), 0);
     }
 
+    public int getTotalPlayerCount() {
+        return playerCounts.values().stream()
+                .mapToInt(Integer::intValue)
+                .sum();
+    }
+
     public void updateServerPlayerCount(final String serverId, final int count) {
         if (serverId == null) {
             return;

--- a/src/main/java/com/lobby/velocity/VelocityManager.java
+++ b/src/main/java/com/lobby/velocity/VelocityManager.java
@@ -261,6 +261,12 @@ public class VelocityManager {
         return serverPlayerCounts.getOrDefault(normalize(serverId), 0);
     }
 
+    public int getTotalPlayerCount() {
+        return serverPlayerCounts.values().stream()
+                .mapToInt(Integer::intValue)
+                .sum();
+    }
+
     public boolean isServerOnline(final String serverId) {
         final VelocityServerInfo info = servers.get(normalize(serverId));
         return info != null && info.isEnabled();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -58,6 +58,7 @@ discord:
   enabled: false
 
 lobby:
+  server_id: "1"
   spawn:
     world: "world"
     x: 0.5


### PR DESCRIPTION
## Summary
- introduce a LobbyScoreboardManager that asynchronously caches player data, refreshes sidebars, and drives the animated footer
- add helpers for LuckPerms prefix caching and URL colour cycling plus expose total player counts for scoreboard placeholders
- wire the scoreboard manager into the plugin lifecycle, add the lobby server id config entry, and depend on the LuckPerms API

## Testing
- `mvn -q -DskipTests package` *(fails: network unreachable while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cd20c9fc8329a887675a4e17bd55