### PR TITLE
Fix social menu compilation errors

### DIFF
--- a/src/main/java/com/lobby/social/menus/SocialHeavyMenus.java
+++ b/src/main/java/com/lobby/social/menus/SocialHeavyMenus.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 /**
  * Entry point for every heavy social menu. Each menu collects all required

--- a/src/main/java/com/lobby/social/menus/friends/FriendsMenu.java
+++ b/src/main/java/com/lobby/social/menus/friends/FriendsMenu.java
@@ -383,7 +383,7 @@ public final class FriendsMenu implements Menu, InventoryHolder {
         meta.setDisplayName(prefix + (online ? "§a" : "§7") + info.getName());
         meta.setLore(buildFriendLore(info));
         if (favorite) {
-            meta.addEnchant(org.bukkit.enchantments.Enchantment.LUCK, 1, true);
+            meta.addEnchant(org.bukkit.enchantments.Enchantment.UNBREAKING, 1, true);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         }
         head.setItemMeta(meta);


### PR DESCRIPTION
## Summary
- add the missing Collectors import to the heavy social menu helper
- replace the invalid LUCK enchantment usage with a supported enchantment for favorite friend items

## Testing
- mvn -q -DskipTests package *(fails: dependency download blocked by HTTP 403 from papermc repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d67d4279108329bcf6e69b727381e6