### PR TITLE
Fix record constructor to normalize prefix without reassigning final field

### DIFF
--- a/src/main/java/com/lobby/scoreboard/PlayerScoreboardData.java
+++ b/src/main/java/com/lobby/scoreboard/PlayerScoreboardData.java
@@ -3,7 +3,7 @@ package com.lobby.scoreboard;
 public record PlayerScoreboardData(String prefix, long coins, long tokens) {
 
     public PlayerScoreboardData {
-        this.prefix = prefix == null ? "" : prefix;
+        prefix = prefix == null ? "" : prefix;
     }
 
     public static PlayerScoreboardData empty() {


### PR DESCRIPTION
## Summary
- update the PlayerScoreboardData canonical constructor to normalize the prefix argument without reassigning the record component

## Testing
- mvn clean install *(fails: unable to download maven-clean-plugin because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d34ae48c8329ab4dcd12eadcb861