### PR TITLE
feat: refactor social menus configuration

### DIFF
--- a/src/main/java/com/lobby/menus/AssetManager.java
+++ b/src/main/java/com/lobby/menus/AssetManager.java
@@ -5,10 +5,16 @@ import com.lobby.heads.HeadDatabaseManager;
 import com.lobby.servers.ServerPlaceholderCache;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitTask;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -118,12 +124,16 @@ public class AssetManager {
     }
 
     private void preloadHeadsAsync() {
+        final Set<String> headIds = discoverHeadIds();
+        if (headIds.isEmpty()) {
+            return;
+        }
         headPreloadTask = Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             final HeadDatabaseManager headDatabaseManager = plugin.getHeadDatabaseManager();
             if (headDatabaseManager == null) {
                 return;
             }
-            for (String headId : PRELOADED_HEADS) {
+            for (String headId : headIds) {
                 if (headId == null || headId.isBlank()) {
                     continue;
                 }
@@ -152,6 +162,69 @@ public class AssetManager {
                 plugin.getLogger().warning("Failed to refresh menu placeholder cache: " + exception.getMessage());
             }
         }, 20L, 40L);
+    }
+
+    private Set<String> discoverHeadIds() {
+        final Set<String> headIds = new HashSet<>(PRELOADED_HEADS);
+        headIds.addAll(scanConfiguredHeadIds());
+        return headIds;
+    }
+
+    private Set<String> scanConfiguredHeadIds() {
+        final Set<String> collected = new HashSet<>();
+        final File menusDirectory = new File(plugin.getDataFolder(), "config/menus");
+        if (!menusDirectory.exists() || !menusDirectory.isDirectory()) {
+            return collected;
+        }
+        final File[] files = menusDirectory.listFiles((dir, name) -> name != null && name.endsWith(".yml"));
+        if (files == null || files.length == 0) {
+            return collected;
+        }
+        for (File file : files) {
+            final YamlConfiguration configuration = new YamlConfiguration();
+            try {
+                configuration.load(file);
+                collectHeadIdentifiers(configuration, collected);
+            } catch (IOException | InvalidConfigurationException exception) {
+                plugin.getLogger().warning("Unable to parse menu configuration '" + file.getName() + "': "
+                        + exception.getMessage());
+            }
+        }
+        return collected;
+    }
+
+    private void collectHeadIdentifiers(final ConfigurationSection section, final Set<String> sink) {
+        if (section == null || sink == null) {
+            return;
+        }
+        for (String key : section.getKeys(false)) {
+            final Object value = section.get(key);
+            if (value instanceof ConfigurationSection nested) {
+                collectHeadIdentifiers(nested, sink);
+            } else if (value instanceof String stringValue) {
+                addHeadIfValid(stringValue, sink);
+            } else if (value instanceof Iterable<?> iterable) {
+                for (Object element : iterable) {
+                    if (element instanceof String stringElement) {
+                        addHeadIfValid(stringElement, sink);
+                    }
+                }
+            }
+        }
+    }
+
+    private void addHeadIfValid(final String rawValue, final Set<String> sink) {
+        if (rawValue == null || sink == null) {
+            return;
+        }
+        final String trimmed = rawValue.trim();
+        if (trimmed.isEmpty()) {
+            return;
+        }
+        final String normalized = trimmed.toLowerCase(Locale.ROOT);
+        if (normalized.startsWith("hdb:")) {
+            sink.add(normalized);
+        }
     }
 
     private ItemStack loadHeadInternal(final String identifier) {

--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -51,6 +51,8 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
     private final Component title;
     private final int size;
     private final List<MenuItemDefinition> items;
+    private final MenuRenderContext renderContext;
+    private final Map<String, String> additionalPlaceholders;
 
     private final Map<Integer, MenuAction> actions = new HashMap<>();
     private Inventory inventory;
@@ -61,7 +63,9 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
                            final String menuId,
                            final Component title,
                            final int size,
-                           final List<MenuItemDefinition> items) {
+                           final List<MenuItemDefinition> items,
+                           final MenuRenderContext renderContext,
+                           final Map<String, String> additionalPlaceholders) {
         this.plugin = plugin;
         this.menuManager = menuManager;
         this.assetManager = assetManager;
@@ -69,12 +73,27 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
         this.title = title;
         this.size = size;
         this.items = items;
+        this.renderContext = renderContext == null ? MenuRenderContext.EMPTY : renderContext;
+        if (additionalPlaceholders == null || additionalPlaceholders.isEmpty()) {
+            this.additionalPlaceholders = Map.of();
+        } else {
+            this.additionalPlaceholders = Collections.unmodifiableMap(new HashMap<>(additionalPlaceholders));
+        }
     }
 
     public static ConfiguredMenu fromConfiguration(final LobbyPlugin plugin,
                                                    final MenuManager menuManager,
                                                    final AssetManager assetManager,
                                                    final String menuId) {
+        return fromConfiguration(plugin, menuManager, assetManager, menuId, Map.of(), MenuRenderContext.EMPTY);
+    }
+
+    public static ConfiguredMenu fromConfiguration(final LobbyPlugin plugin,
+                                                   final MenuManager menuManager,
+                                                   final AssetManager assetManager,
+                                                   final String menuId,
+                                                   final Map<String, String> extraPlaceholders,
+                                                   final MenuRenderContext renderContext) {
         if (plugin == null || menuId == null || menuId.isBlank()) {
             return null;
         }
@@ -99,41 +118,31 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
         final int requestedSize = configuration.getInt("size", MAX_INVENTORY_SIZE);
         final int size = normalizeInventorySize(requestedSize);
 
+        final List<MenuItemDefinition> definitions = new ArrayList<>();
+        appendDesignItems(plugin, menuId, configuration.getConfigurationSection("design"), definitions);
+
         final ConfigurationSection itemsSection = configuration.getConfigurationSection("items");
         if (itemsSection == null) {
             plugin.getLogger().warning("Menu '" + menuId + "' does not define an items section.");
             return null;
         }
 
-        final List<MenuItemDefinition> definitions = new ArrayList<>();
         for (String key : itemsSection.getKeys(false)) {
             final ConfigurationSection itemSection = itemsSection.getConfigurationSection(key);
             if (itemSection == null) {
                 continue;
             }
-            final List<Integer> slots = resolveSlots(itemSection);
-            if (slots.isEmpty()) {
-                plugin.getLogger().warning("Menu '" + menuId + "' item '" + key + "' does not specify any slot.");
-                continue;
+            final MenuItemDefinition definition = parseItemDefinition(plugin, menuId, key, itemSection);
+            if (definition != null) {
+                definitions.add(definition);
             }
-            final String material = itemSection.getString("material", "BARRIER");
-            final String name = itemSection.getString("name", "&r");
-            final List<String> lore = itemSection.getStringList("lore");
-            final String actionValue = itemSection.getString("action");
-            final int amount = Math.max(1, Math.min(64, itemSection.getInt("amount", 1)));
-            final String skullOwner = itemSection.getString("skull-owner");
-            final boolean usePlayerHead = itemSection.getBoolean("player-head", false)
-                    || "PLAYER_HEAD".equalsIgnoreCase(material);
-            final MenuAction action = MenuAction.parse(actionValue);
-            definitions.add(new MenuItemDefinition(slots, material, name, lore, action, amount, usePlayerHead,
-                    skullOwner));
         }
 
         if (definitions.isEmpty()) {
             plugin.getLogger().warning("Menu '" + menuId + "' does not define any items.");
         }
         return new ConfiguredMenu(plugin, menuManager, assetManager, menuId, title, size,
-                Collections.unmodifiableList(definitions));
+                Collections.unmodifiableList(definitions), renderContext, extraPlaceholders);
     }
 
     @Override
@@ -146,8 +155,14 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
 
         final ItemStack[] contents = new ItemStack[size];
         final Map<String, String> placeholders = buildPlaceholderMap(player);
+        if (!additionalPlaceholders.isEmpty()) {
+            placeholders.putAll(additionalPlaceholders);
+        }
 
         for (MenuItemDefinition definition : items) {
+            if (!definition.condition().isSatisfied(renderContext)) {
+                continue;
+            }
             final ItemStack baseItem = definition.createItem(assetManager, player, placeholders);
             if (baseItem == null) {
                 continue;
@@ -227,6 +242,54 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
         return placeholders;
     }
 
+    private static void appendDesignItems(final LobbyPlugin plugin,
+                                          final String menuId,
+                                          final ConfigurationSection designSection,
+                                          final List<MenuItemDefinition> definitions) {
+        if (designSection == null) {
+            return;
+        }
+        final ConfigurationSection primary = designSection.getConfigurationSection("primary_border");
+        if (primary != null) {
+            final MenuItemDefinition definition = parseItemDefinition(plugin, menuId,
+                    "design-primary-border", primary);
+            if (definition != null) {
+                definitions.add(definition);
+            }
+        }
+        final ConfigurationSection secondary = designSection.getConfigurationSection("secondary_border");
+        if (secondary != null) {
+            final MenuItemDefinition definition = parseItemDefinition(plugin, menuId,
+                    "design-secondary-border", secondary);
+            if (definition != null) {
+                definitions.add(definition);
+            }
+        }
+    }
+
+    private static MenuItemDefinition parseItemDefinition(final LobbyPlugin plugin,
+                                                          final String menuId,
+                                                          final String itemId,
+                                                          final ConfigurationSection section) {
+        final List<Integer> slots = resolveSlots(section);
+        if (slots.isEmpty()) {
+            plugin.getLogger().warning("Menu '" + menuId + "' item '" + itemId + "' does not specify any slot.");
+            return null;
+        }
+        final String material = section.getString("material", "BARRIER");
+        final String name = section.getString("name", "&r");
+        final List<String> lore = section.getStringList("lore");
+        final String actionValue = section.getString("action");
+        final int amount = Math.max(1, Math.min(64, section.getInt("amount", 1)));
+        final String skullOwner = section.getString("skull-owner");
+        final boolean usePlayerHead = section.getBoolean("player-head", false)
+                || "PLAYER_HEAD".equalsIgnoreCase(material);
+        final MenuAction action = MenuAction.parse(actionValue);
+        final MenuItemCondition condition = MenuItemCondition.fromSection(section.getConfigurationSection("conditions"));
+        return new MenuItemDefinition(itemId, slots, material, name, lore, action, amount, usePlayerHead,
+                skullOwner, condition);
+    }
+
     private static File resolveMenuFile(final LobbyPlugin plugin, final String menuId) {
         final File menusDirectory = new File(plugin.getDataFolder(), "config/menus");
         if (!menusDirectory.exists() && !menusDirectory.mkdirs()) {
@@ -302,14 +365,16 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
         }
     }
 
-    private record MenuItemDefinition(List<Integer> slots,
+    private record MenuItemDefinition(String id,
+                                      List<Integer> slots,
                                       String materialKey,
                                       String displayName,
                                       List<String> lore,
                                       MenuAction action,
                                       int amount,
                                       boolean playerHead,
-                                      String skullOwner) {
+                                      String skullOwner,
+                                      MenuItemCondition condition) {
 
         private ItemStack createItem(final AssetManager assetManager,
                                      final Player player,
@@ -380,6 +445,60 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
                 result = result.replace(entry.getKey(), entry.getValue());
             }
             return result;
+        }
+    }
+
+    private enum Requirement {
+        ANY,
+        MEMBER,
+        NONE,
+        LEADER;
+
+        private static Requirement fromString(final String raw) {
+            if (raw == null || raw.isBlank()) {
+                return ANY;
+            }
+            final String normalized = raw.trim().toLowerCase(Locale.ROOT);
+            return switch (normalized) {
+                case "member", "present", "oui", "yes", "true" -> MEMBER;
+                case "leader", "chef" -> LEADER;
+                case "none", "absent", "no", "false" -> NONE;
+                default -> ANY;
+            };
+        }
+
+        private boolean isSatisfied(final boolean has, final boolean leader) {
+            return switch (this) {
+                case ANY -> true;
+                case MEMBER -> has;
+                case NONE -> !has;
+                case LEADER -> leader;
+            };
+        }
+    }
+
+    private record MenuItemCondition(Requirement groupRequirement, Requirement clanRequirement) {
+
+        private static final MenuItemCondition NONE = new MenuItemCondition(Requirement.ANY, Requirement.ANY);
+
+        private static MenuItemCondition fromSection(final ConfigurationSection section) {
+            if (section == null) {
+                return NONE;
+            }
+            final Requirement group = Requirement.fromString(section.getString("group"));
+            final Requirement clan = Requirement.fromString(section.getString("clan"));
+            if (group == Requirement.ANY && clan == Requirement.ANY) {
+                return NONE;
+            }
+            return new MenuItemCondition(group, clan);
+        }
+
+        private boolean isSatisfied(final MenuRenderContext context) {
+            if (context == null) {
+                return groupRequirement == Requirement.ANY && clanRequirement == Requirement.ANY;
+            }
+            return groupRequirement.isSatisfied(context.hasGroup(), context.groupLeader())
+                    && clanRequirement.isSatisfied(context.hasClan(), context.clanLeader());
         }
     }
 }

--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -31,20 +31,38 @@ public class MenuManager {
     }
 
     public boolean openMenu(final Player player, final String rawMenuId) {
+        return openMenu(player, rawMenuId, Map.of(), MenuRenderContext.EMPTY);
+    }
+
+    public boolean openMenu(final Player player,
+                            final String rawMenuId,
+                            final Map<String, String> placeholders) {
+        return openMenu(player, rawMenuId, placeholders, MenuRenderContext.EMPTY);
+    }
+
+    public boolean openMenu(final Player player,
+                            final String rawMenuId,
+                            final Map<String, String> placeholders,
+                            final MenuRenderContext context) {
         if (player == null || rawMenuId == null || rawMenuId.isBlank()) {
             return false;
         }
         final String menuId = rawMenuId.toLowerCase(Locale.ROOT);
 
         if (isSimpleMenu(menuId)) {
-            return buildAndOpenSimpleMenu(player, menuId);
+            return buildAndOpenSimpleMenu(player, menuId, placeholders, context);
         }
 
         if (isHeavyMenu(menuId)) {
-            return buildAndOpenHeavyMenu(player, menuId);
+            return buildAndOpenHeavyMenu(player, menuId, placeholders, context);
         }
 
-        return false;
+        final Menu menu = ConfiguredMenu.fromConfiguration(plugin, this, assetManager, menuId, placeholders, context);
+        if (menu == null) {
+            return false;
+        }
+        displayMenu(player, menu);
+        return true;
     }
 
     public Optional<Menu> getOpenMenu(final UUID uuid) {
@@ -102,8 +120,11 @@ public class MenuManager {
         };
     }
 
-    private boolean buildAndOpenSimpleMenu(final Player player, final String menuId) {
-        final Menu menu = ConfiguredMenu.fromConfiguration(plugin, this, assetManager, menuId);
+    private boolean buildAndOpenSimpleMenu(final Player player,
+                                           final String menuId,
+                                           final Map<String, String> placeholders,
+                                           final MenuRenderContext context) {
+        final Menu menu = ConfiguredMenu.fromConfiguration(plugin, this, assetManager, menuId, placeholders, context);
         if (menu == null) {
             return false;
         }
@@ -111,13 +132,19 @@ public class MenuManager {
         return true;
     }
 
-    private boolean buildAndOpenHeavyMenu(final Player player, final String menuId) {
-        return com.lobby.social.menus.SocialHeavyMenus.open(menuId, this, player)
-                || openConfiguredMenu(player, menuId);
+    private boolean buildAndOpenHeavyMenu(final Player player,
+                                          final String menuId,
+                                          final Map<String, String> placeholders,
+                                          final MenuRenderContext context) {
+        return com.lobby.social.menus.SocialHeavyMenus.open(menuId, this, player, placeholders, context)
+                || openConfiguredMenu(player, menuId, placeholders, context);
     }
 
-    private boolean openConfiguredMenu(final Player player, final String menuId) {
-        final Menu menu = ConfiguredMenu.fromConfiguration(plugin, this, assetManager, menuId);
+    private boolean openConfiguredMenu(final Player player,
+                                       final String menuId,
+                                       final Map<String, String> placeholders,
+                                       final MenuRenderContext context) {
+        final Menu menu = ConfiguredMenu.fromConfiguration(plugin, this, assetManager, menuId, placeholders, context);
         if (menu == null) {
             return false;
         }

--- a/src/main/java/com/lobby/menus/MenuRenderContext.java
+++ b/src/main/java/com/lobby/menus/MenuRenderContext.java
@@ -1,0 +1,23 @@
+package com.lobby.menus;
+
+/**
+ * Represents runtime information used when rendering a configured menu.
+ * Menus can query these flags to decide whether an item should be displayed
+ * for the current player. The context is immutable and can be freely shared
+ * between menu instances.
+ */
+public record MenuRenderContext(boolean hasGroup,
+                                boolean groupLeader,
+                                boolean hasClan,
+                                boolean clanLeader) {
+
+    public static final MenuRenderContext EMPTY = new MenuRenderContext(false, false, false, false);
+
+    public MenuRenderContext withGroup(final boolean present, final boolean leader) {
+        return new MenuRenderContext(present, leader, hasClan, clanLeader);
+    }
+
+    public MenuRenderContext withClan(final boolean present, final boolean leader) {
+        return new MenuRenderContext(hasGroup, groupLeader, present, leader);
+    }
+}

--- a/src/main/java/com/lobby/social/menus/SocialHeavyMenus.java
+++ b/src/main/java/com/lobby/social/menus/SocialHeavyMenus.java
@@ -2,19 +2,19 @@ package com.lobby.social.menus;
 
 import com.lobby.LobbyPlugin;
 import com.lobby.menus.AssetManager;
+import com.lobby.menus.ConfiguredMenu;
 import com.lobby.menus.Menu;
 import com.lobby.menus.MenuManager;
+import com.lobby.menus.MenuRenderContext;
 import com.lobby.social.clans.Clan;
 import com.lobby.social.clans.ClanManager;
-import com.lobby.social.friends.FriendInfo;
 import com.lobby.social.friends.FriendManager;
-import com.lobby.social.groups.Group;
 import com.lobby.social.groups.GroupManager;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -28,16 +28,26 @@ public final class SocialHeavyMenus {
     }
 
     public static boolean open(final String menuId, final MenuManager menuManager, final Player player) {
+        return open(menuId, menuManager, player, Map.of(), MenuRenderContext.EMPTY);
+    }
+
+    public static boolean open(final String menuId,
+                               final MenuManager menuManager,
+                               final Player player,
+                               final Map<String, String> placeholders,
+                               final MenuRenderContext context) {
         return switch (menuId) {
-            case "amis_menu" -> openFriendsMenu(menuManager, player, 0);
-            case "groupe_menu" -> openGroupMenu(menuManager, player);
-            case "clan_menu" -> openClanMenu(menuManager, player);
+            case "amis_menu" -> openFriendsMenu(menuManager, player, placeholders);
+            case "groupe_menu" -> openGroupMenu(menuManager, player, placeholders, context);
+            case "clan_menu" -> openClanMenu(menuManager, player, placeholders, context);
             case "clan_management_menu" -> openClanManagementMenu(menuManager, player);
             default -> false;
         };
     }
 
-    public static boolean openFriendsMenu(final MenuManager menuManager, final Player player, final int page) {
+    public static boolean openFriendsMenu(final MenuManager menuManager,
+                                          final Player player,
+                                          final Map<String, String> additionalPlaceholders) {
         if (menuManager == null || player == null) {
             return false;
         }
@@ -52,16 +62,35 @@ public final class SocialHeavyMenus {
         }
         final UUID uuid = player.getUniqueId();
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            final List<FriendInfo> friends = new ArrayList<>(friendManager.getFriendsList(uuid));
+            final Map<String, String> placeholders = new HashMap<>();
+            if (additionalPlaceholders != null) {
+                placeholders.putAll(additionalPlaceholders);
+            }
             final int requests = friendManager.getPendingRequests(uuid).size();
-            final FriendsMainMenu menu = new FriendsMainMenu(plugin, menuManager, assetManager, friendManager,
-                    friends, requests, page);
-            menuManager.displayMenu(player, menu);
+            final int friends = friendManager.getFriendsList(uuid).size();
+            placeholders.putIfAbsent("%friend_requests_count%", Integer.toString(requests));
+            placeholders.putIfAbsent("%friends_total%", Integer.toString(friends));
+            final ConfiguredMenu menu = ConfiguredMenu.fromConfiguration(plugin, menuManager, assetManager,
+                    "amis_menu", placeholders, MenuRenderContext.EMPTY);
+            if (menu != null) {
+                menuManager.displayMenu(player, menu);
+            }
         });
         return true;
     }
 
+    public static boolean openFriendsMenu(final MenuManager menuManager, final Player player, final int page) {
+        return openFriendsMenu(menuManager, player, Map.of());
+    }
+
     public static boolean openGroupMenu(final MenuManager menuManager, final Player player) {
+        return openGroupMenu(menuManager, player, Map.of(), MenuRenderContext.EMPTY);
+    }
+
+    public static boolean openGroupMenu(final MenuManager menuManager,
+                                        final Player player,
+                                        final Map<String, String> additionalPlaceholders,
+                                        final MenuRenderContext baseContext) {
         if (menuManager == null || player == null) {
             return false;
         }
@@ -76,15 +105,39 @@ public final class SocialHeavyMenus {
         }
         final UUID uuid = player.getUniqueId();
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            final Group group = groupManager.getPlayerGroup(uuid);
+            final var placeholders = new HashMap<String, String>();
+            if (additionalPlaceholders != null) {
+                placeholders.putAll(additionalPlaceholders);
+            }
+            final var group = groupManager.getPlayerGroup(uuid);
             final int invites = groupManager.countPendingInvitations(uuid);
-            final GroupMenu menu = new GroupMenu(plugin, menuManager, assetManager, groupManager, group, invites, uuid);
-            menuManager.displayMenu(player, menu);
+            placeholders.putIfAbsent("%group_invites_count%", Integer.toString(invites));
+            MenuRenderContext context = baseContext == null ? MenuRenderContext.EMPTY : baseContext;
+            if (group != null) {
+                placeholders.putIfAbsent("%group_name%", group.getDisplayName());
+                placeholders.putIfAbsent("%group_members_count%", Integer.toString(group.getSize()));
+                placeholders.putIfAbsent("%group_max_members%", Integer.toString(group.getMaxSize()));
+                context = context.withGroup(true, group.isLeader(uuid));
+            } else {
+                context = context.withGroup(false, false);
+            }
+            final ConfiguredMenu menu = ConfiguredMenu.fromConfiguration(plugin, menuManager, assetManager,
+                    "groupe_menu", placeholders, context);
+            if (menu != null) {
+                menuManager.displayMenu(player, menu);
+            }
         });
         return true;
     }
 
     public static boolean openClanMenu(final MenuManager menuManager, final Player player) {
+        return openClanMenu(menuManager, player, Map.of(), MenuRenderContext.EMPTY);
+    }
+
+    public static boolean openClanMenu(final MenuManager menuManager,
+                                       final Player player,
+                                       final Map<String, String> additionalPlaceholders,
+                                       final MenuRenderContext baseContext) {
         if (menuManager == null || player == null) {
             return false;
         }
@@ -99,9 +152,25 @@ public final class SocialHeavyMenus {
         }
         final UUID uuid = player.getUniqueId();
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final var placeholders = new HashMap<String, String>();
+            if (additionalPlaceholders != null) {
+                placeholders.putAll(additionalPlaceholders);
+            }
             final Clan clan = clanManager.getPlayerClan(uuid);
-            final ClanMenu menu = new ClanMenu(plugin, menuManager, assetManager, clanManager, clan, uuid);
-            menuManager.displayMenu(player, menu);
+            MenuRenderContext context = baseContext == null ? MenuRenderContext.EMPTY : baseContext;
+            if (clan != null) {
+                placeholders.putIfAbsent("%clan_name%", clan.getName());
+                placeholders.putIfAbsent("%clan_members_count%", Integer.toString(clan.getMembers().size()));
+                placeholders.putIfAbsent("%clan_level%", Integer.toString(clan.getLevel()));
+                context = context.withClan(true, clan.isLeader(uuid));
+            } else {
+                context = context.withClan(false, false);
+            }
+            final ConfiguredMenu menu = ConfiguredMenu.fromConfiguration(plugin, menuManager, assetManager,
+                    "clan_menu", placeholders, context);
+            if (menu != null) {
+                menuManager.displayMenu(player, menu);
+            }
         });
         return true;
     }

--- a/src/main/resources/config/menus/amis_menu.yml
+++ b/src/main/resources/config/menus/amis_menu.yml
@@ -1,0 +1,60 @@
+title: '&8» &aMes Amis'
+size: 54
+design:
+  primary_border:
+    material: 'LIME_STAINED_GLASS_PANE'
+    slots: [0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 46, 52, 53]
+  secondary_border:
+    material: 'GRAY_STAINED_GLASS_PANE'
+    slots: [39, 40, 41]
+items:
+  ajouter-ami:
+    slot: 3
+    material: 'hdb:23533'
+    name: '&a&lAjouter un Ami'
+    lore:
+      - '&r'
+      - '&7Utilisez la commande &e/amis add'
+      - '&7pour envoyer une demande.'
+      - '&r'
+      - '&b▸ Statut : &aOuvert'
+      - '&r'
+      - '&e▶ Tapez la commande dans le chat'
+  demandes-recues:
+    slot: 7
+    material: 'hdb:23528'
+    name: '&e&lDemandes Reçues'
+    lore:
+      - '&r'
+      - '&7Gérez les demandes d''amis que'
+      - '&7vous avez reçues.'
+      - '&r'
+      - '&b▸ Statut : &6%friend_requests_count% en attente'
+      - '&r'
+      - '&e▶ Cliquez pour voir'
+    action: '[MENU] friend_requests_menu'
+  liste-amis-overview:
+    slot: 22
+    material: 'hdb:31405'
+    name: '&b&lMes Compagnons'
+    lore:
+      - '&r'
+      - '&7Consultez la liste complète de vos'
+      - '&7alliés dans les menus dédiés.'
+      - '&r'
+      - '&b▸ Statut : &a%friends_total% amis'
+      - '&r'
+      - '&e▶ Explorez votre carnet'
+  retour-profil:
+    slot: 50
+    material: 'hdb:9334'
+    name: '&c&lRetour au Profil'
+    lore:
+      - '&r'
+      - '&7Revenez à votre espace personnel'
+      - '&7pour gérer l''ensemble des menus.'
+      - '&r'
+      - '&b▸ Statut : &aToujours disponible'
+      - '&r'
+      - '&e▶ Cliquez pour revenir'
+    action: '[MENU] profil_menu'

--- a/src/main/resources/config/menus/clan_menu.yml
+++ b/src/main/resources/config/menus/clan_menu.yml
@@ -1,0 +1,83 @@
+title: '&8» &9Mon Clan'
+size: 54
+design:
+  primary_border:
+    material: 'BLUE_STAINED_GLASS_PANE'
+    slots: [0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 46, 52, 53]
+  secondary_border:
+    material: 'GRAY_STAINED_GLASS_PANE'
+    slots: [39, 40, 41]
+items:
+  creer-clan:
+    slot: 21
+    material: 'hdb:8971'
+    name: '&a&lCréer un Clan'
+    lore:
+      - '&r'
+      - '&7Fondez votre propre clan et'
+      - '&7bâtissez une communauté soudée.'
+      - '&r'
+      - '&b▸ Coût : &e50 000 Coins'
+      - '&r'
+      - '&e▶ Cliquez pour créer'
+    action: '[COMMAND] clan create'
+    conditions:
+      clan: 'none'
+  rechercher-clan:
+    slot: 23
+    material: 'hdb:41680'
+    name: '&b&lRechercher un Clan'
+    lore:
+      - '&r'
+      - '&7Explorez les clans existants et'
+      - '&7trouvez celui qui vous correspond.'
+      - '&r'
+      - '&b▸ Statut : &aOuvert à tous'
+      - '&r'
+      - '&e▶ Cliquez pour rechercher'
+    action: '[MENU] clan_list_menu'
+    conditions:
+      clan: 'none'
+  mon-clan:
+    slot: 21
+    material: 'hdb:32038'
+    name: '&9&lInformations du Clan'
+    lore:
+      - '&r'
+      - '&7Accédez aux statistiques et au'
+      - '&7niveau de votre clan actuel.'
+      - '&r'
+      - '&b▸ Statut : &a%clan_members_count% membres'
+      - '&r'
+      - '&e▶ Cliquez pour consulter'
+    action: '[MESSAGE] &7Clan : &b%clan_name%'
+    conditions:
+      clan: 'member'
+  gestion-clan:
+    slot: 23
+    material: 'hdb:47366'
+    name: '&6&lGestion du Clan'
+    lore:
+      - '&r'
+      - '&7Administrez les rôles, les recrutements'
+      - '&7et les améliorations de votre clan.'
+      - '&r'
+      - '&b▸ Statut : &aNiveau &e%clan_level%'
+      - '&r'
+      - '&e▶ Cliquez pour gérer'
+    action: '[MENU] clan_management_menu'
+    conditions:
+      clan: 'leader'
+  retour-profil:
+    slot: 50
+    material: 'hdb:9334'
+    name: '&c&lRetour au Profil'
+    lore:
+      - '&r'
+      - '&7Revenez au menu principal pour'
+      - '&7accéder à vos autres interfaces.'
+      - '&r'
+      - '&b▸ Statut : &aDisponible'
+      - '&r'
+      - '&e▶ Cliquez pour revenir'
+    action: '[MENU] profil_menu'

--- a/src/main/resources/config/menus/groupe_menu.yml
+++ b/src/main/resources/config/menus/groupe_menu.yml
@@ -1,0 +1,98 @@
+title: '&8» &6Mon Groupe'
+size: 54
+design:
+  primary_border:
+    material: 'ORANGE_STAINED_GLASS_PANE'
+    slots: [0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 46, 52, 53]
+  secondary_border:
+    material: 'GRAY_STAINED_GLASS_PANE'
+    slots: [39, 40, 41]
+items:
+  creer-groupe:
+    slot: 22
+    material: 'hdb:9723'
+    name: '&a&lCréer un Groupe'
+    lore:
+      - '&r'
+      - '&7Fondez votre propre groupe et'
+      - '&7invitez vos amis à jouer avec vous.'
+      - '&r'
+      - '&b▸ Statut : &eGratuit'
+      - '&r'
+      - '&e▶ Cliquez pour créer'
+    action: '[COMMAND] party create'
+    conditions:
+      group: 'none'
+  invitations-groupe:
+    slot: 24
+    material: 'hdb:31406'
+    name: '&b&lInvitations en Attente'
+    lore:
+      - '&r'
+      - '&7Consultez les demandes pour'
+      - '&7rejoindre un groupe existant.'
+      - '&r'
+      - '&b▸ Statut : &6%group_invites_count% invitations'
+      - '&r'
+      - '&e▶ Cliquez pour ouvrir'
+    action: '[MENU] party_invites_menu'
+    conditions:
+      group: 'none'
+  mon-groupe-info:
+    slot: 22
+    material: 'hdb:47365'
+    name: '&e&lGestion du Groupe'
+    lore:
+      - '&r'
+      - '&7Surveillez les membres, le chef et'
+      - '&7les capacités actuelles de votre équipe.'
+      - '&r'
+      - '&b▸ Statut : &a%group_members_count%&7/&a%group_max_members%'
+      - '&r'
+      - '&e▶ Cliquez pour gérer'
+    action: '[MENU] party_management_menu'
+    conditions:
+      group: 'member'
+  chat-groupe:
+    slot: 24
+    material: 'hdb:31408'
+    name: '&d&lBasculer sur le Chat Groupe'
+    lore:
+      - '&r'
+      - '&7Activez le canal privé pour'
+      - '&7échanger avec vos compagnons.'
+      - '&r'
+      - '&b▸ Statut : &aDisponible'
+      - '&r'
+      - '&e▶ Cliquez pour parler'
+    action: '[COMMAND] party chat'
+    conditions:
+      group: 'member'
+  quitter-groupe:
+    slot: 31
+    material: 'hdb:31405'
+    name: '&c&lQuitter le Groupe'
+    lore:
+      - '&r'
+      - '&7Libérez votre place pour rejoindre'
+      - '&7une nouvelle équipe quand vous le souhaitez.'
+      - '&r'
+      - '&b▸ Statut : &cAction définitive'
+      - '&r'
+      - '&e▶ Cliquez pour partir'
+    action: '[COMMAND] party leave'
+    conditions:
+      group: 'member'
+  retour-profil:
+    slot: 50
+    material: 'hdb:9334'
+    name: '&c&lRetour au Profil'
+    lore:
+      - '&r'
+      - '&7Revenez sur votre fiche joueur pour'
+      - '&7accéder aux autres options sociales.'
+      - '&r'
+      - '&b▸ Statut : &aAccessible'
+      - '&r'
+      - '&e▶ Cliquez pour revenir'
+    action: '[MENU] profil_menu'


### PR DESCRIPTION
## Summary
- extend the configurable menu engine with design borders, conditional items and runtime placeholders
- add a rendering context plus social heavy menu loaders that build the new config-driven friends, group and clan menus
- preload HeadDatabase assets discovered in menu configurations and ship the new YAML definitions for each social menu

## Testing
- mvn -q -DskipTests package *(fails: cannot reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d4504f67a88329ab56f9e50133c367