### PR TITLE
Fix missing Scoreboard import

### DIFF
--- a/src/main/java/com/lobby/tablist/NametagManager.java
+++ b/src/main/java/com/lobby/tablist/NametagManager.java
@@ -7,8 +7,8 @@ import net.luckperms.api.model.group.Group;
 import net.luckperms.api.query.QueryOptions;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.Scoreboard;
 import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 
 import java.util.ArrayList;


### PR DESCRIPTION
## Summary
- import the Bukkit Scoreboard class from the correct package used in the nametag manager

## Testing
- mvn -q -DskipTests package *(fails: network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d42674a2908329a78722c94c92de14