### PR TITLE
feat: add asynchronous friends menu system

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -10,10 +10,12 @@ import com.lobby.core.DatabaseManager;
 import com.lobby.core.PlayerDataManager;
 import com.lobby.economy.EconomyManager;
 import com.lobby.heads.HeadDatabaseManager;
+import com.lobby.friends.FriendManager;
 import com.lobby.holograms.HologramManager;
 import com.lobby.menus.AssetManager;
 import com.lobby.menus.GlobalListener;
 import com.lobby.menus.MenuManager;
+import com.lobby.menus.prompt.ChatPromptManager;
 import com.lobby.menus.confirmation.ConfirmationManager;
 import com.lobby.npcs.NPCInteractionHandler;
 import com.lobby.npcs.NPCManager;
@@ -50,6 +52,8 @@ public final class LobbyPlugin extends JavaPlugin {
     private LobbyManager lobbyManager;
     private AssetManager assetManager;
     private MenuManager menuManager;
+    private FriendManager friendManager;
+    private ChatPromptManager chatPromptManager;
     private ConfirmationManager confirmationManager;
     private HeadDatabaseManager headDatabaseManager;
     private ShopManager shopManager;
@@ -101,9 +105,12 @@ public final class LobbyPlugin extends JavaPlugin {
         npcManager.initialize();
         lobbyManager = new LobbyManager(this);
         lobbyManager.applyWorldSettings();
+        friendManager = new FriendManager(this);
         assetManager = new AssetManager(this);
-        menuManager = new MenuManager(this, assetManager);
+        chatPromptManager = new ChatPromptManager(this);
+        menuManager = new MenuManager(this, assetManager, friendManager);
         getServer().getPluginManager().registerEvents(new GlobalListener(menuManager), this);
+        getServer().getPluginManager().registerEvents(chatPromptManager, this);
         confirmationManager = new ConfirmationManager(this);
         shopManager = new ShopManager(this);
         shopManager.initialize();
@@ -181,6 +188,8 @@ public final class LobbyPlugin extends JavaPlugin {
         if (assetManager != null) {
             assetManager.shutdown();
         }
+        chatPromptManager = null;
+        friendManager = null;
         if (confirmationManager != null) {
             confirmationManager.clearAll();
         }
@@ -217,6 +226,14 @@ public final class LobbyPlugin extends JavaPlugin {
 
     public MenuManager getMenuManager() {
         return menuManager;
+    }
+
+    public FriendManager getFriendManager() {
+        return friendManager;
+    }
+
+    public ChatPromptManager getChatPromptManager() {
+        return chatPromptManager;
     }
 
     public AssetManager getAssetManager() {

--- a/src/main/java/com/lobby/commands/PlayerCommands.java
+++ b/src/main/java/com/lobby/commands/PlayerCommands.java
@@ -50,6 +50,13 @@ public class PlayerCommands implements CommandExecutor, TabExecutor {
             }
             return true;
         }
+        if (commandName.equals("amis")) {
+            final boolean opened = menuManager != null && menuManager.openFriendsMenu(player, 0);
+            if (!opened) {
+                MessageUtils.sendConfigMessage(player, "menus.not_found", Map.of("menu", "amis"));
+            }
+            return true;
+        }
         final String messagePath = COMMAND_MESSAGES.getOrDefault(commandName, "commands.unavailable");
         MessageUtils.sendConfigMessage(player, messagePath, Map.of("command", "/" + label));
         return true;

--- a/src/main/java/com/lobby/friends/FriendEntry.java
+++ b/src/main/java/com/lobby/friends/FriendEntry.java
@@ -1,0 +1,20 @@
+package com.lobby.friends;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Immutable view model representing a single friend entry in the menu.
+ */
+public record FriendEntry(UUID uuid,
+                          String name,
+                          boolean online,
+                          boolean favorite,
+                          Instant since) {
+
+    public FriendEntry {
+        if (uuid == null) {
+            throw new IllegalArgumentException("Friend UUID cannot be null");
+        }
+    }
+}

--- a/src/main/java/com/lobby/friends/FriendManager.java
+++ b/src/main/java/com/lobby/friends/FriendManager.java
@@ -1,0 +1,344 @@
+package com.lobby.friends;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.core.DatabaseManager;
+import com.lobby.core.DatabaseManager.DatabaseType;
+import com.lobby.utils.LogUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Central access point for all friend related persistence logic.
+ */
+public class FriendManager {
+
+    private static final String STATUS_ACCEPTED = "ACCEPTED";
+
+    private final LobbyPlugin plugin;
+    private final DatabaseManager databaseManager;
+
+    public FriendManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        this.databaseManager = plugin.getDatabaseManager();
+    }
+
+    public FriendMenuData loadMenuData(final UUID playerUuid, final Set<UUID> onlinePlayersSnapshot) {
+        final List<FriendEntry> friends = loadFriends(playerUuid, onlinePlayersSnapshot);
+        final List<FriendRequestEntry> requests = loadIncomingRequests(playerUuid);
+        return new FriendMenuData(friends, requests);
+    }
+
+    public List<FriendEntry> loadFriends(final UUID playerUuid, final Set<UUID> onlinePlayersSnapshot) {
+        if (playerUuid == null) {
+            return List.of();
+        }
+        final Set<UUID> onlinePlayers = onlinePlayersSnapshot == null ? Set.of() : new HashSet<>(onlinePlayersSnapshot);
+        final List<FriendEntry> entries = new ArrayList<>();
+        final String query = """
+                SELECT f.friend_uuid, f.created_at, f.is_favorite, p.username
+                FROM friends f
+                LEFT JOIN players p ON p.uuid = f.friend_uuid
+                WHERE f.player_uuid = ? AND f.status = 'ACCEPTED'
+                """;
+
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUuid.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    final UUID friendUuid = UUID.fromString(resultSet.getString("friend_uuid"));
+                    final String name = optionalString(resultSet.getString("username"))
+                            .orElseGet(() -> resolveOfflineName(friendUuid));
+                    final boolean favorite = resultSet.getBoolean("is_favorite");
+                    final Timestamp created = resultSet.getTimestamp("created_at");
+                    final Instant since = created == null ? Instant.EPOCH : created.toInstant();
+                    final boolean online = onlinePlayers.contains(friendUuid);
+                    entries.add(new FriendEntry(friendUuid, name, online, favorite, since));
+                }
+            }
+        } catch (final SQLException exception) {
+            LogUtils.warning(plugin, "Failed to load friends for " + playerUuid + ": " + exception.getMessage());
+        }
+
+        entries.sort(Comparator
+                .comparing(FriendEntry::favorite).reversed()
+                .thenComparing(FriendEntry::online).reversed()
+                .thenComparing(entry -> entry.name().toLowerCase(Locale.ROOT)));
+        return List.copyOf(entries);
+    }
+
+    public List<FriendRequestEntry> loadIncomingRequests(final UUID playerUuid) {
+        if (playerUuid == null) {
+            return List.of();
+        }
+        final List<FriendRequestEntry> requests = new ArrayList<>();
+        final String query = """
+                SELECT r.sender_uuid, r.created_at, p.username
+                FROM friend_requests r
+                LEFT JOIN players p ON p.uuid = r.sender_uuid
+                WHERE r.target_uuid = ?
+                ORDER BY r.created_at DESC
+                """;
+
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUuid.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    final UUID senderUuid = UUID.fromString(resultSet.getString("sender_uuid"));
+                    final String name = optionalString(resultSet.getString("username"))
+                            .orElseGet(() -> resolveOfflineName(senderUuid));
+                    final Timestamp created = resultSet.getTimestamp("created_at");
+                    final Instant createdAt = created == null ? Instant.now() : created.toInstant();
+                    requests.add(new FriendRequestEntry(senderUuid, name, createdAt));
+                }
+            }
+        } catch (final SQLException exception) {
+            LogUtils.warning(plugin, "Failed to load friend requests for " + playerUuid + ": "
+                    + exception.getMessage());
+        }
+        return List.copyOf(requests);
+    }
+
+    public boolean toggleFavorite(final UUID playerUuid, final UUID friendUuid) {
+        if (playerUuid == null || friendUuid == null) {
+            return false;
+        }
+        final String select = "SELECT is_favorite FROM friends WHERE player_uuid = ? AND friend_uuid = ? AND status = 'ACCEPTED'";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement selectStatement = connection.prepareStatement(select)) {
+            selectStatement.setString(1, playerUuid.toString());
+            selectStatement.setString(2, friendUuid.toString());
+            final boolean current;
+            try (ResultSet resultSet = selectStatement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return false;
+                }
+                current = resultSet.getBoolean("is_favorite");
+            }
+            final String update = "UPDATE friends SET is_favorite = ? WHERE player_uuid = ? AND friend_uuid = ?";
+            try (PreparedStatement updateStatement = connection.prepareStatement(update)) {
+                updateStatement.setBoolean(1, !current);
+                updateStatement.setString(2, playerUuid.toString());
+                updateStatement.setString(3, friendUuid.toString());
+                return updateStatement.executeUpdate() > 0;
+            }
+        } catch (final SQLException exception) {
+            LogUtils.warning(plugin, "Failed to toggle favorite for " + playerUuid + ": " + exception.getMessage());
+            return false;
+        }
+    }
+
+    public boolean acceptRequest(final UUID playerUuid, final UUID senderUuid) {
+        if (playerUuid == null || senderUuid == null) {
+            return false;
+        }
+        try (Connection connection = databaseManager.getConnection()) {
+            final boolean previousAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try {
+                deleteRequest(connection, senderUuid, playerUuid);
+                upsertFriend(connection, senderUuid, playerUuid);
+                upsertFriend(connection, playerUuid, senderUuid);
+                connection.commit();
+                connection.setAutoCommit(previousAutoCommit);
+                return true;
+            } catch (final SQLException exception) {
+                connection.rollback();
+                connection.setAutoCommit(previousAutoCommit);
+                LogUtils.warning(plugin, "Failed to accept friend request for " + playerUuid + ": "
+                        + exception.getMessage());
+            }
+        } catch (final SQLException exception) {
+            LogUtils.warning(plugin, "Failed to accept friend request for " + playerUuid + ": "
+                    + exception.getMessage());
+        }
+        return false;
+    }
+
+    public boolean declineRequest(final UUID playerUuid, final UUID senderUuid) {
+        if (playerUuid == null || senderUuid == null) {
+            return false;
+        }
+        try (Connection connection = databaseManager.getConnection()) {
+            deleteRequest(connection, senderUuid, playerUuid);
+            return true;
+        } catch (final SQLException exception) {
+            LogUtils.warning(plugin, "Failed to decline friend request for " + playerUuid + ": "
+                    + exception.getMessage());
+            return false;
+        }
+    }
+
+    public FriendOperationResult sendFriendRequest(final UUID senderUuid, final String rawTargetName) {
+        if (senderUuid == null) {
+            return FriendOperationResult.failure("§cImpossible d'envoyer la demande.");
+        }
+        final String trimmed = rawTargetName == null ? "" : rawTargetName.trim();
+        if (trimmed.isEmpty()) {
+            return FriendOperationResult.failure("§cVous devez préciser un pseudo.");
+        }
+
+        final UUID targetUuid = resolveUuidByName(trimmed);
+        if (targetUuid == null) {
+            return FriendOperationResult.failure("§cAucun joueur trouvé pour " + trimmed + ".");
+        }
+        if (senderUuid.equals(targetUuid)) {
+            return FriendOperationResult.failure("§cVous ne pouvez pas vous ajouter vous-même.");
+        }
+
+        if (areAlreadyFriends(senderUuid, targetUuid)) {
+            return FriendOperationResult.failure("§cVous êtes déjà amis.");
+        }
+
+        if (hasPendingRequest(senderUuid, targetUuid)) {
+            return FriendOperationResult.failure("§cVous avez déjà envoyé une demande à ce joueur.");
+        }
+
+        if (hasPendingRequest(targetUuid, senderUuid)) {
+            final boolean accepted = acceptRequest(senderUuid, targetUuid);
+            if (accepted) {
+                return FriendOperationResult.success("§aDemande acceptée automatiquement !");
+            }
+            return FriendOperationResult.failure("§cImpossible d'accepter la demande existante.");
+        }
+
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(buildInsertRequestQuery())) {
+            statement.setString(1, senderUuid.toString());
+            statement.setString(2, targetUuid.toString());
+            statement.executeUpdate();
+            return FriendOperationResult.success("§aDemande envoyée à §f" + trimmed + "§a !");
+        } catch (final SQLException exception) {
+            LogUtils.warning(plugin, "Failed to create friend request: " + exception.getMessage());
+            return FriendOperationResult.failure("§cErreur lors de l'envoi de la demande.");
+        }
+    }
+
+    private void deleteRequest(final Connection connection, final UUID senderUuid, final UUID targetUuid) throws SQLException {
+        final String delete = "DELETE FROM friend_requests WHERE sender_uuid = ? AND target_uuid = ?";
+        try (PreparedStatement statement = connection.prepareStatement(delete)) {
+            statement.setString(1, senderUuid.toString());
+            statement.setString(2, targetUuid.toString());
+            statement.executeUpdate();
+        }
+    }
+
+    private void upsertFriend(final Connection connection,
+                              final UUID playerUuid,
+                              final UUID friendUuid) throws SQLException {
+        final DatabaseType type = databaseManager.getDatabaseType();
+        final String query;
+        if (type == DatabaseType.MYSQL) {
+            query = """
+                    INSERT INTO friends (player_uuid, friend_uuid, status, created_at, accepted_at, is_favorite)
+                    VALUES (?, ?, 'ACCEPTED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, FALSE)
+                    ON DUPLICATE KEY UPDATE status = 'ACCEPTED', accepted_at = CURRENT_TIMESTAMP
+                    """;
+        } else {
+            query = """
+                    INSERT INTO friends (player_uuid, friend_uuid, status, created_at, accepted_at, is_favorite)
+                    VALUES (?, ?, 'ACCEPTED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0)
+                    ON CONFLICT(player_uuid, friend_uuid) DO UPDATE SET status = 'ACCEPTED', accepted_at = CURRENT_TIMESTAMP
+                    """;
+        }
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUuid.toString());
+            statement.setString(2, friendUuid.toString());
+            statement.executeUpdate();
+        }
+    }
+
+    private boolean areAlreadyFriends(final UUID playerUuid, final UUID friendUuid) {
+        final String query = "SELECT status FROM friends WHERE player_uuid = ? AND friend_uuid = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUuid.toString());
+            statement.setString(2, friendUuid.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    return false;
+                }
+                final String status = resultSet.getString("status");
+                return STATUS_ACCEPTED.equalsIgnoreCase(status);
+            }
+        } catch (final SQLException exception) {
+            LogUtils.warning(plugin, "Failed to check friend status: " + exception.getMessage());
+            return false;
+        }
+    }
+
+    private boolean hasPendingRequest(final UUID senderUuid, final UUID targetUuid) {
+        final String query = "SELECT 1 FROM friend_requests WHERE sender_uuid = ? AND target_uuid = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, senderUuid.toString());
+            statement.setString(2, targetUuid.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        } catch (final SQLException exception) {
+            LogUtils.warning(plugin, "Failed to check pending friend request: " + exception.getMessage());
+            return false;
+        }
+    }
+
+    private UUID resolveUuidByName(final String playerName) {
+        final String query = "SELECT uuid FROM players WHERE LOWER(username) = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerName.toLowerCase(Locale.ROOT));
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return UUID.fromString(resultSet.getString("uuid"));
+                }
+            }
+        } catch (final SQLException exception) {
+            LogUtils.warning(plugin, "Failed to resolve uuid for " + playerName + ": " + exception.getMessage());
+        }
+        return null;
+    }
+
+    private String buildInsertRequestQuery() {
+        final DatabaseType type = databaseManager.getDatabaseType();
+        if (type == DatabaseType.MYSQL) {
+            return """
+                    INSERT INTO friend_requests (sender_uuid, target_uuid, created_at)
+                    VALUES (?, ?, CURRENT_TIMESTAMP)
+                    ON DUPLICATE KEY UPDATE created_at = VALUES(created_at)
+                    """;
+        }
+        return """
+                INSERT INTO friend_requests (sender_uuid, target_uuid, created_at)
+                VALUES (?, ?, CURRENT_TIMESTAMP)
+                ON CONFLICT(sender_uuid, target_uuid) DO UPDATE SET created_at = CURRENT_TIMESTAMP
+                """;
+    }
+
+    private Optional<String> optionalString(final String value) {
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(value);
+    }
+
+    private String resolveOfflineName(final UUID uuid) {
+        final OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(uuid);
+        return offlinePlayer.getName() == null ? uuid.toString() : offlinePlayer.getName();
+    }
+}

--- a/src/main/java/com/lobby/friends/FriendMenuData.java
+++ b/src/main/java/com/lobby/friends/FriendMenuData.java
@@ -1,0 +1,27 @@
+package com.lobby.friends;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Bundles the data required to render the friends menu.
+ */
+public record FriendMenuData(List<FriendEntry> friends, List<FriendRequestEntry> requests) {
+
+    public FriendMenuData {
+        if (friends == null) {
+            throw new IllegalArgumentException("friends list cannot be null");
+        }
+        if (requests == null) {
+            throw new IllegalArgumentException("requests list cannot be null");
+        }
+    }
+
+    public List<FriendEntry> friends() {
+        return Collections.unmodifiableList(friends);
+    }
+
+    public List<FriendRequestEntry> requests() {
+        return Collections.unmodifiableList(requests);
+    }
+}

--- a/src/main/java/com/lobby/friends/FriendOperationResult.java
+++ b/src/main/java/com/lobby/friends/FriendOperationResult.java
@@ -1,0 +1,15 @@
+package com.lobby.friends;
+
+/**
+ * Result returned by friend operations such as sending a request.
+ */
+public record FriendOperationResult(boolean success, String message) {
+
+    public static FriendOperationResult success(final String message) {
+        return new FriendOperationResult(true, message);
+    }
+
+    public static FriendOperationResult failure(final String message) {
+        return new FriendOperationResult(false, message);
+    }
+}

--- a/src/main/java/com/lobby/friends/FriendRequestEntry.java
+++ b/src/main/java/com/lobby/friends/FriendRequestEntry.java
@@ -1,0 +1,18 @@
+package com.lobby.friends;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Represents a pending friend request sent to the viewing player.
+ */
+public record FriendRequestEntry(UUID senderUuid,
+                                 String senderName,
+                                 Instant createdAt) {
+
+    public FriendRequestEntry {
+        if (senderUuid == null) {
+            throw new IllegalArgumentException("Sender UUID cannot be null");
+        }
+    }
+}

--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -7,8 +7,12 @@ import org.bukkit.entity.Player;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Lightweight menu manager responsible for instantiating menus and tracking
@@ -19,11 +23,15 @@ public class MenuManager {
 
     private final LobbyPlugin plugin;
     private final AssetManager assetManager;
+    private final com.lobby.friends.FriendManager friendManager;
     private final Map<UUID, Menu> openMenus = new ConcurrentHashMap<>();
 
-    public MenuManager(final LobbyPlugin plugin, final AssetManager assetManager) {
+    public MenuManager(final LobbyPlugin plugin,
+                       final AssetManager assetManager,
+                       final com.lobby.friends.FriendManager friendManager) {
         this.plugin = plugin;
         this.assetManager = assetManager;
+        this.friendManager = friendManager;
     }
 
     public AssetManager getAssetManager() {
@@ -48,6 +56,13 @@ public class MenuManager {
             return false;
         }
         final String menuId = rawMenuId.toLowerCase(Locale.ROOT);
+
+        if (menuId.equals("amis_menu")) {
+            return openFriendsMenu(player, 0);
+        }
+        if (menuId.equals("amis_requests_menu")) {
+            return openFriendRequestsMenu(player);
+        }
 
         if (isSimpleMenu(menuId)) {
             return buildAndOpenSimpleMenu(player, menuId, placeholders, context);
@@ -137,5 +152,152 @@ public class MenuManager {
         } else {
             Bukkit.getScheduler().runTask(plugin, opener);
         }
+    }
+
+    public boolean openFriendsMenu(final Player player, final int page) {
+        if (player == null) {
+            return false;
+        }
+        if (friendManager == null) {
+            player.sendMessage(com.lobby.utils.MessageUtils.colorize("&cLe menu des amis est indisponible."));
+            return false;
+        }
+        final UUID playerUuid = player.getUniqueId();
+        final Set<UUID> onlineSnapshot = Bukkit.getOnlinePlayers().stream()
+                .map(Player::getUniqueId)
+                .collect(Collectors.toUnmodifiableSet());
+        return buildAndOpenHeavyMenu(player,
+                () -> new FriendMenuContext(friendManager.loadMenuData(playerUuid, onlineSnapshot), page),
+                (viewer, context) -> new com.lobby.menus.friends.FriendsMenu(plugin, this, assetManager,
+                        context.data().friends(), Math.max(0, context.page()), context.data().requests().size()));
+    }
+
+    public boolean openFriendRequestsMenu(final Player player) {
+        if (player == null) {
+            return false;
+        }
+        if (friendManager == null) {
+            player.sendMessage(com.lobby.utils.MessageUtils.colorize("&cLes demandes d'amis sont indisponibles."));
+            return false;
+        }
+        final UUID playerUuid = player.getUniqueId();
+        return buildAndOpenHeavyMenu(player,
+                () -> friendManager.loadIncomingRequests(playerUuid),
+                (viewer, requests) -> new com.lobby.menus.friends.FriendRequestsMenu(plugin, this, assetManager, requests));
+    }
+
+    public void toggleFriendFavorite(final Player player, final UUID friendUuid, final int currentPage) {
+        if (player == null || friendUuid == null) {
+            return;
+        }
+        if (friendManager == null) {
+            player.sendMessage(com.lobby.utils.MessageUtils.colorize("&cLe système d'amis est indisponible."));
+            return;
+        }
+        final UUID playerUuid = player.getUniqueId();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final boolean updated = friendManager.toggleFavorite(playerUuid, friendUuid);
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (!player.isOnline()) {
+                    return;
+                }
+                if (updated) {
+                    player.sendMessage(com.lobby.utils.MessageUtils.colorize("&aFavori mis à jour."));
+                } else {
+                    player.sendMessage(com.lobby.utils.MessageUtils.colorize("&cImpossible de mettre à jour ce favori."));
+                }
+                openFriendsMenu(player, currentPage);
+            });
+        });
+    }
+
+    public void handleFriendPrompt(final Player player, final String input) {
+        if (player == null) {
+            return;
+        }
+        if (friendManager == null) {
+            player.sendMessage(com.lobby.utils.MessageUtils.colorize("&cLe système d'amis est indisponible."));
+            return;
+        }
+        final UUID playerUuid = player.getUniqueId();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final com.lobby.friends.FriendOperationResult result = friendManager.sendFriendRequest(playerUuid, input);
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (!player.isOnline()) {
+                    return;
+                }
+                player.sendMessage(result.message());
+                openFriendsMenu(player, 0);
+            });
+        });
+    }
+
+    public void handleFriendRequestDecision(final Player player, final UUID senderUuid, final boolean accept) {
+        if (player == null || senderUuid == null) {
+            return;
+        }
+        if (friendManager == null) {
+            player.sendMessage(com.lobby.utils.MessageUtils.colorize("&cLe système d'amis est indisponible."));
+            return;
+        }
+        final UUID playerUuid = player.getUniqueId();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final boolean success = accept
+                    ? friendManager.acceptRequest(playerUuid, senderUuid)
+                    : friendManager.declineRequest(playerUuid, senderUuid);
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (!player.isOnline()) {
+                    return;
+                }
+                if (accept) {
+                    player.sendMessage(com.lobby.utils.MessageUtils.colorize(success
+                            ? "&aDemande d'ami acceptée !"
+                            : "&cImpossible d'accepter cette demande."));
+                } else {
+                    player.sendMessage(com.lobby.utils.MessageUtils.colorize(success
+                            ? "&eDemande d'ami refusée."
+                            : "&cImpossible de refuser cette demande."));
+                }
+                openFriendRequestsMenu(player);
+            });
+        });
+    }
+
+    public <T> boolean buildAndOpenHeavyMenu(final Player player,
+                                             final Supplier<T> dataSupplier,
+                                             final BiFunction<Player, T, Menu> menuFactory) {
+        if (player == null || dataSupplier == null || menuFactory == null) {
+            return false;
+        }
+        final UUID uuid = player.getUniqueId();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final T data;
+            try {
+                data = dataSupplier.get();
+            } catch (final Exception exception) {
+                plugin.getLogger().warning("Failed to prepare heavy menu: " + exception.getMessage());
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    final Player target = Bukkit.getPlayer(uuid);
+                    if (target != null && target.isOnline()) {
+                        target.sendMessage(com.lobby.utils.MessageUtils.colorize("&cCe menu est temporairement indisponible."));
+                    }
+                });
+                return;
+            }
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                final Player target = Bukkit.getPlayer(uuid);
+                if (target == null || !target.isOnline()) {
+                    return;
+                }
+                final Menu menu = menuFactory.apply(target, data);
+                if (menu != null) {
+                    displayMenu(target, menu);
+                }
+            });
+        });
+        return true;
+    }
+
+    private record FriendMenuContext(com.lobby.friends.FriendMenuData data, int page) {
     }
 }

--- a/src/main/java/com/lobby/menus/friends/FriendRequestsMenu.java
+++ b/src/main/java/com/lobby/menus/friends/FriendRequestsMenu.java
@@ -1,0 +1,205 @@
+package com.lobby.menus.friends;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.friends.FriendRequestEntry;
+import com.lobby.menus.AssetManager;
+import com.lobby.menus.Menu;
+import com.lobby.menus.MenuManager;
+import com.lobby.utils.MessageUtils;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+public class FriendRequestsMenu implements Menu, InventoryHolder {
+
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection();
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+            .withZone(ZoneId.systemDefault());
+
+    private final LobbyPlugin plugin;
+    private final MenuManager menuManager;
+    private final AssetManager assetManager;
+    private final FriendRequestsMenuConfig config;
+    private final List<FriendRequestEntry> requests;
+    private Inventory inventory;
+    private final Map<Integer, FriendRequestEntry> requestSlots = new HashMap<>();
+
+    public FriendRequestsMenu(final LobbyPlugin plugin,
+                              final MenuManager menuManager,
+                              final AssetManager assetManager,
+                              final List<FriendRequestEntry> requests) {
+        this.plugin = plugin;
+        this.menuManager = menuManager;
+        this.assetManager = assetManager;
+        this.config = FriendRequestsMenuConfig.load(plugin);
+        this.requests = requests == null ? List.of() : List.copyOf(requests);
+    }
+
+    @Override
+    public void open(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final Component title = LEGACY_SERIALIZER.deserialize(MessageUtils.colorize(config.title()));
+        inventory = Bukkit.createInventory(this, config.size(), title);
+        requestSlots.clear();
+
+        placeItems(config.designItems(), player);
+        placeItems(List.of(config.returnButton()), player);
+
+        fillRequests();
+        player.openInventory(inventory);
+    }
+
+    @Override
+    public void handleClick(final InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        final int slot = event.getSlot();
+        if (config.returnButton().slots().contains(slot)) {
+            handleAction(player, config.returnButton().action());
+            return;
+        }
+        final FriendRequestEntry entry = requestSlots.get(slot);
+        if (entry == null) {
+            return;
+        }
+        if (event.getClick() == ClickType.RIGHT) {
+            menuManager.handleFriendRequestDecision(player, entry.senderUuid(), false);
+        } else {
+            menuManager.handleFriendRequestDecision(player, entry.senderUuid(), true);
+        }
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    private void fillRequests() {
+        final Set<Integer> reservedSlots = new HashSet<>();
+        config.designItems().forEach(item -> reservedSlots.addAll(item.slots()));
+        reservedSlots.addAll(config.returnButton().slots());
+
+        final List<Integer> availableSlots = new ArrayList<>();
+        for (int i = 0; i < config.size(); i++) {
+            if (!reservedSlots.contains(i)) {
+                availableSlots.add(i);
+            }
+        }
+        final int displayCount = Math.min(requests.size(), availableSlots.size());
+        for (int index = 0; index < displayCount; index++) {
+            final FriendRequestEntry entry = requests.get(index);
+            final int slot = availableSlots.get(index);
+            inventory.setItem(slot, buildRequestItem(entry));
+            requestSlots.put(slot, entry);
+        }
+    }
+
+    private ItemStack buildRequestItem(final FriendRequestEntry entry) {
+        final ItemStack item = new ItemStack(Material.PLAYER_HEAD);
+        final ItemMeta baseMeta = item.getItemMeta();
+        if (baseMeta instanceof SkullMeta skullMeta) {
+            skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(entry.senderUuid()));
+            final String displayName = entry.senderName() == null ? entry.senderUuid().toString() : entry.senderName();
+            skullMeta.setDisplayName(colorize("&e" + displayName));
+            final List<String> lore = List.of(
+                    colorize("&7Demande reçue le &f" + DATE_FORMAT.format(entry.createdAt())),
+                    "",
+                    colorize("&a▶ Clic gauche : Accepter"),
+                    colorize("&c▶ Clic droit : Refuser")
+            );
+            skullMeta.setLore(lore);
+            item.setItemMeta(skullMeta);
+        }
+        return item;
+    }
+
+    private void placeItems(final List<FriendsMenuConfig.MenuItemDefinition> definitions, final Player viewer) {
+        for (FriendsMenuConfig.MenuItemDefinition definition : definitions) {
+            final ItemStack item = createItem(definition, viewer);
+            for (int slot : definition.slots()) {
+                inventory.setItem(slot, item);
+            }
+        }
+    }
+
+    private ItemStack createItem(final FriendsMenuConfig.MenuItemDefinition definition, final Player viewer) {
+        final ItemStack base;
+        if (definition.material() != null && definition.material().toLowerCase(Locale.ROOT).startsWith("hdb:")) {
+            base = assetManager.getHead(definition.material());
+        } else {
+            final Material material = Material.matchMaterial(definition.material().toUpperCase(Locale.ROOT));
+            base = new ItemStack(material == null ? Material.BARRIER : material);
+        }
+        base.setAmount(Math.max(1, definition.amount()));
+        final ItemMeta meta = base.getItemMeta();
+        if (meta != null) {
+            if (!definition.name().isBlank()) {
+                meta.setDisplayName(colorize(definition.name()));
+            }
+            final List<String> lore = definition.lore().stream().map(this::colorize).toList();
+            if (!lore.isEmpty()) {
+                meta.setLore(lore);
+            }
+            if (meta instanceof SkullMeta skullMeta) {
+                if (definition.playerHead() && viewer != null) {
+                    skullMeta.setOwningPlayer(viewer);
+                } else if (definition.skullOwner() != null && !definition.skullOwner().isBlank()) {
+                    skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(definition.skullOwner()));
+                }
+                base.setItemMeta(skullMeta);
+            } else {
+                base.setItemMeta(meta);
+            }
+        }
+        return base;
+    }
+
+    private String colorize(final String input) {
+        return ChatColor.translateAlternateColorCodes('&', input == null ? "" : input);
+    }
+
+    private void handleAction(final Player player, final String action) {
+        if (action == null || action.isBlank()) {
+            return;
+        }
+        final String trimmed = action.trim();
+        if (!trimmed.startsWith("[")) {
+            menuManager.openMenu(player, trimmed);
+            return;
+        }
+        final int closingIndex = trimmed.indexOf(']');
+        if (closingIndex <= 0) {
+            return;
+        }
+        final String type = trimmed.substring(1, closingIndex).trim().toUpperCase(Locale.ROOT);
+        final String argument = trimmed.substring(closingIndex + 1).trim();
+        if (type.equals("MENU")) {
+            if (!menuManager.openMenu(player, argument)) {
+                player.sendMessage(MessageUtils.colorize("&cCe menu est indisponible."));
+            }
+        }
+    }
+}

--- a/src/main/java/com/lobby/menus/friends/FriendRequestsMenuConfig.java
+++ b/src/main/java/com/lobby/menus/friends/FriendRequestsMenuConfig.java
@@ -1,0 +1,117 @@
+package com.lobby.menus.friends;
+
+import com.lobby.LobbyPlugin;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+final class FriendRequestsMenuConfig {
+
+    private final String title;
+    private final int size;
+    private final List<FriendsMenuConfig.MenuItemDefinition> designItems;
+    private final FriendsMenuConfig.MenuItemDefinition returnButton;
+
+    private FriendRequestsMenuConfig(final String title,
+                                     final int size,
+                                     final List<FriendsMenuConfig.MenuItemDefinition> designItems,
+                                     final FriendsMenuConfig.MenuItemDefinition returnButton) {
+        this.title = title;
+        this.size = size;
+        this.designItems = designItems;
+        this.returnButton = returnButton;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public List<FriendsMenuConfig.MenuItemDefinition> designItems() {
+        return designItems;
+    }
+
+    public FriendsMenuConfig.MenuItemDefinition returnButton() {
+        return returnButton;
+    }
+
+    static FriendRequestsMenuConfig load(final LobbyPlugin plugin) {
+        final YamlConfiguration configuration = loadConfiguration(plugin, "amis_requests_menu");
+        final String title = configuration.getString("title", "&8Menu");
+        final int size = normalizeSize(configuration.getInt("size", 54));
+        final List<FriendsMenuConfig.MenuItemDefinition> designItems = new ArrayList<>();
+        final ConfigurationSection designSection = configuration.getConfigurationSection("design");
+        if (designSection != null) {
+            final ConfigurationSection primary = designSection.getConfigurationSection("primary_border");
+            if (primary != null) {
+                final FriendsMenuConfig.MenuItemDefinition definition = FriendsMenuConfig.MenuItemDefinition.fromSection(
+                        "design-primary", primary, true);
+                if (definition != null) {
+                    designItems.add(definition);
+                }
+            }
+            final ConfigurationSection secondary = designSection.getConfigurationSection("secondary_border");
+            if (secondary != null) {
+                final FriendsMenuConfig.MenuItemDefinition definition = FriendsMenuConfig.MenuItemDefinition.fromSection(
+                        "design-secondary", secondary, true);
+                if (definition != null) {
+                    designItems.add(definition);
+                }
+            }
+        }
+        final ConfigurationSection itemsSection = configuration.getConfigurationSection("items");
+        if (itemsSection == null) {
+            throw new IllegalStateException("Menu amis_requests_menu missing items section");
+        }
+        final FriendsMenuConfig.MenuItemDefinition returnButton = FriendsMenuConfig.MenuItemDefinition.fromSection(
+                "return-to-friends", itemsSection.getConfigurationSection("return-to-friends"), true);
+        if (returnButton == null) {
+            throw new IllegalStateException("Menu amis_requests_menu missing return-to-friends item");
+        }
+        return new FriendRequestsMenuConfig(title, size, List.copyOf(designItems), returnButton);
+    }
+
+    private static int normalizeSize(final int requested) {
+        final int clamped = Math.max(9, Math.min(54, requested));
+        return (clamped % 9 == 0) ? clamped : ((clamped / 9) + 1) * 9;
+    }
+
+    private static YamlConfiguration loadConfiguration(final LobbyPlugin plugin, final String menuId) {
+        final File file = resolveMenuFile(plugin, menuId.toLowerCase(Locale.ROOT));
+        if (file == null) {
+            throw new IllegalStateException("Unable to resolve menu configuration for " + menuId);
+        }
+        final YamlConfiguration configuration = new YamlConfiguration();
+        try {
+            configuration.load(file);
+        } catch (IOException | InvalidConfigurationException exception) {
+            throw new IllegalStateException("Unable to load menu configuration " + menuId, exception);
+        }
+        return configuration;
+    }
+
+    private static File resolveMenuFile(final LobbyPlugin plugin, final String menuId) {
+        final File menusDirectory = new File(plugin.getDataFolder(), "menus");
+        if (!menusDirectory.exists() && !menusDirectory.mkdirs()) {
+            return null;
+        }
+        final File menuFile = new File(menusDirectory, menuId + ".yml");
+        if (menuFile.exists()) {
+            return menuFile;
+        }
+        try {
+            plugin.saveResource("menus/" + menuId + ".yml", false);
+        } catch (final IllegalArgumentException ignored) {
+        }
+        return menuFile.exists() ? menuFile : null;
+    }
+}

--- a/src/main/java/com/lobby/menus/friends/FriendsMenu.java
+++ b/src/main/java/com/lobby/menus/friends/FriendsMenu.java
@@ -1,0 +1,379 @@
+package com.lobby.menus.friends;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.friends.FriendEntry;
+import com.lobby.menus.AssetManager;
+import com.lobby.menus.Menu;
+import com.lobby.menus.MenuManager;
+import com.lobby.menus.prompt.ChatPromptManager;
+import com.lobby.utils.MessageUtils;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class FriendsMenu implements Menu, InventoryHolder {
+
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacySection();
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+            .withZone(ZoneId.systemDefault());
+    private static final Pattern COMPARISON_PATTERN = Pattern.compile(
+            "(-?\\d+(?:\\.\\d+)?)\\s*(>=|<=|==|!=|>|<)\\s*(-?\\d+(?:\\.\\d+)?)");
+
+    private final LobbyPlugin plugin;
+    private final MenuManager menuManager;
+    private final AssetManager assetManager;
+    private final FriendsMenuConfig config;
+    private final List<FriendEntry> friends;
+    private final int page;
+    private final int requestsCount;
+    private Inventory inventory;
+    private final Map<Integer, FriendEntry> friendSlots = new HashMap<>();
+
+    public FriendsMenu(final LobbyPlugin plugin,
+                       final MenuManager menuManager,
+                       final AssetManager assetManager,
+                       final List<FriendEntry> friends,
+                       final int page,
+                       final int requestsCount) {
+        this.plugin = plugin;
+        this.menuManager = menuManager;
+        this.assetManager = assetManager;
+        this.config = FriendsMenuConfig.load(plugin);
+        this.friends = friends == null ? List.of() : List.copyOf(friends);
+        this.page = Math.max(0, page);
+        this.requestsCount = Math.max(0, requestsCount);
+    }
+
+    @Override
+    public void open(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final Component title = LEGACY_SERIALIZER.deserialize(MessageUtils.colorize(config.title()));
+        inventory = Bukkit.createInventory(this, config.size(), title);
+        friendSlots.clear();
+
+        final Map<String, String> placeholders = new HashMap<>();
+        placeholders.put("%friend_requests_count%", Integer.toString(requestsCount));
+
+        placeItems(config.designItems(), placeholders, player, false);
+        placeItems(List.of(config.addFriendButton()), placeholders, player, false);
+        placeItems(List.of(config.requestsButton()), placeholders, player, true);
+        placeItems(List.of(config.previousPageButton(), config.nextPageButton(), config.returnButton()), placeholders,
+                player, false);
+
+        fillFriends(player);
+        player.openInventory(inventory);
+    }
+
+    @Override
+    public void handleClick(final InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        final int slot = event.getSlot();
+        final String normalizedAction = findActionForSlot(slot);
+        if (normalizedAction != null) {
+            handleAction(player, normalizedAction);
+            return;
+        }
+        final FriendEntry entry = friendSlots.get(slot);
+        if (entry == null) {
+            return;
+        }
+        if (event.isShiftClick()) {
+            handleFavoriteToggle(player, entry);
+            return;
+        }
+        player.closeInventory();
+        Bukkit.getScheduler().runTask(plugin,
+                () -> player.performCommand("msg " + entry.name()));
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    private void fillFriends(final Player player) {
+        final Set<Integer> reservedSlots = new HashSet<>();
+        config.designItems().forEach(item -> reservedSlots.addAll(item.slots()));
+        reservedSlots.addAll(config.addFriendButton().slots());
+        reservedSlots.addAll(config.requestsButton().slots());
+        reservedSlots.addAll(config.previousPageButton().slots());
+        reservedSlots.addAll(config.nextPageButton().slots());
+        reservedSlots.addAll(config.returnButton().slots());
+
+        final List<Integer> availableSlots = new ArrayList<>();
+        for (int i = 0; i < config.size(); i++) {
+            if (!reservedSlots.contains(i)) {
+                availableSlots.add(i);
+            }
+        }
+        if (availableSlots.isEmpty()) {
+            return;
+        }
+        final int itemsPerPage = availableSlots.size();
+        final int totalPages = Math.max(1, (int) Math.ceil((double) friends.size() / (double) itemsPerPage));
+        final int currentPage = Math.min(page, totalPages - 1);
+        final int startIndex = currentPage * itemsPerPage;
+        final int endIndex = Math.min(friends.size(), startIndex + itemsPerPage);
+
+        final List<FriendEntry> pageEntries = friends.subList(startIndex, endIndex);
+        final FriendsMenuConfig.MenuItemDefinition template = config.friendTemplate();
+        for (int index = 0; index < pageEntries.size(); index++) {
+            final FriendEntry entry = pageEntries.get(index);
+            final int slot = availableSlots.get(index);
+            final ItemStack item = buildFriendItem(template, entry, player);
+            inventory.setItem(slot, item);
+            friendSlots.put(slot, entry);
+        }
+    }
+
+    private ItemStack buildFriendItem(final FriendsMenuConfig.MenuItemDefinition template,
+                                      final FriendEntry entry,
+                                      final Player viewer) {
+        final Map<String, String> placeholders = new HashMap<>();
+        placeholders.put("%friend_name%", (entry.online() ? "&a" : "&7") + entry.name());
+        placeholders.put("%friend_status%", entry.online() ? "&aEn ligne" : "&cHors ligne");
+        placeholders.put("%friend_since_date%", DATE_FORMAT.format(entry.since()));
+        final ItemStack item = createItem(template, placeholders, viewer);
+        if (item.getType() == Material.PLAYER_HEAD) {
+            final ItemMeta meta = item.getItemMeta();
+            if (meta instanceof SkullMeta skullMeta) {
+                skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(entry.uuid()));
+                item.setItemMeta(skullMeta);
+            }
+        }
+        if (entry.favorite()) {
+            final ItemMeta meta = item.getItemMeta();
+            if (meta != null) {
+                meta.addEnchant(Enchantment.DURABILITY, 1, true);
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                item.setItemMeta(meta);
+            }
+        }
+        return item;
+    }
+
+    private void placeItems(final List<FriendsMenuConfig.MenuItemDefinition> definitions,
+                            final Map<String, String> placeholders,
+                            final Player viewer,
+                            final boolean evaluateEnchant) {
+        for (FriendsMenuConfig.MenuItemDefinition definition : definitions) {
+            final ItemStack item = createItem(definition, placeholders, viewer, evaluateEnchant);
+            for (int slot : definition.slots()) {
+                inventory.setItem(slot, item);
+            }
+        }
+    }
+
+    private ItemStack createItem(final FriendsMenuConfig.MenuItemDefinition definition,
+                                 final Map<String, String> placeholders,
+                                 final Player viewer) {
+        return createItem(definition, placeholders, viewer, true);
+    }
+
+    private ItemStack createItem(final FriendsMenuConfig.MenuItemDefinition definition,
+                                 final Map<String, String> placeholders,
+                                 final Player viewer,
+                                 final boolean evaluateEnchant) {
+        final String materialKey = definition.material();
+        final ItemStack base = resolveBaseItem(materialKey);
+        base.setAmount(Math.max(1, definition.amount()));
+        final ItemMeta meta = base.getItemMeta();
+        if (meta != null) {
+            final String displayName = applyPlaceholders(definition.name(), placeholders);
+            if (!displayName.isBlank()) {
+                meta.setDisplayName(colorize(displayName));
+            }
+            final List<String> lore = renderLore(definition.lore(), placeholders);
+            if (!lore.isEmpty()) {
+                meta.setLore(lore);
+            }
+            if (meta instanceof SkullMeta skullMeta) {
+                if (definition.playerHead() && viewer != null) {
+                    skullMeta.setOwningPlayer(viewer);
+                } else if (definition.skullOwner() != null && !definition.skullOwner().isBlank()) {
+                    skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(applyPlaceholders(definition.skullOwner(), placeholders)));
+                }
+            }
+            if (evaluateEnchant && shouldEnchant(definition.enchantExpression(), placeholders)) {
+                meta.addEnchant(Enchantment.DURABILITY, 1, true);
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
+            base.setItemMeta(meta);
+        }
+        return base;
+    }
+
+    private ItemStack resolveBaseItem(final String materialKey) {
+        if (materialKey == null || materialKey.isBlank()) {
+            return new ItemStack(Material.BARRIER);
+        }
+        final String trimmed = materialKey.trim();
+        if (trimmed.toLowerCase(Locale.ROOT).startsWith("hdb:")) {
+            return assetManager.getHead(trimmed);
+        }
+        final Material material = Material.matchMaterial(trimmed.toUpperCase(Locale.ROOT));
+        if (material == null) {
+            return new ItemStack(Material.BARRIER);
+        }
+        return new ItemStack(material);
+    }
+
+    private List<String> renderLore(final List<String> rawLore, final Map<String, String> placeholders) {
+        if (rawLore == null || rawLore.isEmpty()) {
+            return List.of();
+        }
+        final List<String> rendered = new ArrayList<>(rawLore.size());
+        for (String line : rawLore) {
+            if (line == null) {
+                continue;
+            }
+            rendered.add(colorize(applyPlaceholders(line, placeholders)));
+        }
+        return rendered;
+    }
+
+    private String applyPlaceholders(final String input, final Map<String, String> placeholders) {
+        if (input == null) {
+            return "";
+        }
+        String result = input;
+        for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+            result = result.replace(entry.getKey(), entry.getValue());
+        }
+        return result;
+    }
+
+    private String colorize(final String input) {
+        return ChatColor.translateAlternateColorCodes('&', Objects.requireNonNullElse(input, ""));
+    }
+
+    private boolean shouldEnchant(final String expression, final Map<String, String> placeholders) {
+        if (expression == null || expression.isBlank()) {
+            return false;
+        }
+        String processed = expression;
+        for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+            processed = processed.replace(entry.getKey(), entry.getValue());
+        }
+        processed = processed.trim();
+        if (processed.equalsIgnoreCase("true")) {
+            return true;
+        }
+        if (processed.equalsIgnoreCase("false")) {
+            return false;
+        }
+        final Matcher matcher = COMPARISON_PATTERN.matcher(processed);
+        if (!matcher.matches()) {
+            return false;
+        }
+        final double left = Double.parseDouble(matcher.group(1));
+        final String operator = matcher.group(2);
+        final double right = Double.parseDouble(matcher.group(3));
+        return switch (operator) {
+            case ">" -> left > right;
+            case ">=" -> left >= right;
+            case "<" -> left < right;
+            case "<=" -> left <= right;
+            case "==" -> Double.compare(left, right) == 0;
+            case "!=" -> Double.compare(left, right) != 0;
+            default -> false;
+        };
+    }
+
+    private String findActionForSlot(final int slot) {
+        if (config.addFriendButton().slots().contains(slot)) {
+            return config.addFriendButton().action();
+        }
+        if (config.requestsButton().slots().contains(slot)) {
+            return config.requestsButton().action();
+        }
+        if (config.previousPageButton().slots().contains(slot)) {
+            return config.previousPageButton().action();
+        }
+        if (config.nextPageButton().slots().contains(slot)) {
+            return config.nextPageButton().action();
+        }
+        if (config.returnButton().slots().contains(slot)) {
+            return config.returnButton().action();
+        }
+        return null;
+    }
+
+    private void handleAction(final Player player, final String action) {
+        if (action == null || action.isBlank()) {
+            return;
+        }
+        final String trimmed = action.trim();
+        if (!trimmed.startsWith("[")) {
+            return;
+        }
+        final int closingIndex = trimmed.indexOf(']');
+        if (closingIndex <= 0) {
+            return;
+        }
+        final String type = trimmed.substring(1, closingIndex).trim().toUpperCase(Locale.ROOT);
+        final String argument = trimmed.substring(closingIndex + 1).trim();
+        switch (type) {
+            case "MENU" -> {
+                if (!menuManager.openMenu(player, argument)) {
+                    player.sendMessage(MessageUtils.colorize("&cCe menu est indisponible."));
+                }
+            }
+            case "CHAT_PROMPT" -> openChatPrompt(player, argument);
+            case "PAGE" -> handlePageChange(player, argument);
+            default -> {
+            }
+        }
+    }
+
+    private void handlePageChange(final Player player, final String argument) {
+        final int targetPage = switch (argument.toLowerCase(Locale.ROOT)) {
+            case "previous" -> Math.max(0, page - 1);
+            case "next" -> page + 1;
+            default -> page;
+        };
+        menuManager.openFriendsMenu(player, targetPage);
+    }
+
+    private void openChatPrompt(final Player player, final String message) {
+        final ChatPromptManager promptManager = plugin.getChatPromptManager();
+        if (promptManager == null) {
+            player.sendMessage(MessageUtils.colorize("&cLe système de saisie est indisponible."));
+            return;
+        }
+        promptManager.openPrompt(player, message, (target, input) -> menuManager.handleFriendPrompt(target, input));
+    }
+
+    private void handleFavoriteToggle(final Player player, final FriendEntry entry) {
+        menuManager.toggleFriendFavorite(player, entry.uuid(), page);
+    }
+}

--- a/src/main/java/com/lobby/menus/friends/FriendsMenuConfig.java
+++ b/src/main/java/com/lobby/menus/friends/FriendsMenuConfig.java
@@ -1,0 +1,205 @@
+package com.lobby.menus.friends;
+
+import com.lobby.LobbyPlugin;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+final class FriendsMenuConfig {
+
+    private final String title;
+    private final int size;
+    private final List<MenuItemDefinition> designItems;
+    private final MenuItemDefinition addFriendButton;
+    private final MenuItemDefinition requestsButton;
+    private final MenuItemDefinition friendTemplate;
+    private final MenuItemDefinition previousPageButton;
+    private final MenuItemDefinition nextPageButton;
+    private final MenuItemDefinition returnButton;
+
+    private FriendsMenuConfig(final String title,
+                              final int size,
+                              final List<MenuItemDefinition> designItems,
+                              final MenuItemDefinition addFriendButton,
+                              final MenuItemDefinition requestsButton,
+                              final MenuItemDefinition friendTemplate,
+                              final MenuItemDefinition previousPageButton,
+                              final MenuItemDefinition nextPageButton,
+                              final MenuItemDefinition returnButton) {
+        this.title = title;
+        this.size = size;
+        this.designItems = designItems;
+        this.addFriendButton = addFriendButton;
+        this.requestsButton = requestsButton;
+        this.friendTemplate = friendTemplate;
+        this.previousPageButton = previousPageButton;
+        this.nextPageButton = nextPageButton;
+        this.returnButton = returnButton;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public List<MenuItemDefinition> designItems() {
+        return designItems;
+    }
+
+    public MenuItemDefinition addFriendButton() {
+        return addFriendButton;
+    }
+
+    public MenuItemDefinition requestsButton() {
+        return requestsButton;
+    }
+
+    public MenuItemDefinition friendTemplate() {
+        return friendTemplate;
+    }
+
+    public MenuItemDefinition previousPageButton() {
+        return previousPageButton;
+    }
+
+    public MenuItemDefinition nextPageButton() {
+        return nextPageButton;
+    }
+
+    public MenuItemDefinition returnButton() {
+        return returnButton;
+    }
+
+    static FriendsMenuConfig load(final LobbyPlugin plugin) {
+        final YamlConfiguration configuration = loadConfiguration(plugin, "amis_menu");
+        final String title = configuration.getString("title", "&8Menu");
+        final int size = normalizeSize(configuration.getInt("size", 54));
+        final List<MenuItemDefinition> designItems = new ArrayList<>();
+        final ConfigurationSection designSection = configuration.getConfigurationSection("design");
+        if (designSection != null) {
+            final ConfigurationSection primary = designSection.getConfigurationSection("primary_border");
+            if (primary != null) {
+                final MenuItemDefinition definition = MenuItemDefinition.fromSection("design-primary", primary, true);
+                if (definition != null) {
+                    designItems.add(definition);
+                }
+            }
+            final ConfigurationSection secondary = designSection.getConfigurationSection("secondary_border");
+            if (secondary != null) {
+                final MenuItemDefinition definition = MenuItemDefinition.fromSection("design-secondary", secondary, true);
+                if (definition != null) {
+                    designItems.add(definition);
+                }
+            }
+        }
+
+        final ConfigurationSection itemsSection = configuration.getConfigurationSection("items");
+        if (itemsSection == null) {
+            throw new IllegalStateException("Menu amis_menu missing items section");
+        }
+
+        final MenuItemDefinition addFriend = MenuItemDefinition.fromSection("add-friend",
+                itemsSection.getConfigurationSection("add-friend"), true);
+        final MenuItemDefinition requests = MenuItemDefinition.fromSection("requests",
+                itemsSection.getConfigurationSection("requests"), true);
+        final MenuItemDefinition template = MenuItemDefinition.fromSection("friend-list-template",
+                itemsSection.getConfigurationSection("friend-list-template"), false);
+        final MenuItemDefinition prev = MenuItemDefinition.fromSection("prev-page",
+                itemsSection.getConfigurationSection("prev-page"), true);
+        final MenuItemDefinition next = MenuItemDefinition.fromSection("next-page",
+                itemsSection.getConfigurationSection("next-page"), true);
+        final MenuItemDefinition back = MenuItemDefinition.fromSection("return-to-profile",
+                itemsSection.getConfigurationSection("return-to-profile"), true);
+
+        if (addFriend == null || requests == null || template == null || prev == null || next == null || back == null) {
+            throw new IllegalStateException("Menu amis_menu missing required items");
+        }
+
+        return new FriendsMenuConfig(title, size, List.copyOf(designItems), addFriend, requests, template, prev, next, back);
+    }
+
+    private static int normalizeSize(final int requested) {
+        final int clamped = Math.max(9, Math.min(54, requested));
+        return (clamped % 9 == 0) ? clamped : ((clamped / 9) + 1) * 9;
+    }
+
+    private static YamlConfiguration loadConfiguration(final LobbyPlugin plugin, final String menuId) {
+        final File file = resolveMenuFile(plugin, menuId.toLowerCase(Locale.ROOT));
+        if (file == null) {
+            throw new IllegalStateException("Unable to resolve menu configuration for " + menuId);
+        }
+        final YamlConfiguration configuration = new YamlConfiguration();
+        try {
+            configuration.load(file);
+        } catch (IOException | InvalidConfigurationException exception) {
+            throw new IllegalStateException("Unable to load menu configuration " + menuId, exception);
+        }
+        return configuration;
+    }
+
+    private static File resolveMenuFile(final LobbyPlugin plugin, final String menuId) {
+        final File menusDirectory = new File(plugin.getDataFolder(), "menus");
+        if (!menusDirectory.exists() && !menusDirectory.mkdirs()) {
+            return null;
+        }
+        final File menuFile = new File(menusDirectory, menuId + ".yml");
+        if (menuFile.exists()) {
+            return menuFile;
+        }
+        try {
+            plugin.saveResource("menus/" + menuId + ".yml", false);
+        } catch (final IllegalArgumentException ignored) {
+            // Custom file only
+        }
+        return menuFile.exists() ? menuFile : null;
+    }
+
+    record MenuItemDefinition(String id,
+                              List<Integer> slots,
+                              String material,
+                              String name,
+                              List<String> lore,
+                              String action,
+                              String skullOwner,
+                              boolean playerHead,
+                              String enchantExpression,
+                              int amount) {
+
+        static MenuItemDefinition fromSection(final String id,
+                                              final ConfigurationSection section,
+                                              final boolean requireSlot) {
+            if (section == null) {
+                return null;
+            }
+            final List<Integer> slots = new ArrayList<>();
+            if (section.isList("slots")) {
+                section.getIntegerList("slots").forEach(slot -> slots.add(Math.max(0, slot)));
+            }
+            if (section.contains("slot")) {
+                slots.add(section.getInt("slot"));
+            }
+            if (requireSlot && slots.isEmpty()) {
+                return null;
+            }
+            final String material = section.getString("material", "BARRIER");
+            final String name = section.getString("name", "&r");
+            final List<String> lore = section.getStringList("lore");
+            final String action = section.getString("action", "");
+            final String skullOwner = section.getString("skull-owner");
+            final boolean playerHead = section.getBoolean("player-head", false);
+            final String enchant = section.getString("enchanted");
+            final int amount = Math.max(1, section.getInt("amount", 1));
+            return new MenuItemDefinition(id, List.copyOf(slots), material, name, List.copyOf(lore), action,
+                    skullOwner, playerHead, enchant, amount);
+        }
+    }
+}

--- a/src/main/java/com/lobby/menus/prompt/ChatPromptManager.java
+++ b/src/main/java/com/lobby/menus/prompt/ChatPromptManager.java
@@ -1,0 +1,78 @@
+package com.lobby.menus.prompt;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.utils.MessageUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+
+/**
+ * Handles temporary chat prompts triggered from menus.
+ */
+public class ChatPromptManager implements Listener {
+
+    private final LobbyPlugin plugin;
+    private final Map<UUID, Prompt> prompts = new ConcurrentHashMap<>();
+
+    public ChatPromptManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void openPrompt(final Player player,
+                           final String message,
+                           final BiConsumer<Player, String> handler) {
+        if (player == null || handler == null) {
+            return;
+        }
+        prompts.put(player.getUniqueId(), new Prompt(handler));
+        player.closeInventory();
+        if (message != null && !message.isBlank()) {
+            player.sendMessage(MessageUtils.colorize(message));
+        }
+        player.sendMessage(MessageUtils.colorize("&7Tapez &ccancel &7pour annuler."));
+    }
+
+    public void cancelPrompt(final UUID uuid) {
+        if (uuid != null) {
+            prompts.remove(uuid);
+        }
+    }
+
+    public boolean hasPrompt(final UUID uuid) {
+        return uuid != null && prompts.containsKey(uuid);
+    }
+
+    @EventHandler
+    public void onChat(final AsyncPlayerChatEvent event) {
+        final Player player = event.getPlayer();
+        final Prompt prompt = prompts.remove(player.getUniqueId());
+        if (prompt == null) {
+            return;
+        }
+        event.setCancelled(true);
+        final String message = event.getMessage();
+        if (message != null && message.equalsIgnoreCase("cancel")) {
+            Bukkit.getScheduler().runTask(plugin,
+                    () -> player.sendMessage(MessageUtils.colorize("&cDemande annulée.")));
+            return;
+        }
+        Bukkit.getScheduler().runTaskAsynchronously(plugin,
+                () -> prompt.handler().accept(player, message == null ? "" : message.trim()));
+    }
+
+    @EventHandler
+    public void onQuit(final PlayerQuitEvent event) {
+        cancelPrompt(event.getPlayer().getUniqueId());
+    }
+
+    private record Prompt(BiConsumer<Player, String> handler) {
+    }
+}

--- a/src/main/resources/menus/amis_menu.yml
+++ b/src/main/resources/menus/amis_menu.yml
@@ -1,0 +1,62 @@
+title: '&8» &aMes Amis'
+size: 54
+design:
+  primary_border: { material: 'LIME_STAINED_GLASS_PANE', slots: [0,1,2,6,7,8,9,17,36,44,45,46,52,53] }
+  secondary_border: { material: 'GRAY_STAINED_GLASS_PANE', slots: [39,40,41] }
+items:
+  add-friend:
+    slot: 3
+    material: 'hdb:23533'
+    name: '&a&lAjouter un Ami'
+    lore:
+      - '&r'
+      - '&7Envoyez une demande d''ami'
+      - '&7à un autre joueur.'
+      - '&r'
+      - '&e▶ Cliquez pour taper un pseudo'
+    action: '[CHAT_PROMPT] &aVeuillez taper le pseudo de l''ami à ajouter.'
+
+  requests:
+    slot: 7
+    material: 'hdb:23528'
+    name: '&e&lDemandes Reçues'
+    enchanted: '%friend_requests_count% > 0'
+    lore:
+      - '&r'
+      - '&7Gérez les demandes d''ami que'
+      - '&7vous avez reçues.'
+      - '&r'
+      - '&b▸ En attente : &6%friend_requests_count%'
+      - '&r'
+      - '&e▶ Cliquez pour voir'
+    action: '[MENU] amis_requests_menu'
+
+  friend-list-template:
+    material: 'PLAYER_HEAD'
+    name: '&a%friend_name%'
+    lore:
+      - '&r'
+      - '&7Statut: %friend_status%'
+      - '&r'
+      - '&b▸ Ami depuis: &f%friend_since_date%'
+      - '&r'
+      - '&e▶ Clic-gauche : Message'
+      - '&d▶ Maj-clic : Gérer Favori'
+
+  prev-page:
+    slot: 48
+    material: 'hdb:31405'
+    name: '&c&lPage Précédente'
+    action: '[PAGE] previous'
+
+  return-to-profile:
+    slot: 50
+    material: 'hdb:9334'
+    name: '&c&lRetour au Profil'
+    action: '[MENU] profil_menu'
+
+  next-page:
+    slot: 52
+    material: 'hdb:31406'
+    name: '&a&lPage Suivante'
+    action: '[PAGE] next'

--- a/src/main/resources/menus/amis_requests_menu.yml
+++ b/src/main/resources/menus/amis_requests_menu.yml
@@ -1,0 +1,11 @@
+title: '&8» &eDemandes d''Amis'
+size: 54
+design:
+  primary_border: { material: 'LIME_STAINED_GLASS_PANE', slots: [0,1,2,6,7,8,9,17,36,44,45,46,52,53] }
+  secondary_border: { material: 'GRAY_STAINED_GLASS_PANE', slots: [39,40,41] }
+items:
+  return-to-friends:
+    slot: 50
+    material: 'hdb:9334'
+    name: '&c&lRetour'
+    action: '[MENU] amis_menu'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -27,6 +27,9 @@ commands:
   jeux:
     description: Ouvre le menu des jeux
     permission: lobby.use
+  amis:
+    description: Ouvre le menu des amis
+    permission: lobby.use
   serveurs:
     description: Ouvre le sélecteur de serveurs
     aliases: [server]


### PR DESCRIPTION
## Summary
- implement a new FriendManager with async database lookups and friend/favorite/request actions
- add configurable amis and amis_requests menus with dynamic rendering, chat prompts, and request handling
- wire the system into LobbyPlugin, MenuManager, player commands, and register the /amis command

## Testing
- mvn -q -DskipTests package *(fails: dependency download blocked by HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d6934bb3d88329bc6b49e71a66a8a8