### PR TITLE
Fix tablist player name color

### DIFF
--- a/src/main/resources/tablist.yml
+++ b/src/main/resources/tablist.yml
@@ -44,7 +44,7 @@ tablist:
   # ============================================================
   # Contrôle l'apparence des joueurs dans la liste.
   # Placeholders disponibles : %luckperms_prefix%, %player_name%, %luckperms_suffix%
-  player-name-format: '%luckperms_prefix%&f%player_name%'
+  player-name-format: '%luckperms_prefix% %player_name%'
   
   # Optionnel : Trier les joueurs dans la tablist en fonction de leur groupe LuckPerms.
   # Les groupes avec le poids le plus élevé (ex: admin) apparaîtront en haut.


### PR DESCRIPTION
## Summary
- remove the hardcoded white color code from the player name format so LuckPerms colors persist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d42b3668588329a1aba42c56443109