### PR TITLE
Implement custom tablist nametag support and persist NPC equipment

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -37,6 +37,7 @@ import com.lobby.social.friends.FriendManager;
 import com.lobby.social.groups.GroupManager;
 import com.lobby.stats.StatsManager;
 import com.lobby.tablist.TablistManager;
+import com.lobby.tablist.NametagManager;
 import com.lobby.velocity.VelocityManager;
 import com.lobby.utils.LogUtils;
 import org.bukkit.Material;
@@ -72,6 +73,7 @@ public final class LobbyPlugin extends JavaPlugin {
     private StatsManager statsManager;
     private PlayerSettingsManager playerSettingsManager;
     private ScoreboardManager scoreboardManager;
+    private NametagManager nametagManager;
     private TablistManager tablistManager;
 
     public static LobbyPlugin getInstance() {
@@ -128,6 +130,8 @@ public final class LobbyPlugin extends JavaPlugin {
         scoreboardManager = new ScoreboardManager(this);
         getServer().getPluginManager().registerEvents(scoreboardManager, this);
 
+        nametagManager = new NametagManager(this);
+
         tablistManager = new TablistManager(this);
         getServer().getPluginManager().registerEvents(tablistManager, this);
 
@@ -149,6 +153,9 @@ public final class LobbyPlugin extends JavaPlugin {
         getServer().getMessenger().unregisterOutgoingPluginChannel(this);
         if (scoreboardManager != null) {
             scoreboardManager.shutdown();
+        }
+        if (nametagManager != null) {
+            nametagManager.shutdown();
         }
         if (tablistManager != null) {
             tablistManager.shutdown();
@@ -196,6 +203,10 @@ public final class LobbyPlugin extends JavaPlugin {
             confirmationManager.clearAll();
         }
         instance = null;
+    }
+
+    public NametagManager getNametagManager() {
+        return nametagManager;
     }
 
     public DatabaseManager getDatabaseManager() {

--- a/src/main/java/com/lobby/commands/NPCCommands.java
+++ b/src/main/java/com/lobby/commands/NPCCommands.java
@@ -10,7 +10,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
-import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -389,20 +388,15 @@ public class NPCCommands implements CommandExecutor, TabCompleter {
             return;
         }
 
-        final ArmorStand armorStand = npc.getArmorStand();
-        if (armorStand == null || armorStand.isDead()) {
-            MessageUtils.sendPrefixedMessage(player, "&cLe PNJ n'est pas disponible actuellement.");
-            return;
+        try {
+            npcManager.updateNPCMainHandItem(name, itemInHand);
+            MessageUtils.sendPrefixedMessage(player, "&aPNJ '&6" + name + "&a' équipé avec l'item !");
+        } catch (final Exception exception) {
+            MessageUtils.sendPrefixedMessage(player, "&cImpossible d'équiper ce PNJ (" + exception.getMessage() + ")");
+            if (plugin != null) {
+                plugin.getLogger().severe("Error updating NPC item: " + exception.getMessage());
+            }
         }
-
-        final var equipment = armorStand.getEquipment();
-        if (equipment == null) {
-            MessageUtils.sendPrefixedMessage(player, "&cImpossible d'équiper ce PNJ.");
-            return;
-        }
-
-        equipment.setItemInMainHand(itemInHand.clone());
-        MessageUtils.sendPrefixedMessage(player, "&aPNJ '&6" + name + "&a' équipé avec l'item !");
     }
 
     private void handleSetColor(final CommandSender sender, final String[] args) {

--- a/src/main/java/com/lobby/core/DatabaseManager.java
+++ b/src/main/java/com/lobby/core/DatabaseManager.java
@@ -293,11 +293,13 @@ public class DatabaseManager {
                         z REAL NOT NULL,
                         yaw REAL DEFAULT 0,
                         pitch REAL DEFAULT 0,
-                        head_texture TEXT,
-                        armor_color TEXT,
-                        animation TEXT,
-                        actions TEXT,
-                        visible INTEGER DEFAULT 1,
+                    head_texture TEXT,
+                    armor_color TEXT,
+                    animation TEXT,
+                    actions TEXT,
+                    main_hand_item TEXT,
+                    off_hand_item TEXT,
+                    visible INTEGER DEFAULT 1,
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                     )
                     """;
@@ -306,6 +308,8 @@ public class DatabaseManager {
             plugin.getLogger().fine("Created npcs table for SQLite");
             addColumnIfNotExists("npcs", "armor_color", "TEXT");
             addColumnIfNotExists("npcs", "animation", "TEXT");
+            addColumnIfNotExists("npcs", "main_hand_item", "TEXT");
+            addColumnIfNotExists("npcs", "off_hand_item", "TEXT");
             createNPCIndexes();
             return;
         }
@@ -325,6 +329,8 @@ public class DatabaseManager {
                     armor_color VARCHAR(7) NULL DEFAULT NULL,
                     animation VARCHAR(50) NULL DEFAULT NULL,
                     actions TEXT,
+                    main_hand_item TEXT,
+                    off_hand_item TEXT,
                     visible BOOLEAN DEFAULT TRUE,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     INDEX idx_world (world),
@@ -337,6 +343,8 @@ public class DatabaseManager {
         LogUtils.info(plugin, "Created npcs table with proper AUTO_INCREMENT");
         addColumnIfNotExists("npcs", "armor_color", "VARCHAR(7)");
         addColumnIfNotExists("npcs", "animation", "VARCHAR(50)");
+        addColumnIfNotExists("npcs", "main_hand_item", "TEXT");
+        addColumnIfNotExists("npcs", "off_hand_item", "TEXT");
     }
 
     private void addColumnIfMissing(final String table, final String columnName, final String definition) throws SQLException {
@@ -688,7 +696,10 @@ public class DatabaseManager {
                         pitch FLOAT DEFAULT 0,
                         head_texture TEXT,
                         armor_color VARCHAR(7),
+                        animation VARCHAR(50),
                         `actions` TEXT,
+                        main_hand_item TEXT,
+                        off_hand_item TEXT,
                         visible BOOLEAN DEFAULT TRUE,
                         INDEX idx_world (world),
                         INDEX idx_visible (visible)
@@ -709,7 +720,10 @@ public class DatabaseManager {
                     pitch REAL DEFAULT 0,
                     head_texture TEXT,
                     armor_color TEXT,
+                    animation TEXT,
                     actions TEXT,
+                    main_hand_item TEXT,
+                    off_hand_item TEXT,
                     visible INTEGER DEFAULT 1
                 )
                 """;

--- a/src/main/java/com/lobby/data/NPCData.java
+++ b/src/main/java/com/lobby/data/NPCData.java
@@ -1,5 +1,7 @@
 package com.lobby.data;
 
+import org.bukkit.inventory.ItemStack;
+
 import java.util.List;
 
 public record NPCData(
@@ -15,22 +17,43 @@ public record NPCData(
         String armorColor,
         List<String> actions,
         String animation,
-        boolean visible
+        boolean visible,
+        ItemStack mainHandItem,
+        ItemStack offHandItem
 ) {
 
     public NPCData {
         actions = List.copyOf(actions == null ? List.of() : actions);
+        mainHandItem = cloneItem(mainHandItem);
+        offHandItem = cloneItem(offHandItem);
     }
 
     public NPCData withActions(final List<String> newActions) {
-        return new NPCData(name, displayName, world, x, y, z, yaw, pitch, headTexture, armorColor, newActions, animation, visible);
+        return new NPCData(name, displayName, world, x, y, z, yaw, pitch, headTexture, armorColor, newActions, animation,
+                visible, mainHandItem, offHandItem);
     }
 
     public NPCData withArmorColor(final String newColor) {
-        return new NPCData(name, displayName, world, x, y, z, yaw, pitch, headTexture, newColor, actions, animation, visible);
+        return new NPCData(name, displayName, world, x, y, z, yaw, pitch, headTexture, newColor, actions, animation,
+                visible, mainHandItem, offHandItem);
     }
 
     public NPCData withAnimation(final String newAnimation) {
-        return new NPCData(name, displayName, world, x, y, z, yaw, pitch, headTexture, armorColor, actions, newAnimation, visible);
+        return new NPCData(name, displayName, world, x, y, z, yaw, pitch, headTexture, armorColor, actions, newAnimation,
+                visible, mainHandItem, offHandItem);
+    }
+
+    public NPCData withMainHandItem(final ItemStack item) {
+        return new NPCData(name, displayName, world, x, y, z, yaw, pitch, headTexture, armorColor, actions, animation,
+                visible, item, offHandItem);
+    }
+
+    public NPCData withOffHandItem(final ItemStack item) {
+        return new NPCData(name, displayName, world, x, y, z, yaw, pitch, headTexture, armorColor, actions, animation,
+                visible, mainHandItem, item);
+    }
+
+    private static ItemStack cloneItem(final ItemStack item) {
+        return item == null ? null : item.clone();
     }
 }

--- a/src/main/java/com/lobby/npcs/NPC.java
+++ b/src/main/java/com/lobby/npcs/NPC.java
@@ -12,6 +12,7 @@ import org.bukkit.World;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.persistence.PersistentDataType;
@@ -184,6 +185,7 @@ public class NPC {
         if (equipment.getItemInMainHand() == null || equipment.getItemInMainHand().getType() == Material.AIR) {
             equipment.setItemInMainHand(new ItemStack(Material.STICK));
         }
+        applyPersistedItems(equipment);
     }
 
     private void applyArmorColor() {
@@ -192,6 +194,20 @@ public class NPC {
         }
 
         manager.applyArmorColor(armorStand, data.armorColor());
+    }
+
+    private void applyPersistedItems(final EntityEquipment equipment) {
+        if (equipment == null) {
+            return;
+        }
+        final ItemStack mainHand = data.mainHandItem();
+        if (mainHand != null && mainHand.getType() != Material.AIR) {
+            equipment.setItemInMainHand(mainHand.clone());
+        }
+        final ItemStack offHand = data.offHandItem();
+        if (offHand != null && offHand.getType() != Material.AIR) {
+            equipment.setItemInOffHand(offHand.clone());
+        }
     }
 
     private static final Pattern UUID_PATTERN = Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");

--- a/src/main/java/com/lobby/npcs/NPCManager.java
+++ b/src/main/java/com/lobby/npcs/NPCManager.java
@@ -108,7 +108,7 @@ public class NPCManager {
                 location.getWorld().getName(),
                 location.getX(), location.getY(), location.getZ(),
                 location.getYaw(), location.getPitch(),
-                headTexture, null, actions, null, true
+                headTexture, null, actions, null, true, null, null
         );
 
         try {
@@ -208,6 +208,66 @@ public class NPCManager {
 
         if (!updated) {
             LogUtils.warning(plugin, "Updated armor color for NPC '" + name + "' locally but no database row was modified.");
+        }
+    }
+
+    public void updateNPCMainHandItem(final String name, final ItemStack item) {
+        final NPC npc = npcs.get(name);
+        if (npc == null) {
+            throw new IllegalArgumentException("NPC '" + name + "' not found");
+        }
+
+        final ItemStack clone = item == null ? null : item.clone();
+        final boolean updated;
+        try {
+            updated = npcDAO.updateNpcMainHandItem(name, clone);
+        } catch (final SQLException exception) {
+            throw new RuntimeException("Failed to update NPC item: " + exception.getMessage(), exception);
+        }
+
+        final ArmorStand armorStand = npc.getArmorStand();
+        if (armorStand != null && !armorStand.isDead()) {
+            final var equipment = armorStand.getEquipment();
+            if (equipment != null) {
+                equipment.setItemInMainHand(clone);
+            }
+        }
+
+        npc.setData(npc.getData().withMainHandItem(clone));
+
+        if (!updated) {
+            LogUtils.warning(plugin, "Updated main hand item for NPC '" + name
+                    + "' locally but no database row was modified.");
+        }
+    }
+
+    public void updateNPCOffHandItem(final String name, final ItemStack item) {
+        final NPC npc = npcs.get(name);
+        if (npc == null) {
+            throw new IllegalArgumentException("NPC '" + name + "' not found");
+        }
+
+        final ItemStack clone = item == null ? null : item.clone();
+        final boolean updated;
+        try {
+            updated = npcDAO.updateNpcOffHandItem(name, clone);
+        } catch (final SQLException exception) {
+            throw new RuntimeException("Failed to update NPC off hand item: " + exception.getMessage(), exception);
+        }
+
+        final ArmorStand armorStand = npc.getArmorStand();
+        if (armorStand != null && !armorStand.isDead()) {
+            final var equipment = armorStand.getEquipment();
+            if (equipment != null) {
+                equipment.setItemInOffHand(clone);
+            }
+        }
+
+        npc.setData(npc.getData().withOffHandItem(clone));
+
+        if (!updated) {
+            LogUtils.warning(plugin, "Updated off hand item for NPC '" + name
+                    + "' locally but no database row was modified.");
         }
     }
 

--- a/src/main/java/com/lobby/npcs/NpcDAO.java
+++ b/src/main/java/com/lobby/npcs/NpcDAO.java
@@ -3,7 +3,9 @@ package com.lobby.npcs;
 import com.lobby.LobbyPlugin;
 import com.lobby.core.DatabaseManager;
 import com.lobby.data.NPCData;
+import com.lobby.utils.ItemSerializationUtils;
 import com.lobby.utils.LogUtils;
+import org.bukkit.inventory.ItemStack;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -29,8 +31,8 @@ public class NpcDAO {
 
     public List<NPCData> loadAllNpcs() throws SQLException {
         final List<NPCData> npcs = new ArrayList<>();
-        final String sql = "SELECT name, display_name, world, x, y, z, yaw, pitch, head_texture, armor_color, actions, animation, visible "
-                + "FROM npcs WHERE visible = TRUE";
+        final String sql = "SELECT name, display_name, world, x, y, z, yaw, pitch, head_texture, armor_color, actions, animation,"
+                + " visible, main_hand_item, off_hand_item FROM npcs WHERE visible = TRUE";
 
         try (Connection connection = databaseManager.getConnection();
              PreparedStatement statement = connection.prepareStatement(sql);
@@ -52,8 +54,9 @@ public class NpcDAO {
 
     public boolean createNpc(final NPCData data) throws SQLException {
         final String sql = """
-                INSERT INTO npcs (name, display_name, world, x, y, z, yaw, pitch, head_texture, armor_color, actions, animation, visible)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO npcs (name, display_name, world, x, y, z, yaw, pitch, head_texture, armor_color, actions, animation,
+                visible, main_hand_item, off_hand_item)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """;
 
         try (Connection connection = databaseManager.getConnection();
@@ -72,6 +75,8 @@ public class NpcDAO {
             statement.setString(11, actionsToJson(data.actions()));
             setNullableString(statement, 12, data.animation());
             statement.setBoolean(13, data.visible());
+            setNullableString(statement, 14, serializeItem(data.mainHandItem()));
+            setNullableString(statement, 15, serializeItem(data.offHandItem()));
 
             return statement.executeUpdate() > 0;
         }
@@ -132,8 +137,30 @@ public class NpcDAO {
                 resultSet.getString("armor_color"),
                 actions,
                 resultSet.getString("animation"),
-                resultSet.getBoolean("visible")
+                resultSet.getBoolean("visible"),
+                deserializeItem(resultSet.getString("main_hand_item")),
+                deserializeItem(resultSet.getString("off_hand_item"))
         );
+    }
+
+    public boolean updateNpcMainHandItem(final String name, final ItemStack item) throws SQLException {
+        final String sql = "UPDATE npcs SET main_hand_item = ? WHERE name = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            setNullableString(statement, 1, serializeItem(item));
+            statement.setString(2, name);
+            return statement.executeUpdate() > 0;
+        }
+    }
+
+    public boolean updateNpcOffHandItem(final String name, final ItemStack item) throws SQLException {
+        final String sql = "UPDATE npcs SET off_hand_item = ? WHERE name = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            setNullableString(statement, 1, serializeItem(item));
+            statement.setString(2, name);
+            return statement.executeUpdate() > 0;
+        }
     }
 
     private List<String> parseActions(String actionsJson) {
@@ -248,5 +275,30 @@ public class NpcDAO {
             return;
         }
         statement.setString(index, value);
+    }
+
+    private String serializeItem(final ItemStack item) {
+        try {
+            return ItemSerializationUtils.serializeItem(item);
+        } catch (final IllegalStateException exception) {
+            if (plugin != null) {
+                LogUtils.warning(plugin, "Failed to serialize NPC item: " + exception.getMessage());
+            }
+            return null;
+        }
+    }
+
+    private ItemStack deserializeItem(final String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return ItemSerializationUtils.deserializeItem(value);
+        } catch (final IllegalStateException exception) {
+            if (plugin != null) {
+                LogUtils.warning(plugin, "Failed to deserialize NPC item: " + exception.getMessage());
+            }
+            return null;
+        }
     }
 }

--- a/src/main/java/com/lobby/tablist/LuckPermsTablistResolver.java
+++ b/src/main/java/com/lobby/tablist/LuckPermsTablistResolver.java
@@ -36,7 +36,7 @@ final class LuckPermsTablistResolver {
         this.luckPerms = Bukkit.getServicesManager().load(LuckPerms.class);
         this.queryOptions = luckPerms != null ? luckPerms.getContextManager().getStaticQueryOptions() : null;
         final String resolvedPrefix = Objects.requireNonNullElse(defaultPrefix, ChatColor.GRAY + "Joueur");
-        this.defaultData = new PlayerTablistData(resolvedPrefix, "", 0);
+        this.defaultData = new PlayerTablistData(resolvedPrefix, "", 0, null);
     }
 
     PlayerTablistData getMeta(final UUID uuid, final String username) {
@@ -74,7 +74,7 @@ final class LuckPermsTablistResolver {
                     if (user == null) {
                         metaFuture = CompletableFuture.completedFuture(resolved);
                     } else {
-                        final String primaryGroup = user.getPrimaryGroup();
+                        final String primaryGroup = resolved.primaryGroup();
                         if (primaryGroup == null || primaryGroup.isBlank()) {
                             metaFuture = CompletableFuture.completedFuture(resolved);
                         } else {
@@ -153,7 +153,8 @@ final class LuckPermsTablistResolver {
         final String prefix = colorize(metaData.getPrefix());
         final String suffix = colorize(metaData.getSuffix());
         final String resolvedPrefix = prefix.isBlank() ? previous.prefix() : prefix;
-        return new PlayerTablistData(resolvedPrefix, suffix, previous.weight());
+        final String primaryGroup = user != null ? user.getPrimaryGroup() : previous.primaryGroup();
+        return new PlayerTablistData(resolvedPrefix, suffix, previous.weight(), primaryGroup);
     }
 
     private PlayerTablistData mergeGroupData(final PlayerTablistData base,
@@ -161,10 +162,10 @@ final class LuckPermsTablistResolver {
                                             final PlayerTablistData previous) {
         final Group group = unwrapGroup(groupResult);
         if (group == null) {
-            return new PlayerTablistData(base.prefix(), base.suffix(), previous.weight());
+            return new PlayerTablistData(base.prefix(), base.suffix(), previous.weight(), base.primaryGroup());
         }
         final int weight = group.getWeight().orElse(previous.weight());
-        return new PlayerTablistData(base.prefix(), base.suffix(), weight);
+        return new PlayerTablistData(base.prefix(), base.suffix(), weight, base.primaryGroup());
     }
 
     private Group unwrapGroup(final Object groupResult) {

--- a/src/main/java/com/lobby/tablist/NametagManager.java
+++ b/src/main/java/com/lobby/tablist/NametagManager.java
@@ -1,0 +1,369 @@
+package com.lobby.tablist;
+
+import com.lobby.LobbyPlugin;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.cacheddata.CachedMetaData;
+import net.luckperms.api.model.group.Group;
+import net.luckperms.api.query.QueryOptions;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Scoreboard;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Team;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages player nametag formatting by creating and assigning scoreboard teams
+ * based on LuckPerms groups. This manager cooperates with the tablist manager
+ * to ensure prefixes and colors are consistent both in the player list and
+ * above player heads.
+ */
+public final class NametagManager {
+
+    private static final String TEAM_PREFIX = "nt";
+    private static final int TEAM_NAME_MAX_LENGTH = 16;
+
+    private final LobbyPlugin plugin;
+    private final LuckPerms luckPerms;
+    private final QueryOptions queryOptions;
+    private final Map<String, TeamTemplate> templates = new ConcurrentHashMap<>();
+    private final Map<UUID, String> playerTeams = new ConcurrentHashMap<>();
+
+    private volatile TeamTemplate defaultTemplate;
+
+    public NametagManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        this.luckPerms = Bukkit.getServicesManager().load(LuckPerms.class);
+        this.queryOptions = luckPerms != null ? luckPerms.getContextManager().getStaticQueryOptions() : null;
+        reload();
+    }
+
+    public void reload() {
+        templates.clear();
+        if (luckPerms == null) {
+            defaultTemplate = createFallbackTemplate();
+            return;
+        }
+        final Collection<Group> groups = luckPerms.getGroupManager().getLoadedGroups();
+        if (groups.isEmpty()) {
+            defaultTemplate = createFallbackTemplate();
+            return;
+        }
+        final List<Group> sortedGroups = new ArrayList<>(groups);
+        sortedGroups.sort((first, second) -> {
+            final int secondWeight = second.getWeight().orElse(0);
+            final int firstWeight = first.getWeight().orElse(0);
+            final int comparison = Integer.compare(secondWeight, firstWeight);
+            if (comparison != 0) {
+                return comparison;
+            }
+            return first.getName().compareToIgnoreCase(second.getName());
+        });
+        final Map<String, TeamTemplate> resolvedTemplates = new HashMap<>();
+        int order = 1;
+        for (Group group : sortedGroups) {
+            final TeamTemplate template = createTemplateForGroup(group, order++);
+            resolvedTemplates.put(group.getName().toLowerCase(Locale.ROOT), template);
+            if (defaultTemplate == null && "default".equalsIgnoreCase(group.getName())) {
+                defaultTemplate = template;
+            }
+        }
+        templates.putAll(resolvedTemplates);
+        if (defaultTemplate == null) {
+            defaultTemplate = createFallbackTemplate();
+        }
+        refreshAllViewers();
+    }
+
+    public void applyNametag(final Player player, final PlayerTablistData data) {
+        if (player == null) {
+            return;
+        }
+        final TeamTemplate template = resolveTemplate(data != null ? data.primaryGroup() : null);
+        final UUID uuid = player.getUniqueId();
+        final String previousTeam = playerTeams.put(uuid, template.key());
+        final String entry = player.getName();
+        for (Player viewer : Bukkit.getOnlinePlayers()) {
+            final Scoreboard scoreboard = viewer.getScoreboard();
+            if (scoreboard == null) {
+                continue;
+            }
+            if (previousTeam != null && !previousTeam.equals(template.key())) {
+                removeEntryFromTeam(scoreboard, entry, previousTeam);
+            }
+            addEntryToTeam(scoreboard, entry, template);
+        }
+    }
+
+    public void removePlayer(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final UUID uuid = player.getUniqueId();
+        final String teamKey = playerTeams.remove(uuid);
+        if (teamKey == null) {
+            return;
+        }
+        final String entry = player.getName();
+        for (Player viewer : Bukkit.getOnlinePlayers()) {
+            final Scoreboard scoreboard = viewer.getScoreboard();
+            if (scoreboard == null) {
+                continue;
+            }
+            removeEntryFromTeam(scoreboard, entry, teamKey);
+        }
+    }
+
+    public void clearAll() {
+        playerTeams.clear();
+        for (Player viewer : Bukkit.getOnlinePlayers()) {
+            final Scoreboard scoreboard = viewer.getScoreboard();
+            if (scoreboard == null) {
+                continue;
+            }
+            clearTeams(scoreboard);
+        }
+    }
+
+    public void shutdown() {
+        clearAll();
+        templates.clear();
+        defaultTemplate = null;
+    }
+
+    private void refreshAllViewers() {
+        final Map<UUID, String> assignments = new HashMap<>(playerTeams);
+        for (Player viewer : Bukkit.getOnlinePlayers()) {
+            final Scoreboard scoreboard = viewer.getScoreboard();
+            if (scoreboard == null) {
+                continue;
+            }
+            clearTeams(scoreboard);
+            for (Player target : Bukkit.getOnlinePlayers()) {
+                final String teamKey = assignments.get(target.getUniqueId());
+                final TeamTemplate template = resolveTemplateByKey(teamKey);
+                if (template == null) {
+                    continue;
+                }
+                addEntryToTeam(scoreboard, target.getName(), template);
+            }
+        }
+    }
+
+    private void addEntryToTeam(final Scoreboard scoreboard, final String entry, final TeamTemplate template) {
+        Team team = scoreboard.getTeam(template.key());
+        if (team == null) {
+            team = scoreboard.registerNewTeam(template.key());
+        }
+        template.apply(team);
+        if (!team.hasEntry(entry)) {
+            team.addEntry(entry);
+        }
+    }
+
+    private void removeEntryFromTeam(final Scoreboard scoreboard, final String entry, final String teamKey) {
+        final Team team = teamKey != null ? scoreboard.getTeam(teamKey) : null;
+        if (team == null) {
+            return;
+        }
+        if (team.hasEntry(entry)) {
+            team.removeEntry(entry);
+        }
+        if (team.getEntries().isEmpty() && team.getName().startsWith(TEAM_PREFIX)) {
+            team.unregister();
+        }
+    }
+
+    private void clearTeams(final Scoreboard scoreboard) {
+        final Set<Team> teamsToRemove = new HashSet<>();
+        for (Team team : scoreboard.getTeams()) {
+            if (team.getName().startsWith(TEAM_PREFIX)) {
+                teamsToRemove.add(team);
+            }
+        }
+        for (Team team : teamsToRemove) {
+            team.unregister();
+        }
+    }
+
+    private TeamTemplate resolveTemplate(final String primaryGroup) {
+        if (primaryGroup != null && !primaryGroup.isBlank()) {
+            final TeamTemplate template = templates.get(primaryGroup.toLowerCase(Locale.ROOT));
+            if (template != null) {
+                return template;
+            }
+        }
+        if (defaultTemplate == null) {
+            defaultTemplate = createFallbackTemplate();
+        }
+        return defaultTemplate;
+    }
+
+    private TeamTemplate resolveTemplateByKey(final String key) {
+        if (key == null) {
+            return null;
+        }
+        for (TeamTemplate template : templates.values()) {
+            if (template.key().equals(key)) {
+                return template;
+            }
+        }
+        if (defaultTemplate != null && defaultTemplate.key().equals(key)) {
+            return defaultTemplate;
+        }
+        return null;
+    }
+
+    private TeamTemplate createTemplateForGroup(final Group group, final int order) {
+        final String rawPrefix = resolveGroupPrefix(group);
+        final String prefix = rawPrefix.isBlank() ? "" : appendSpace(rawPrefix);
+        final ChatColor color = resolveGroupColor(group, rawPrefix);
+        final String teamKey = createTeamKey(order, group.getName());
+        return new TeamTemplate(teamKey, prefix, color);
+    }
+
+    private String resolveGroupPrefix(final Group group) {
+        if (group == null || queryOptions == null) {
+            return "";
+        }
+        final CachedMetaData metaData = group.getCachedData().getMetaData(queryOptions);
+        if (metaData == null) {
+            return "";
+        }
+        final String prefix = metaData.getPrefix();
+        if (prefix == null || prefix.isBlank()) {
+            return "";
+        }
+        return ChatColor.translateAlternateColorCodes('&', prefix);
+    }
+
+    private ChatColor resolveGroupColor(final Group group, final String prefix) {
+        ChatColor color = extractColorFromPrefix(prefix);
+        if (group == null || queryOptions == null) {
+            return color;
+        }
+        final CachedMetaData metaData = group.getCachedData().getMetaData(queryOptions);
+        if (metaData == null) {
+            return color;
+        }
+        final String metaColor = metaData.getMetaValue("color");
+        final ChatColor resolved = parseColor(metaColor);
+        return resolved != null ? resolved : color;
+    }
+
+    private ChatColor parseColor(final String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        final String trimmed = value.trim();
+        try {
+            if (trimmed.startsWith("#")) {
+                return ChatColor.of(trimmed);
+            }
+        } catch (final IllegalArgumentException ignored) {
+            return null;
+        }
+        if (trimmed.length() == 2 && trimmed.charAt(0) == ChatColor.COLOR_CHAR) {
+            final ChatColor color = ChatColor.getByChar(trimmed.charAt(1));
+            if (color != null && color.isColor()) {
+                return color;
+            }
+        }
+        try {
+            final ChatColor color = ChatColor.valueOf(trimmed.toUpperCase(Locale.ROOT));
+            return color.isColor() ? color : null;
+        } catch (final IllegalArgumentException ignored) {
+            // Fallback handled by caller.
+        }
+        if (trimmed.length() == 2 && trimmed.charAt(0) == '&') {
+            final ChatColor color = ChatColor.getByChar(trimmed.charAt(1));
+            if (color != null && color.isColor()) {
+                return color;
+            }
+        }
+        return null;
+    }
+
+    private ChatColor extractColorFromPrefix(final String prefix) {
+        if (prefix == null || prefix.isBlank()) {
+            return ChatColor.WHITE;
+        }
+        for (int index = prefix.length() - 1; index >= 0; index--) {
+            if (prefix.charAt(index) != ChatColor.COLOR_CHAR || index + 1 >= prefix.length()) {
+                continue;
+            }
+            final char code = Character.toLowerCase(prefix.charAt(index + 1));
+            final ChatColor color = ChatColor.getByChar(code);
+            if (color != null && color.isColor()) {
+                return color;
+            }
+        }
+        return ChatColor.WHITE;
+    }
+
+    private TeamTemplate createFallbackTemplate() {
+        final String key = createTeamKey(999, "default");
+        final String prefix = appendSpace(ChatColor.GRAY + "Joueur");
+        return new TeamTemplate(key, prefix, ChatColor.WHITE);
+    }
+
+    private String createTeamKey(final int order, final String groupName) {
+        final String number = String.format("%03d", Math.max(0, Math.min(order, 999)));
+        final String sanitized = sanitizeGroupName(groupName);
+        final int remaining = TEAM_NAME_MAX_LENGTH - TEAM_PREFIX.length() - number.length();
+        final String trimmed = sanitized.length() > remaining ? sanitized.substring(0, remaining) : sanitized;
+        return TEAM_PREFIX + number + trimmed;
+    }
+
+    private String sanitizeGroupName(final String input) {
+        if (input == null || input.isBlank()) {
+            return "grp";
+        }
+        final StringBuilder builder = new StringBuilder();
+        for (int index = 0; index < input.length(); index++) {
+            final char character = Character.toLowerCase(input.charAt(index));
+            if ((character >= 'a' && character <= 'z') || (character >= '0' && character <= '9')) {
+                builder.append(character);
+            }
+        }
+        if (builder.length() == 0) {
+            return "grp";
+        }
+        return builder.toString();
+    }
+
+    private String appendSpace(final String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        return value.endsWith(" ") ? value : value + ' ';
+    }
+
+    private record TeamTemplate(String key, String prefix, ChatColor color) {
+
+        private void apply(final Team team) {
+            if (team == null) {
+                return;
+            }
+            if (!Objects.equals(team.getPrefix(), prefix)) {
+                team.setPrefix(prefix);
+            }
+            team.setSuffix("");
+            if (color != null) {
+                team.setColor(color);
+            }
+            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.ALWAYS);
+        }
+    }
+}

--- a/src/main/java/com/lobby/tablist/PlayerTablistData.java
+++ b/src/main/java/com/lobby/tablist/PlayerTablistData.java
@@ -4,9 +4,9 @@ package com.lobby.tablist;
  * Immutable container representing the LuckPerms related data used to render the
  * tablist for a player.
  */
-record PlayerTablistData(String prefix, String suffix, int weight) {
+record PlayerTablistData(String prefix, String suffix, int weight, String primaryGroup) {
 
     static PlayerTablistData empty() {
-        return new PlayerTablistData("", "", 0);
+        return new PlayerTablistData("", "", 0, null);
     }
 }

--- a/src/main/java/com/lobby/tablist/TablistManager.java
+++ b/src/main/java/com/lobby/tablist/TablistManager.java
@@ -53,6 +53,7 @@ public final class TablistManager implements Listener {
     private final ServerPlaceholderCache serverPlaceholderCache;
     private final VelocityManager velocityManager;
     private final LuckPermsTablistResolver luckPermsResolver;
+    private final NametagManager nametagManager;
     private final ScoreboardAnimation footerAnimation = new ScoreboardAnimation(List.of(""));
     private final AtomicReference<TablistSettings> settings = new AtomicReference<>();
     private final Set<UUID> trackedPlayers = ConcurrentHashMap.newKeySet();
@@ -69,6 +70,7 @@ public final class TablistManager implements Listener {
         this.serverPlaceholderCache = plugin.getServerPlaceholderCache();
         this.velocityManager = plugin.getVelocityManager();
         this.luckPermsResolver = new LuckPermsTablistResolver(plugin, ChatColor.GRAY + "Joueur");
+        this.nametagManager = plugin.getNametagManager();
         reload();
     }
 
@@ -220,6 +222,9 @@ public final class TablistManager implements Listener {
             final Component footer = renderFooter(footerFrame, placeholders);
             player.sendPlayerListHeaderAndFooter(header, footer);
             applyPlayerListName(player, current.playerNameFormat(), placeholders);
+            if (nametagManager != null) {
+                nametagManager.applyNametag(player, entry.data());
+            }
         }
     }
 
@@ -295,13 +300,51 @@ public final class TablistManager implements Listener {
                                                   final PlayerTablistData data,
                                                   final int networkPlayers) {
         final Map<String, String> placeholders = new HashMap<>();
+        final String prefix = Optional.ofNullable(data.prefix()).orElse("");
         placeholders.put("%player_name%", player.getName());
         placeholders.put("%player_ping%", Integer.toString(player.getPing()));
-        placeholders.put("%luckperms_prefix%", Optional.ofNullable(data.prefix()).orElse(""));
+        placeholders.put("%luckperms_prefix%", prefix);
         placeholders.put("%luckperms_suffix%", Optional.ofNullable(data.suffix()).orElse(""));
+        placeholders.put("%luckperms_primary_group%", Optional.ofNullable(data.primaryGroup()).orElse(""));
+        placeholders.put("%luckperms_primary_color%", extractNameColor(prefix));
         placeholders.put("%server_id%", serverId);
         placeholders.put("%bungee_total%", NUMBER_FORMAT.format(networkPlayers));
         return placeholders;
+    }
+
+    private String extractNameColor(final String prefix) {
+        if (prefix == null || prefix.isBlank()) {
+            return "&f";
+        }
+        for (int index = prefix.length() - 1; index >= 0; index--) {
+            if (prefix.charAt(index) != ChatColor.COLOR_CHAR || index + 1 >= prefix.length()) {
+                continue;
+            }
+            final char code = Character.toLowerCase(prefix.charAt(index + 1));
+            if (code == 'x') {
+                if ((index + 13) < prefix.length()) {
+                    final StringBuilder builder = new StringBuilder("&#");
+                    boolean valid = true;
+                    for (int offset = 2; offset <= 12; offset += 2) {
+                        final int sectionIndex = index + offset;
+                        if (sectionIndex + 1 >= prefix.length() || prefix.charAt(sectionIndex) != ChatColor.COLOR_CHAR) {
+                            valid = false;
+                            break;
+                        }
+                        builder.append(Character.toLowerCase(prefix.charAt(sectionIndex + 1)));
+                    }
+                    if (valid && builder.length() == 8) {
+                        return builder.toString();
+                    }
+                }
+                continue;
+            }
+            final ChatColor color = ChatColor.getByChar(code);
+            if (color != null && color.isColor()) {
+                return "&" + code;
+            }
+        }
+        return "&f";
     }
 
     private void applyPlayerListName(final Player player,
@@ -388,6 +431,9 @@ public final class TablistManager implements Listener {
         trackedPlayers.clear();
         lastKnownNames.clear();
         dataCache.clear();
+        if (nametagManager != null) {
+            nametagManager.clearAll();
+        }
     }
 
     private void resetPlayer(final Player player) {
@@ -396,6 +442,9 @@ public final class TablistManager implements Listener {
         final Scoreboard scoreboard = player.getScoreboard();
         if (scoreboard != null) {
             cleanupTablistTeams(scoreboard);
+        }
+        if (nametagManager != null) {
+            nametagManager.removePlayer(player);
         }
     }
 
@@ -424,7 +473,8 @@ public final class TablistManager implements Listener {
         final long updateInterval = Math.max(1L, section.getLong("update-interval-ticks", 40L));
         final List<String> header = section.getStringList("header");
         final List<String> footerFrames = section.getStringList("footer-animation-frames");
-        final String nameFormat = section.getString("player-name-format", "%luckperms_prefix%%player_name%");
+        final String nameFormat = section.getString("player-name-format",
+                "%luckperms_prefix%%luckperms_primary_color%%player_name%");
         final boolean sort = section.getBoolean("sort-players-by-luckperms-weight", false);
         return new TablistSettings(enabled, updateInterval,
                 header == null ? List.of() : List.copyOf(header),
@@ -481,7 +531,7 @@ public final class TablistManager implements Listener {
             return new TablistSettings(true, 40L,
                     List.of("&r", "&3&lHENERIA NETWORK", "&7Bienvenue sur nos serveurs, &b%player_name%&7!", "&r"),
                     List.of(""),
-                    "%luckperms_prefix%%player_name%",
+                    "%luckperms_prefix%%luckperms_primary_color%%player_name%",
                     true);
         }
 

--- a/src/main/java/com/lobby/utils/ItemSerializationUtils.java
+++ b/src/main/java/com/lobby/utils/ItemSerializationUtils.java
@@ -1,0 +1,53 @@
+package com.lobby.utils;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+/**
+ * Utility methods to serialize and deserialize {@link ItemStack} instances to
+ * and from Base64 strings so they can be stored in the database.
+ */
+public final class ItemSerializationUtils {
+
+    private ItemSerializationUtils() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static String serializeItem(final ItemStack item) {
+        if (item == null || item.getType() == Material.AIR) {
+            return null;
+        }
+        try (ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+             BukkitObjectOutputStream dataOutput = new BukkitObjectOutputStream(byteStream)) {
+            dataOutput.writeObject(item);
+            dataOutput.flush();
+            return Base64.getEncoder().encodeToString(byteStream.toByteArray());
+        } catch (final IOException exception) {
+            throw new IllegalStateException("Failed to serialize item stack", exception);
+        }
+    }
+
+    public static ItemStack deserializeItem(final String base64) {
+        if (base64 == null || base64.isBlank()) {
+            return null;
+        }
+        final byte[] data = Base64.getDecoder().decode(base64);
+        try (ByteArrayInputStream byteStream = new ByteArrayInputStream(data);
+             BukkitObjectInputStream dataInput = new BukkitObjectInputStream(byteStream)) {
+            final Object object = dataInput.readObject();
+            if (object instanceof ItemStack item) {
+                return item;
+            }
+        } catch (final IOException | ClassNotFoundException exception) {
+            throw new IllegalStateException("Failed to deserialize item stack", exception);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- derive player name colours from LuckPerms prefixes and expose them to the tablist, notifying a new nametag manager on each refresh
- introduce a NametagManager that prepares LuckPerms group teams and keeps scoreboard nametags in sync for every viewer
- persist NPC main/off-hand equipment by extending the schema, serialising items, restoring them on spawn and updating the equip command to save changes

## Testing
- `mvn -q -DskipTests package` *(fails: Maven repository unreachable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4206c33d4832996b1d101c52deaea