### PR TITLE
Implement social menu actions and streamlined join messages

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -137,7 +137,7 @@ public final class LobbyPlugin extends JavaPlugin {
 
         registerCommands();
 
-        getServer().getPluginManager().registerEvents(new PlayerJoinLeaveEvent(this, playerDataManager, economyManager), this);
+        getServer().getPluginManager().registerEvents(new PlayerJoinLeaveEvent(playerDataManager, economyManager), this);
         getServer().getPluginManager().registerEvents(new LobbyPlayerListener(lobbyManager), this);
         getServer().getPluginManager().registerEvents(new LobbyItemListener(lobbyManager, lobbyManager.getItemManager()), this);
         getServer().getPluginManager().registerEvents(new LobbyProtectionListener(lobbyManager), this);

--- a/src/main/java/com/lobby/events/PlayerJoinLeaveEvent.java
+++ b/src/main/java/com/lobby/events/PlayerJoinLeaveEvent.java
@@ -1,27 +1,21 @@
 package com.lobby.events;
 
-import com.lobby.LobbyPlugin;
 import com.lobby.core.PlayerDataManager;
 import com.lobby.economy.EconomyManager;
 import com.lobby.utils.MessageUtils;
-import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
-import java.util.List;
-
 public class PlayerJoinLeaveEvent implements Listener {
 
-    private final LobbyPlugin plugin;
     private final PlayerDataManager playerDataManager;
     private final EconomyManager economyManager;
 
-    public PlayerJoinLeaveEvent(final LobbyPlugin plugin, final PlayerDataManager playerDataManager,
-                                final EconomyManager economyManager) {
-        this.plugin = plugin;
+    public PlayerJoinLeaveEvent(final PlayerDataManager playerDataManager, final EconomyManager economyManager) {
         this.playerDataManager = playerDataManager;
         this.economyManager = economyManager;
     }
@@ -29,30 +23,30 @@ public class PlayerJoinLeaveEvent implements Listener {
     @EventHandler
     public void onPlayerJoin(final PlayerJoinEvent event) {
         final Player player = event.getPlayer();
+        event.setJoinMessage(null);
         playerDataManager.handlePlayerJoin(player);
         if (economyManager != null) {
             economyManager.handlePlayerJoin(player.getUniqueId(), player.getName());
         }
-        sendWelcomeMessage(player);
+        broadcastConnectionMessage("&7[&a+&7] &a" + player.getName());
     }
 
     @EventHandler
     public void onPlayerQuit(final PlayerQuitEvent event) {
         final Player player = event.getPlayer();
+        event.setQuitMessage(null);
         playerDataManager.handlePlayerQuit(player);
         if (economyManager != null) {
             economyManager.handlePlayerQuit(player.getUniqueId());
         }
+        broadcastConnectionMessage("&7[&c-&7] &c" + player.getName());
     }
 
-    private void sendWelcomeMessage(final Player player) {
-        final FileConfiguration messagesConfig = plugin.getConfigManager().getMessagesConfig();
-        final List<String> lines = messagesConfig.getStringList("welcome_message");
-        if (lines.isEmpty()) {
+    private void broadcastConnectionMessage(final String message) {
+        if (message == null || message.isBlank()) {
             return;
         }
-        lines.stream()
-                .map(line -> line.replace("%player_name%", player.getName()))
-                .forEach(line -> player.sendMessage(MessageUtils.applyPrefix(line)));
+        Bukkit.getOnlinePlayers().forEach(target ->
+                target.sendMessage(MessageUtils.colorize(message)));
     }
 }

--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -2,6 +2,7 @@ package com.lobby.menus;
 
 import com.lobby.LobbyPlugin;
 import com.lobby.servers.ServerManager;
+import com.lobby.social.ChatInputManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
@@ -204,6 +205,8 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
                     player.sendMessage(colorize(action.argument));
                 }
             }
+            case COMMAND -> executeCommand(player, action.argument);
+            case CHAT_PROMPT -> startChatPrompt(player, action);
         }
     }
 
@@ -231,6 +234,44 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
         }
         if (!menuManager.openMenu(player, targetMenu)) {
             player.sendMessage("§cCe menu est actuellement indisponible.");
+        }
+    }
+
+    private void executeCommand(final Player player, final String rawCommand) {
+        if (player == null || rawCommand == null || rawCommand.isBlank()) {
+            return;
+        }
+        final String command = rawCommand.startsWith("/") ? rawCommand.substring(1) : rawCommand;
+        if (command.isBlank()) {
+            return;
+        }
+        player.closeInventory();
+        Bukkit.getScheduler().runTask(plugin, () -> player.performCommand(command));
+    }
+
+    private void startChatPrompt(final Player player, final MenuAction action) {
+        if (player == null || action == null) {
+            return;
+        }
+        try {
+            final String flow = action.flow();
+            if (flow != null && !flow.isBlank()) {
+                if ("clan_create".equalsIgnoreCase(flow)) {
+                    ChatInputManager.startClanCreationFlow(player, action.argument(), action.reopenMenu());
+                    return;
+                }
+            }
+            if (action.command() != null && !action.command().isBlank()) {
+                ChatInputManager.startCommandPrompt(player, action.argument(), action.command(), action.reopenMenu());
+                return;
+            }
+        } catch (final IllegalStateException exception) {
+            player.sendMessage("§cLes actions de chat sont indisponibles pour le moment.");
+            return;
+        }
+        if (action.argument() != null && !action.argument().isBlank()) {
+            player.closeInventory();
+            player.sendMessage(colorize(action.argument()));
         }
     }
 
@@ -284,7 +325,7 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
         final String skullOwner = section.getString("skull-owner");
         final boolean usePlayerHead = section.getBoolean("player-head", false)
                 || "PLAYER_HEAD".equalsIgnoreCase(material);
-        final MenuAction action = MenuAction.parse(actionValue);
+        final MenuAction action = MenuAction.parse(actionValue, section);
         final MenuItemCondition condition = MenuItemCondition.fromSection(section.getConfigurationSection("conditions"));
         return new MenuItemDefinition(itemId, slots, material, name, lore, action, amount, usePlayerHead,
                 skullOwner, condition);
@@ -337,14 +378,20 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
         SERVER_SEND,
         MENU,
         CLOSE_MENU,
-        MESSAGE
+        MESSAGE,
+        COMMAND,
+        CHAT_PROMPT
     }
 
-    private record MenuAction(ActionType type, String argument) {
+    private record MenuAction(ActionType type,
+                              String argument,
+                              String command,
+                              String reopenMenu,
+                              String flow) {
 
-        private static final MenuAction NONE = new MenuAction(ActionType.NONE, "");
+        private static final MenuAction NONE = new MenuAction(ActionType.NONE, "", null, null, null);
 
-        private static MenuAction parse(final String raw) {
+        private static MenuAction parse(final String raw, final ConfigurationSection section) {
             if (raw == null || raw.isBlank()) {
                 return NONE;
             }
@@ -356,12 +403,31 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
             final String typeName = trimmed.substring(1, closingIndex).trim().toUpperCase(Locale.ROOT);
             final String argument = trimmed.substring(closingIndex + 1).trim();
             return switch (typeName) {
-                case "SERVER_SEND" -> new MenuAction(ActionType.SERVER_SEND, argument);
-                case "MENU" -> new MenuAction(ActionType.MENU, argument);
-                case "CLOSE_MENU" -> new MenuAction(ActionType.CLOSE_MENU, argument);
-                case "MESSAGE" -> new MenuAction(ActionType.MESSAGE, argument);
+                case "SERVER_SEND" -> new MenuAction(ActionType.SERVER_SEND, argument, null, null, null);
+                case "MENU" -> new MenuAction(ActionType.MENU, argument, null, null, null);
+                case "CLOSE_MENU" -> new MenuAction(ActionType.CLOSE_MENU, argument, null, null, null);
+                case "MESSAGE" -> new MenuAction(ActionType.MESSAGE, argument, null, null, null);
+                case "COMMAND" -> new MenuAction(ActionType.COMMAND, argument, null, null, null);
+                case "CHAT_PROMPT" -> {
+                    final String command = readChatPromptValue(section, "command");
+                    final String reopenMenu = readChatPromptValue(section, "reopen_menu");
+                    final String flow = readChatPromptValue(section, "flow");
+                    yield new MenuAction(ActionType.CHAT_PROMPT, argument, command, reopenMenu, flow);
+                }
                 default -> NONE;
             };
+        }
+
+        private static String readChatPromptValue(final ConfigurationSection section, final String key) {
+            if (section == null || key == null || key.isBlank()) {
+                return null;
+            }
+            final ConfigurationSection promptSection = section.getConfigurationSection("chat_prompt");
+            if (promptSection == null) {
+                return null;
+            }
+            final String value = promptSection.getString(key);
+            return (value == null || value.isBlank()) ? null : value;
         }
     }
 

--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -116,8 +116,8 @@ public class MenuManager {
     private boolean isHeavyMenu(final String menuId) {
         return switch (menuId) {
             case "stats_detailed_menu", "amis_menu", "friend_requests_menu", "friend_settings_menu",
-                    "groupe_menu", "party_invites_menu", "clan_menu", "clan_members_menu",
-                    "clan_bank_menu", "clan_management_menu" -> true;
+                    "friends_main_menu", "groupe_menu", "party_invites_menu", "clan_menu",
+                    "clan_list_menu", "clan_members_menu", "clan_bank_menu", "clan_management_menu" -> true;
             default -> false;
         };
     }

--- a/src/main/java/com/lobby/social/ChatInputManager.java
+++ b/src/main/java/com/lobby/social/ChatInputManager.java
@@ -5,6 +5,7 @@ import com.lobby.menus.MenuManager;
 import com.lobby.social.clans.ClanManager;
 import com.lobby.social.groups.GroupManager;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -14,6 +15,7 @@ import org.bukkit.scheduler.BukkitTask;
 
 import java.util.Map;
 import java.util.UUID;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
@@ -70,6 +72,66 @@ public final class ChatInputManager implements Listener {
                 menuManager.openMenu(player, "amis_menu");
             }
         });
+    }
+
+    public static void startCommandPrompt(final Player player,
+                                          final String promptMessage,
+                                          final String commandTemplate,
+                                          final String reopenMenuId) {
+        if (player == null || commandTemplate == null || commandTemplate.isBlank()) {
+            if (promptMessage != null && !promptMessage.isBlank()) {
+                player.sendMessage(colorize(promptMessage));
+            }
+            return;
+        }
+        final ChatInputManager manager = getInstance();
+        final MenuManager menuManager = manager.plugin.getMenuManager();
+        final String reopenMenu = sanitizeMenuId(reopenMenuId, null);
+
+        player.closeInventory();
+        if (promptMessage != null && !promptMessage.isBlank()) {
+            player.sendMessage(colorize(promptMessage));
+        }
+        player.sendMessage("§7Tapez §ccancel §7pour annuler.");
+
+        startInputFlow(player, inputRaw -> {
+            final String input = inputRaw == null ? "" : inputRaw.trim();
+            if (input.equalsIgnoreCase("cancel")) {
+                player.sendMessage("§cOpération annulée.");
+                reopenMenu(menuManager, player, reopenMenu);
+                return;
+            }
+            if (input.isEmpty()) {
+                player.sendMessage("§cMerci d'entrer une valeur valide.");
+                startCommandPrompt(player, promptMessage, commandTemplate, reopenMenu);
+                return;
+            }
+            final String formatted = commandTemplate.replace("%input%", input).replace("{input}", input);
+            final String command = formatted.startsWith("/") ? formatted.substring(1) : formatted;
+            if (!command.isBlank()) {
+                Bukkit.getScheduler().runTask(manager.plugin, () -> player.performCommand(command));
+            }
+            reopenMenu(menuManager, player, reopenMenu);
+        }, () -> reopenMenu(menuManager, player, reopenMenu));
+    }
+
+    public static void startClanCreationFlow(final Player player,
+                                             final String promptMessage,
+                                             final String reopenMenuId) {
+        if (player == null) {
+            return;
+        }
+        final ChatInputManager manager = getInstance();
+        final ClanManager clanManager = manager.plugin.getClanManager();
+        if (clanManager == null) {
+            player.sendMessage("§cLa création de clan est indisponible pour le moment.");
+            return;
+        }
+        final MenuManager menuManager = manager.plugin.getMenuManager();
+        final String reopenMenu = sanitizeMenuId(reopenMenuId, "clan_menu");
+
+        player.closeInventory();
+        promptClanName(manager, player, clanManager, menuManager, reopenMenu, promptMessage);
     }
 
     public static void startGroupCreateFlow(final Player player) {
@@ -231,6 +293,106 @@ public final class ChatInputManager implements Listener {
                 Bukkit.getScheduler().runTask(plugin, (Runnable) onTimeout);
             }
         });
+    }
+
+    private static void promptClanName(final ChatInputManager manager,
+                                       final Player player,
+                                       final ClanManager clanManager,
+                                       final MenuManager menuManager,
+                                       final String reopenMenu,
+                                       final String promptMessage) {
+        if (promptMessage != null && !promptMessage.isBlank()) {
+            player.sendMessage(colorize(promptMessage));
+        } else {
+            player.sendMessage("§eEntrez le nom de votre clan (3 à 20 caractères).");
+        }
+        player.sendMessage("§7Tapez §ccancel §7pour annuler.");
+        startInputFlow(player, inputRaw -> {
+            final String input = inputRaw == null ? "" : inputRaw.trim();
+            if (input.equalsIgnoreCase("cancel")) {
+                player.sendMessage("§cCréation de clan annulée.");
+                reopenMenu(menuManager, player, reopenMenu);
+                return;
+            }
+            if (input.length() < 3 || input.length() > 20) {
+                player.sendMessage("§cLe nom du clan doit faire entre 3 et 20 caractères.");
+                promptClanName(manager, player, clanManager, menuManager, reopenMenu,
+                        "§eEntrez un nom de clan valide (3 à 20 caractères).");
+                return;
+            }
+            promptClanTag(manager, player, clanManager, menuManager, reopenMenu, input);
+        }, () -> reopenMenu(menuManager, player, reopenMenu));
+    }
+
+    private static void promptClanTag(final ChatInputManager manager,
+                                      final Player player,
+                                      final ClanManager clanManager,
+                                      final MenuManager menuManager,
+                                      final String reopenMenu,
+                                      final String clanName) {
+        player.sendMessage("§eEntrez le tag de votre clan (2 à 6 caractères).");
+        player.sendMessage("§7Tapez §ccancel §7pour annuler.");
+        startInputFlow(player, inputRaw -> {
+            final String input = inputRaw == null ? "" : inputRaw.trim();
+            if (input.equalsIgnoreCase("cancel")) {
+                player.sendMessage("§cCréation de clan annulée.");
+                reopenMenu(menuManager, player, reopenMenu);
+                return;
+            }
+            if (input.length() < 2 || input.length() > 6) {
+                player.sendMessage("§cLe tag du clan doit faire entre 2 et 6 caractères.");
+                promptClanTag(manager, player, clanManager, menuManager, reopenMenu, clanName);
+                return;
+            }
+            promptClanConfirmation(manager, player, clanManager, menuManager, reopenMenu,
+                    clanName, input.toUpperCase(Locale.ROOT));
+        }, () -> reopenMenu(menuManager, player, reopenMenu));
+    }
+
+    private static void promptClanConfirmation(final ChatInputManager manager,
+                                               final Player player,
+                                               final ClanManager clanManager,
+                                               final MenuManager menuManager,
+                                               final String reopenMenu,
+                                               final String clanName,
+                                               final String clanTag) {
+        player.sendMessage("§7Nom choisi : §b" + clanName);
+        player.sendMessage("§7Tag choisi : §3[" + clanTag + "]");
+        player.sendMessage("§eTapez §aconfirmer §epour valider ou §ccancel §epour annuler.");
+        startInputFlow(player, inputRaw -> {
+            final String input = inputRaw == null ? "" : inputRaw.trim();
+            if (input.equalsIgnoreCase("cancel")) {
+                player.sendMessage("§cCréation de clan annulée.");
+                reopenMenu(menuManager, player, reopenMenu);
+                return;
+            }
+            if (input.equalsIgnoreCase("confirmer") || input.equalsIgnoreCase("confirm")
+                    || input.equalsIgnoreCase("oui")) {
+                clanManager.createClan(player, clanName, clanTag);
+                reopenMenu(menuManager, player, reopenMenu);
+                return;
+            }
+            player.sendMessage("§cRéponse invalide. Tapez 'confirmer' pour valider ou 'cancel' pour annuler.");
+            promptClanConfirmation(manager, player, clanManager, menuManager, reopenMenu, clanName, clanTag);
+        }, () -> reopenMenu(menuManager, player, reopenMenu));
+    }
+
+    private static void reopenMenu(final MenuManager menuManager, final Player player, final String menuId) {
+        if (menuManager == null || player == null || menuId == null || menuId.isBlank()) {
+            return;
+        }
+        menuManager.openMenu(player, menuId);
+    }
+
+    private static String sanitizeMenuId(final String raw, final String fallback) {
+        if (raw != null && !raw.isBlank()) {
+            return raw;
+        }
+        return fallback;
+    }
+
+    private static String colorize(final String message) {
+        return ChatColor.translateAlternateColorCodes('&', message == null ? "" : message);
     }
 
     private static final class InputSession {

--- a/src/main/java/com/lobby/social/clans/ClanManager.java
+++ b/src/main/java/com/lobby/social/clans/ClanManager.java
@@ -216,6 +216,56 @@ public class ClanManager {
         return 0;
     }
 
+    public int countPublicClans() {
+        final String query = "SELECT COUNT(*) FROM clans WHERE disbanded_at IS NULL AND is_public <> 0";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query);
+             ResultSet resultSet = statement.executeQuery()) {
+            if (resultSet.next()) {
+                return resultSet.getInt(1);
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to count public clans", exception);
+        }
+        return 0;
+    }
+
+    public List<ClanSummary> listPublicClans(final int limit, final int offset) {
+        final int pageSize = Math.max(1, limit);
+        final int safeOffset = Math.max(0, offset);
+        final List<ClanSummary> clans = new ArrayList<>();
+        final String query = "SELECT c.id, c.name, c.tag, c.leader_uuid, c.description, c.level, c.max_members, "
+                + "COUNT(m.player_uuid) AS members_count "
+                + "FROM clans c "
+                + "LEFT JOIN clan_members m ON m.clan_id = c.id "
+                + "WHERE c.disbanded_at IS NULL AND c.is_public <> 0 "
+                + "GROUP BY c.id, c.name, c.tag, c.leader_uuid, c.description, c.level, c.max_members "
+                + "ORDER BY c.level DESC, members_count DESC, c.name ASC "
+                + "LIMIT ? OFFSET ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setInt(1, pageSize);
+            statement.setInt(2, safeOffset);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    final int id = resultSet.getInt("id");
+                    final String name = resultSet.getString("name");
+                    final String tag = resultSet.getString("tag");
+                    final String leaderRaw = resultSet.getString("leader_uuid");
+                    final UUID leaderUuid = leaderRaw != null ? UUID.fromString(leaderRaw) : null;
+                    final String description = resultSet.getString("description");
+                    final int level = resultSet.getInt("level");
+                    final int members = resultSet.getInt("members_count");
+                    final int maxMembers = resultSet.getInt("max_members");
+                    clans.add(new ClanSummary(id, name, tag, leaderUuid, description, level, members, maxMembers));
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to list public clans", exception);
+        }
+        return clans;
+    }
+
     public int countCachedOpenClans() {
         return (int) clanCache.values().stream()
                 .filter(Objects::nonNull)

--- a/src/main/java/com/lobby/social/clans/ClanSummary.java
+++ b/src/main/java/com/lobby/social/clans/ClanSummary.java
@@ -1,0 +1,13 @@
+package com.lobby.social.clans;
+
+import java.util.UUID;
+
+public record ClanSummary(int id,
+                          String name,
+                          String tag,
+                          UUID leaderUuid,
+                          String description,
+                          int level,
+                          int members,
+                          int maxMembers) {
+}

--- a/src/main/java/com/lobby/social/menus/ClanListMenu.java
+++ b/src/main/java/com/lobby/social/menus/ClanListMenu.java
@@ -1,0 +1,249 @@
+package com.lobby.social.menus;
+
+import com.lobby.menus.AssetManager;
+import com.lobby.menus.Menu;
+import com.lobby.menus.MenuManager;
+import com.lobby.social.clans.ClanSummary;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+public class ClanListMenu implements Menu, InventoryHolder {
+
+    public static final int CLANS_PER_PAGE = 21;
+    private static final String TITLE = ChatColor.translateAlternateColorCodes('&', "&8» &9Liste des Clans");
+    private static final int SIZE = 54;
+    private static final List<Integer> CLAN_SLOTS = List.of(
+            10, 11, 12, 13, 14, 15, 16,
+            19, 20, 21, 22, 23, 24, 25,
+            28, 29, 30, 31, 32, 33, 34
+    );
+
+    private final MenuManager menuManager;
+    private final AssetManager assetManager;
+    private final List<ClanSummary> clans;
+    private final int page;
+    private final int totalClans;
+    private final int pageSize;
+
+    private final Map<Integer, ClanSummary> slotMapping = new HashMap<>();
+    private Inventory inventory;
+
+    public ClanListMenu(final MenuManager menuManager,
+                        final AssetManager assetManager,
+                        final List<ClanSummary> clans,
+                        final int page,
+                        final int totalClans,
+                        final int pageSize) {
+        this.menuManager = menuManager;
+        this.assetManager = assetManager;
+        this.clans = clans == null ? List.of() : new ArrayList<>(clans);
+        this.page = Math.max(0, page);
+        this.totalClans = Math.max(0, totalClans);
+        this.pageSize = Math.max(1, pageSize);
+    }
+
+    @Override
+    public void open(final Player player) {
+        inventory = Bukkit.createInventory(this, SIZE, TITLE);
+        slotMapping.clear();
+
+        placeBorders();
+        placeClanEntries();
+        placeNavigation();
+
+        player.openInventory(inventory);
+    }
+
+    @Override
+    public void handleClick(final InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        final int slot = event.getSlot();
+        if (slot == 48 && page > 0) {
+            SocialHeavyMenus.openClanListMenu(menuManager, player, page - 1);
+            return;
+        }
+        if (slot == 52 && hasNextPage()) {
+            SocialHeavyMenus.openClanListMenu(menuManager, player, page + 1);
+            return;
+        }
+        if (slot == 50) {
+            menuManager.openMenu(player, "clan_menu");
+            return;
+        }
+        final ClanSummary summary = slotMapping.get(slot);
+        if (summary == null) {
+            return;
+        }
+        player.closeInventory();
+        final String command = "clan info " + summary.name();
+        player.performCommand(command.trim());
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    private void placeClanEntries() {
+        if (clans.isEmpty()) {
+            final ItemStack empty = assetManager.getHead("hdb:1455");
+            final ItemMeta meta = empty.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName(ChatColor.RED + "Aucun clan public");
+                meta.setLore(List.of(
+                        ChatColor.GRAY + "Les clans ouverts apparaîtront ici.",
+                        ChatColor.GRAY + "Créez le vôtre ou revenez plus tard.",
+                        "",
+                        ChatColor.YELLOW + "▶ Lancez-vous dans l'aventure !"
+                ));
+                empty.setItemMeta(meta);
+            }
+            inventory.setItem(22, empty);
+            return;
+        }
+        final int startIndex = page * pageSize;
+        final int endIndex = Math.min(clans.size(), startIndex + CLAN_SLOTS.size());
+        for (int index = startIndex, slotIndex = 0; index < endIndex && slotIndex < CLAN_SLOTS.size(); index++, slotIndex++) {
+            final ClanSummary summary = clans.get(index);
+            final int slot = CLAN_SLOTS.get(slotIndex);
+            final ItemStack item = createClanItem(summary);
+            inventory.setItem(slot, item);
+            slotMapping.put(slot, summary);
+        }
+    }
+
+    private ItemStack createClanItem(final ClanSummary summary) {
+        final ItemStack book = new ItemStack(Material.WRITABLE_BOOK);
+        final ItemMeta meta = book.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.AQUA + "[" + safeTag(summary.tag()) + "] " + ChatColor.WHITE + safeName(summary.name()));
+            meta.setLore(buildLore(summary));
+            book.setItemMeta(meta);
+        }
+        return book;
+    }
+
+    private List<String> buildLore(final ClanSummary summary) {
+        final List<String> lore = new ArrayList<>();
+        final String description = sanitizeDescription(summary.description());
+        lore.add(ChatColor.RESET.toString());
+        lore.add(ChatColor.GRAY + description);
+        lore.add(ChatColor.RESET.toString());
+        lore.add(ChatColor.AQUA.toString() + ChatColor.BOLD + "▪ " + ChatColor.AQUA + "Chef : "
+                + ChatColor.WHITE + resolveLeaderName(summary.leaderUuid()));
+        lore.add(ChatColor.AQUA.toString() + ChatColor.BOLD + "▪ " + ChatColor.AQUA + "Niveau : "
+                + ChatColor.YELLOW + summary.level());
+        lore.add(ChatColor.AQUA.toString() + ChatColor.BOLD + "▪ " + ChatColor.AQUA + "Membres : "
+                + ChatColor.GREEN + summary.members() + ChatColor.GRAY + " / " + ChatColor.GREEN + summary.maxMembers());
+        lore.add(ChatColor.RESET.toString());
+        lore.add(ChatColor.YELLOW + "▶ Cliquez pour voir le profil du clan");
+        return lore;
+    }
+
+    private void placeNavigation() {
+        final ItemStack back = decorate(assetManager.getHead("hdb:9334"),
+                ChatColor.RED.toString() + ChatColor.BOLD + "Retour",
+                List.of(ChatColor.RESET.toString(), ChatColor.GRAY + "Revenir au menu des clans"));
+        inventory.setItem(50, back);
+
+        final ItemStack pageIndicator = new ItemStack(Material.PAPER);
+        final ItemMeta meta = pageIndicator.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.AQUA + "Page " + (page + 1) + ChatColor.GRAY + " / " + ChatColor.AQUA + getTotalPages());
+            meta.setLore(List.of(ChatColor.GRAY + "Explorez les clans publics du serveur."));
+            pageIndicator.setItemMeta(meta);
+        }
+        inventory.setItem(49, pageIndicator);
+
+        if (page > 0) {
+            final ItemStack previous = decorate(new ItemStack(Material.ARROW),
+                    ChatColor.YELLOW + "Page précédente",
+                    List.of(ChatColor.GRAY + "Retour à la page " + page));
+            inventory.setItem(48, previous);
+        }
+        if (hasNextPage()) {
+            final ItemStack next = decorate(new ItemStack(Material.ARROW),
+                    ChatColor.YELLOW + "Page suivante",
+                    List.of(ChatColor.GRAY + "Aller à la page " + (page + 2)));
+            inventory.setItem(52, next);
+        }
+    }
+
+    private void placeBorders() {
+        final ItemStack border = new ItemStack(Material.BLUE_STAINED_GLASS_PANE);
+        final ItemMeta meta = border.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(" ");
+            border.setItemMeta(meta);
+        }
+        final int[] borderSlots = {0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 46, 52, 53};
+        for (int slot : borderSlots) {
+            inventory.setItem(slot, border);
+        }
+    }
+
+    private boolean hasNextPage() {
+        return (page + 1) * pageSize < totalClans;
+    }
+
+    private int getTotalPages() {
+        if (totalClans <= 0) {
+            return 1;
+        }
+        return (int) Math.max(1, Math.ceil((double) totalClans / pageSize));
+    }
+
+    private ItemStack decorate(final ItemStack item, final String name, final List<String> lore) {
+        final ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    private String resolveLeaderName(final UUID leaderUuid) {
+        if (leaderUuid == null) {
+            return ChatColor.RED + "Inconnu";
+        }
+        final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(leaderUuid);
+        final String name = offlinePlayer.getName();
+        if (name != null && !name.isBlank()) {
+            return name;
+        }
+        return leaderUuid.toString().substring(0, 8).toUpperCase(Locale.ROOT);
+    }
+
+    private String sanitizeDescription(final String description) {
+        if (description == null || description.isBlank()) {
+            return "Aucune description";
+        }
+        return description.length() > 60 ? description.substring(0, 57) + "..." : description;
+    }
+
+    private String safeName(final String name) {
+        return (name == null || name.isBlank()) ? "Clan" : name;
+    }
+
+    private String safeTag(final String tag) {
+        return (tag == null || tag.isBlank()) ? "???" : tag;
+    }
+}

--- a/src/main/java/com/lobby/social/menus/FriendRequestsMenu.java
+++ b/src/main/java/com/lobby/social/menus/FriendRequestsMenu.java
@@ -62,7 +62,6 @@ public class FriendRequestsMenu implements Menu, InventoryHolder {
         inventory = Bukkit.createInventory(this, SIZE, TITLE);
         slotMapping.clear();
 
-        fillBackground();
         placeBorders();
         placeRequests(player);
         placeNavigationControls();
@@ -192,23 +191,11 @@ public class FriendRequestsMenu implements Menu, InventoryHolder {
         }
     }
 
-    private void fillBackground() {
-        final ItemStack filler = createGlass(Material.BLACK_STAINED_GLASS_PANE);
-        for (int slot = 0; slot < SIZE; slot++) {
-            inventory.setItem(slot, filler);
-        }
-    }
-
     private void placeBorders() {
         final ItemStack primary = createGlass(Material.LIME_STAINED_GLASS_PANE);
         final int[] primarySlots = {0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 46, 52, 53};
         for (int slot : primarySlots) {
             inventory.setItem(slot, primary);
-        }
-        final ItemStack secondary = createGlass(Material.GRAY_STAINED_GLASS_PANE);
-        final int[] secondarySlots = {39, 40, 41};
-        for (int slot : secondarySlots) {
-            inventory.setItem(slot, secondary);
         }
     }
 

--- a/src/main/java/com/lobby/social/menus/GroupMenu.java
+++ b/src/main/java/com/lobby/social/menus/GroupMenu.java
@@ -4,9 +4,12 @@ import com.lobby.LobbyPlugin;
 import com.lobby.menus.AssetManager;
 import com.lobby.menus.Menu;
 import com.lobby.menus.MenuManager;
+import com.lobby.menus.MenuRenderContext;
 import com.lobby.social.ChatInputManager;
 import com.lobby.social.groups.Group;
 import com.lobby.social.groups.GroupManager;
+import com.lobby.social.groups.GroupSettings;
+import com.lobby.social.groups.GroupVisibility;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -102,7 +105,10 @@ public class GroupMenu implements Menu, InventoryHolder {
             return;
         }
         if (slot == 4 && group.isLeader(viewerUuid)) {
-            if (!menuManager.openMenu(player, "party_management_menu")) {
+            final Map<String, String> placeholders = new HashMap<>();
+            placeholders.put("%party_status%", formatGroupVisibility(groupManager.getGroupSettings(viewerUuid)));
+            final MenuRenderContext context = MenuRenderContext.EMPTY.withGroup(true, true);
+            if (!menuManager.openMenu(player, "party_management_menu", placeholders, context)) {
                 player.sendMessage("§cOutil de gestion indisponible pour le moment.");
             }
             return;
@@ -223,6 +229,15 @@ public class GroupMenu implements Menu, InventoryHolder {
             info.setItemMeta(infoMeta);
         }
         inventory.setItem(22, info);
+    }
+
+    private String formatGroupVisibility(final GroupSettings settings) {
+        final GroupVisibility visibility = settings == null ? GroupVisibility.PUBLIC : settings.getVisibility();
+        return switch (visibility) {
+            case PUBLIC -> "§aPublic";
+            case FRIENDS_ONLY -> "§eAmis uniquement";
+            case INVITE_ONLY -> "§cSur invitation";
+        };
     }
 
     private ItemStack createMemberItem(final UUID uuid) {

--- a/src/main/java/com/lobby/social/menus/SocialHeavyMenus.java
+++ b/src/main/java/com/lobby/social/menus/SocialHeavyMenus.java
@@ -9,6 +9,8 @@ import com.lobby.menus.MenuRenderContext;
 import com.lobby.social.clans.Clan;
 import com.lobby.social.clans.ClanManager;
 import com.lobby.social.clans.ClanMember;
+import com.lobby.social.clans.ClanSummary;
+import com.lobby.social.friends.FriendInfo;
 import com.lobby.social.friends.FriendManager;
 import com.lobby.social.groups.GroupManager;
 import org.bukkit.Bukkit;
@@ -45,9 +47,11 @@ public final class SocialHeavyMenus {
             case "amis_menu" -> openFriendsMenu(menuManager, player, placeholders);
             case "friend_requests_menu" -> openFriendRequestsMenu(menuManager, player, 0);
             case "friend_settings_menu" -> openFriendSettingsMenu(menuManager, player);
+            case "friends_main_menu" -> openFriendsMainMenu(menuManager, player, 0);
             case "groupe_menu" -> openGroupMenu(menuManager, player, placeholders, context);
             case "party_invites_menu" -> openPartyInvitesMenu(menuManager, player, 0);
             case "clan_menu" -> openClanMenu(menuManager, player, placeholders, context);
+            case "clan_list_menu" -> openClanListMenu(menuManager, player, 0);
             case "clan_members_menu" -> openClanMembersMenu(menuManager, player);
             case "clan_bank_menu" -> openClanBankMenu(menuManager, player);
             case "clan_management_menu" -> openClanManagementMenu(menuManager, player);
@@ -91,6 +95,31 @@ public final class SocialHeavyMenus {
 
     public static boolean openFriendsMenu(final MenuManager menuManager, final Player player, final int page) {
         return openFriendsMenu(menuManager, player, Map.of());
+    }
+
+    public static boolean openFriendsMainMenu(final MenuManager menuManager, final Player player, final int page) {
+        if (menuManager == null || player == null) {
+            return false;
+        }
+        final LobbyPlugin plugin = LobbyPlugin.getInstance();
+        if (plugin == null) {
+            return false;
+        }
+        final FriendManager friendManager = plugin.getFriendManager();
+        final AssetManager assetManager = menuManager.getAssetManager();
+        if (friendManager == null || assetManager == null) {
+            return false;
+        }
+        final UUID uuid = player.getUniqueId();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final List<FriendInfo> friends = friendManager.getFriendsList(uuid);
+            final int requests = friendManager.getPendingRequests(uuid).size();
+            final int pageIndex = Math.max(0, page);
+            final FriendsMainMenu menu = new FriendsMainMenu(plugin, menuManager, assetManager, friendManager,
+                    friends, requests, pageIndex);
+            menuManager.displayMenu(player, menu);
+        });
+        return true;
     }
 
     public static boolean openFriendRequestsMenu(final MenuManager menuManager, final Player player, final int page) {
@@ -227,6 +256,33 @@ public final class SocialHeavyMenus {
 
     public static boolean openClanMenu(final MenuManager menuManager, final Player player) {
         return openClanMenu(menuManager, player, Map.of(), MenuRenderContext.EMPTY);
+    }
+
+    public static boolean openClanListMenu(final MenuManager menuManager, final Player player, final int page) {
+        if (menuManager == null || player == null) {
+            return false;
+        }
+        final LobbyPlugin plugin = LobbyPlugin.getInstance();
+        if (plugin == null) {
+            return false;
+        }
+        final ClanManager clanManager = plugin.getClanManager();
+        final AssetManager assetManager = menuManager.getAssetManager();
+        if (clanManager == null || assetManager == null) {
+            return false;
+        }
+        final int requestedPage = Math.max(0, page);
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final int total = clanManager.countPublicClans();
+            final int pageSize = ClanListMenu.CLANS_PER_PAGE;
+            final int maxPage = total <= 0 ? 0 : Math.max(0, (int) Math.ceil((double) total / pageSize) - 1);
+            final int targetPage = Math.min(requestedPage, maxPage);
+            final int offset = targetPage * pageSize;
+            final List<ClanSummary> clans = clanManager.listPublicClans(pageSize, offset);
+            final ClanListMenu menu = new ClanListMenu(menuManager, assetManager, clans, targetPage, total, pageSize);
+            menuManager.displayMenu(player, menu);
+        });
+        return true;
     }
 
     public static boolean openClanMenu(final MenuManager menuManager,

--- a/src/main/resources/config/menus/amis_menu.yml
+++ b/src/main/resources/config/menus/amis_menu.yml
@@ -19,7 +19,11 @@ items:
       - '&r'
       - '&b▸ Statut : &aOuvert'
       - '&r'
-      - '&e▶ Tapez la commande dans le chat'
+      - '&e▶ Cliquez pour saisir un pseudo'
+    action: '[CHAT_PROMPT] &aVeuillez taper le pseudo de l''ami que vous souhaitez ajouter.'
+    chat_prompt:
+      command: 'amis add %input%'
+      reopen_menu: 'amis_menu'
   demandes-recues:
     slot: 5
     material: 'hdb:23528'
@@ -44,7 +48,8 @@ items:
       - '&r'
       - '&b▸ Statut : &a%friends_total% amis'
       - '&r'
-      - '&e▶ Explorez votre carnet'
+      - '&e▶ Cliquez pour ouvrir la liste'
+    action: '[MENU] friends_main_menu'
   retour-profil:
     slot: 49
     material: 'hdb:9334'

--- a/src/main/resources/config/menus/clan_menu.yml
+++ b/src/main/resources/config/menus/clan_menu.yml
@@ -19,8 +19,11 @@ items:
       - '&r'
       - '&b▸ Coût : &e50 000 Coins'
       - '&r'
-      - '&e▶ Cliquez pour créer'
-    action: '[COMMAND] clan create'
+      - '&e▶ Cliquez pour lancer la création'
+    action: '[CHAT_PROMPT] &aEntrez le nom de votre futur clan.'
+    chat_prompt:
+      flow: 'clan_create'
+      reopen_menu: 'clan_menu'
     conditions:
       clan: 'none'
   rechercher-clan:

--- a/src/main/resources/config/menus/party_management_menu.yml
+++ b/src/main/resources/config/menus/party_management_menu.yml
@@ -1,0 +1,56 @@
+title: '&8» &6Gestion du Groupe'
+size: 54
+design:
+  primary_border:
+    material: 'ORANGE_STAINED_GLASS_PANE'
+    slots: [0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 46, 52, 53]
+items:
+  statut-groupe:
+    slot: 20
+    material: 'hdb:11181'
+    name: '&b&lStatut du Groupe'
+    lore:
+      - '&r'
+      - '&7Contrôlez si votre groupe est'
+      - '&7public ou sur invitation.'
+      - '&r'
+      - '&b▸ Actuel : %party_status%'
+      - '&r'
+      - '&e▶ Cliquez pour changer'
+    action: '[COMMAND] party toggle public'
+  promouvoir-membre:
+    slot: 22
+    material: 'hdb:52331'
+    name: '&a&lPromouvoir un Chef'
+    lore:
+      - '&r'
+      - '&7Donnez le lead du groupe'
+      - '&7à un autre membre.'
+      - '&r'
+      - '&e▶ Ouvre la liste des membres'
+    action: '[MENU] party_promote_menu'
+  renommer-groupe:
+    slot: 24
+    material: 'NAME_TAG'
+    name: '&e&lRenommer le Groupe'
+    lore:
+      - '&r'
+      - '&7Changez le nom de votre'
+      - '&7groupe (cosmétique).'
+      - '&r'
+      - '&e▶ Cliquez pour renommer'
+    action: '[CHAT_PROMPT] &aEntrez le nouveau nom du groupe.'
+    chat_prompt:
+      command: 'party rename %input%'
+      reopen_menu: 'party_management_menu'
+  retour-menu:
+    slot: 50
+    material: 'hdb:9334'
+    name: '&c&lRetour'
+    lore:
+      - '&r'
+      - '&7Revenez au panneau de groupe'
+      - '&7pour continuer la gestion.'
+      - '&r'
+      - '&e▶ Cliquez pour revenir'
+    action: '[MENU] groupe_menu'


### PR DESCRIPTION
## Summary
- replace the verbose join/quit chat spam with minimal +/– messages and suppress default broadcasts
- extend configured menus with command/chat prompt actions and reusable chat flows for social features
- add the party management configuration, interactive friend/clan menu updates, and the new clan list inventory

## Testing
- mvn -q -DskipTests package *(fails: repository download blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d59f630b3c8329b7fad38f5f5af694