### PR TITLE
Add friends main menu with dynamic data scaffolding

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -16,6 +16,9 @@ import com.lobby.menus.GlobalListener;
 import com.lobby.menus.MenuManager;
 import com.lobby.menus.prompt.ChatPromptManager;
 import com.lobby.menus.confirmation.ConfirmationManager;
+import com.lobby.friends.DefaultFriendsDataProvider;
+import com.lobby.friends.menu.FriendsMenuController;
+import com.lobby.friends.menu.NoopFriendsMenuActionHandler;
 import com.lobby.npcs.NPCInteractionHandler;
 import com.lobby.npcs.NPCManager;
 import com.lobby.events.PlayerJoinLeaveEvent;
@@ -64,6 +67,8 @@ public final class LobbyPlugin extends JavaPlugin {
     private ScoreboardManager scoreboardManager;
     private NametagManager nametagManager;
     private TablistManager tablistManager;
+    private DefaultFriendsDataProvider friendsDataProvider;
+    private FriendsMenuController friendsMenuController;
 
     public static LobbyPlugin getInstance() {
         return instance;
@@ -109,6 +114,9 @@ public final class LobbyPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new GlobalListener(menuManager), this);
         getServer().getPluginManager().registerEvents(chatPromptManager, this);
         confirmationManager = new ConfirmationManager(this);
+        friendsDataProvider = new DefaultFriendsDataProvider();
+        friendsMenuController = new FriendsMenuController(this, menuManager, assetManager, friendsDataProvider,
+                new NoopFriendsMenuActionHandler());
         shopManager = new ShopManager(this);
         shopManager.initialize();
         shopCommands = new ShopCommands(this, shopManager);
@@ -189,6 +197,8 @@ public final class LobbyPlugin extends JavaPlugin {
         if (confirmationManager != null) {
             confirmationManager.clearAll();
         }
+        friendsMenuController = null;
+        friendsDataProvider = null;
         instance = null;
     }
 
@@ -276,6 +286,14 @@ public final class LobbyPlugin extends JavaPlugin {
         return tablistManager;
     }
 
+    public FriendsMenuController getFriendsMenuController() {
+        return friendsMenuController;
+    }
+
+    public DefaultFriendsDataProvider getFriendsDataProvider() {
+        return friendsDataProvider;
+    }
+
     public void reloadLobbyConfig() {
         if (configManager != null) {
             configManager.reloadConfigs();
@@ -302,6 +320,9 @@ public final class LobbyPlugin extends JavaPlugin {
             menuManager.closeAll();
             menuManager.reloadMenus();
         }
+        if (friendsMenuController != null) {
+            friendsMenuController.reload();
+        }
         if (serverManager != null) {
             serverManager.reload();
         }
@@ -320,7 +341,7 @@ public final class LobbyPlugin extends JavaPlugin {
     }
 
     private void registerCommands() {
-        final PlayerCommands playerCommands = new PlayerCommands(lobbyManager, menuManager);
+        final PlayerCommands playerCommands = new PlayerCommands(lobbyManager, menuManager, friendsMenuController);
         registerCommand("lobby", playerCommands);
         registerCommand("serveurs", playerCommands);
         registerCommand("profil", playerCommands);

--- a/src/main/java/com/lobby/commands/PlayerCommands.java
+++ b/src/main/java/com/lobby/commands/PlayerCommands.java
@@ -3,6 +3,7 @@ package com.lobby.commands;
 import com.lobby.lobby.LobbyManager;
 import com.lobby.menus.MenuManager;
 import com.lobby.utils.MessageUtils;
+import com.lobby.friends.menu.FriendsMenuController;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -24,10 +25,14 @@ public class PlayerCommands implements CommandExecutor, TabExecutor {
 
     private final LobbyManager lobbyManager;
     private final MenuManager menuManager;
+    private final FriendsMenuController friendsMenuController;
 
-    public PlayerCommands(final LobbyManager lobbyManager, final MenuManager menuManager) {
+    public PlayerCommands(final LobbyManager lobbyManager,
+                          final MenuManager menuManager,
+                          final FriendsMenuController friendsMenuController) {
         this.lobbyManager = lobbyManager;
         this.menuManager = menuManager;
+        this.friendsMenuController = friendsMenuController;
     }
 
     @Override
@@ -63,7 +68,14 @@ public class PlayerCommands implements CommandExecutor, TabExecutor {
     private void handleLobbyCommand(final Player player, final String[] args) {
         if (args != null && args.length > 0) {
             final String argument = args[0].toLowerCase(Locale.ROOT);
-            if (argument.equals("clan") || argument.equals("friends") || argument.equals("groups")) {
+            if (argument.equals("friends")) {
+                if (friendsMenuController != null && friendsMenuController.openMainMenu(player)) {
+                    return;
+                }
+                MessageUtils.sendConfigMessage(player, "commands.unavailable", Map.of("command", "/lobby " + argument));
+                return;
+            }
+            if (argument.equals("clan") || argument.equals("groups")) {
                 MessageUtils.sendConfigMessage(player, "commands.unavailable", Map.of("command", "/lobby " + argument));
                 return;
             }

--- a/src/main/java/com/lobby/friends/DefaultFriendsDataProvider.java
+++ b/src/main/java/com/lobby/friends/DefaultFriendsDataProvider.java
@@ -1,0 +1,40 @@
+package com.lobby.friends;
+
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Simple in-memory provider used while the friends backend is still under
+ * construction. Values can be overridden per player and fallback to sensible
+ * defaults otherwise.
+ */
+public class DefaultFriendsDataProvider implements FriendsDataProvider {
+
+    private final Map<UUID, FriendsPlaceholderData> overrides = new ConcurrentHashMap<>();
+
+    @Override
+    public FriendsPlaceholderData resolve(final Player player) {
+        if (player == null) {
+            return FriendsPlaceholderData.empty();
+        }
+        return overrides.getOrDefault(player.getUniqueId(), FriendsPlaceholderData.empty());
+    }
+
+    public void updateData(final UUID playerId, final FriendsPlaceholderData data) {
+        if (playerId == null || data == null) {
+            return;
+        }
+        overrides.put(playerId, data);
+    }
+
+    public void clearData(final UUID playerId) {
+        if (playerId == null) {
+            return;
+        }
+        overrides.remove(playerId);
+    }
+}
+

--- a/src/main/java/com/lobby/friends/FriendsDataProvider.java
+++ b/src/main/java/com/lobby/friends/FriendsDataProvider.java
@@ -1,0 +1,20 @@
+package com.lobby.friends;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Provides dynamic data for the friends system UI. Implementations are
+ * responsible for aggregating statistics and counts that populate the main
+ * friends menu placeholders.
+ */
+public interface FriendsDataProvider {
+
+    /**
+     * Resolves the placeholder data for the given player.
+     *
+     * @param player the player viewing the menu
+     * @return the data snapshot that should be displayed
+     */
+    FriendsPlaceholderData resolve(Player player);
+}
+

--- a/src/main/java/com/lobby/friends/FriendsPlaceholderData.java
+++ b/src/main/java/com/lobby/friends/FriendsPlaceholderData.java
@@ -1,0 +1,84 @@
+package com.lobby.friends;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Snapshot of every placeholder used by the friends menus. The record holds all
+ * numeric and textual values that can be interpolated inside menu items.
+ */
+public record FriendsPlaceholderData(
+        int amisEnLigne,
+        int amisHorsLigne,
+        int totalAmis,
+        int limiteAmis,
+        int demandesEnvoyees,
+        int demandesEnAttente,
+        int nouvellesDemandes,
+        int totalDemandes,
+        int joueursBloques,
+        String demandesAuto,
+        String notifications,
+        String visibilite,
+        int amisFavoris,
+        int favorisEnLigne,
+        String tempsTotal,
+        int messagesTotal,
+        String amiAncien) {
+
+    private static final FriendsPlaceholderData EMPTY = new FriendsPlaceholderData(
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            "Désactivé", "Aucune", "Public",
+            0, 0, "0h 0m", 0, "-"
+    );
+
+    public FriendsPlaceholderData {
+        demandesAuto = normalizeText(demandesAuto, "Désactivé");
+        notifications = normalizeText(notifications, "Aucune");
+        visibilite = normalizeText(visibilite, "Public");
+        tempsTotal = normalizeText(tempsTotal, "0h 0m");
+        amiAncien = normalizeText(amiAncien, "-");
+    }
+
+    private static String normalizeText(final String input, final String defaultValue) {
+        if (input == null || input.isBlank()) {
+            return defaultValue;
+        }
+        return input;
+    }
+
+    public static FriendsPlaceholderData empty() {
+        return EMPTY;
+    }
+
+    /**
+     * Builds a mutable map containing every placeholder token and its
+     * corresponding formatted value. Numeric values are formatted using the
+     * default locale without grouping to ensure deterministic replacements.
+     *
+     * @return map of placeholder tokens without braces to their value
+     */
+    public Map<String, String> toPlaceholderMap() {
+        final Map<String, String> map = new HashMap<>();
+        map.put("amis_en_ligne", Integer.toString(Math.max(0, amisEnLigne())));
+        map.put("amis_hors_ligne", Integer.toString(Math.max(0, amisHorsLigne())));
+        map.put("total_amis", Integer.toString(Math.max(0, totalAmis())));
+        map.put("limite_amis", Integer.toString(Math.max(0, limiteAmis())));
+        map.put("demandes_envoyees", Integer.toString(Math.max(0, demandesEnvoyees())));
+        map.put("demandes_en_attente", Integer.toString(Math.max(0, demandesEnAttente())));
+        map.put("nouvelles_demandes", Integer.toString(Math.max(0, nouvellesDemandes())));
+        map.put("total_demandes", Integer.toString(Math.max(0, totalDemandes())));
+        map.put("joueurs_bloques", Integer.toString(Math.max(0, joueursBloques())));
+        map.put("demandes_auto", Objects.requireNonNullElse(demandesAuto(), "Désactivé"));
+        map.put("notifications", Objects.requireNonNullElse(notifications(), "Aucune"));
+        map.put("visibilite", Objects.requireNonNullElse(visibilite(), "Public"));
+        map.put("amis_favoris", Integer.toString(Math.max(0, amisFavoris())));
+        map.put("favoris_en_ligne", Integer.toString(Math.max(0, favorisEnLigne())));
+        map.put("temps_total", Objects.requireNonNullElse(tempsTotal(), "0h 0m"));
+        map.put("messages_total", Integer.toString(Math.max(0, messagesTotal())));
+        map.put("ami_ancien", Objects.requireNonNullElse(amiAncien(), "-"));
+        return map;
+    }
+}
+

--- a/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
@@ -1,0 +1,231 @@
+package com.lobby.friends.menu;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.friends.FriendsDataProvider;
+import com.lobby.friends.FriendsPlaceholderData;
+import com.lobby.menus.AssetManager;
+import com.lobby.menus.CloseableMenu;
+import com.lobby.menus.Menu;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+public final class FriendsMainMenu implements Menu, InventoryHolder, CloseableMenu {
+
+    private static final LegacyComponentSerializer SERIALIZER = LegacyComponentSerializer.legacySection();
+
+    private final LobbyPlugin plugin;
+    private final AssetManager assetManager;
+    private final FriendsMenuConfiguration configuration;
+    private final FriendsDataProvider dataProvider;
+    private final FriendsMenuActionHandler actionHandler;
+    private final Map<Integer, FriendsMenuItem> itemBySlot = new HashMap<>();
+
+    private Inventory inventory;
+    private Player viewer;
+    private BukkitTask updateTask;
+
+    public FriendsMainMenu(final LobbyPlugin plugin,
+                           final AssetManager assetManager,
+                           final FriendsMenuConfiguration configuration,
+                           final FriendsDataProvider dataProvider,
+                           final FriendsMenuActionHandler actionHandler) {
+        this.plugin = plugin;
+        this.assetManager = assetManager;
+        this.configuration = configuration;
+        this.dataProvider = dataProvider;
+        this.actionHandler = actionHandler;
+        for (FriendsMenuItem item : configuration.getItems()) {
+            itemBySlot.put(item.getSlot(), item);
+        }
+    }
+
+    @Override
+    public void open(final Player player) {
+        if (player == null) {
+            return;
+        }
+        this.viewer = player;
+        final Component title = SERIALIZER.deserialize(colorize(configuration.getTitle()));
+        this.inventory = Bukkit.createInventory(this, configuration.getSize(), title);
+        buildStaticLayout();
+        refreshDynamicContent();
+        scheduleUpdates();
+        playSound(player, configuration.getOpenSound());
+        player.openInventory(inventory);
+    }
+
+    @Override
+    public void handleClick(final InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        final FriendsMenuItem item = itemBySlot.get(event.getSlot());
+        if (item == null || item.getAction() == null || item.getAction().isBlank()) {
+            playSound(player, configuration.getErrorSound());
+            return;
+        }
+        final boolean handled = actionHandler != null && actionHandler.handle(player, item.getAction());
+        playSound(player, handled ? configuration.getClickSound() : configuration.getErrorSound());
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    @Override
+    public void handleClose(final Player player) {
+        if (updateTask != null) {
+            updateTask.cancel();
+            updateTask = null;
+        }
+    }
+
+    private void scheduleUpdates() {
+        if (configuration.getUpdateIntervalSeconds() <= 0) {
+            return;
+        }
+        updateTask = Bukkit.getScheduler().runTaskTimer(plugin, this::refreshDynamicContent,
+                configuration.getUpdateIntervalTicks(), configuration.getUpdateIntervalTicks());
+    }
+
+    private void buildStaticLayout() {
+        if (inventory == null) {
+            return;
+        }
+        for (FriendsMenuDecoration decoration : configuration.getDecorations()) {
+            final ItemStack pane = new ItemStack(decoration.material());
+            final ItemMeta meta = pane.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName(decoration.displayName());
+                pane.setItemMeta(meta);
+            }
+            for (Integer slot : decoration.slots()) {
+                if (slot == null || slot < 0 || slot >= configuration.getSize()) {
+                    continue;
+                }
+                inventory.setItem(slot, pane);
+            }
+        }
+    }
+
+    private void refreshDynamicContent() {
+        if (inventory == null || viewer == null) {
+            return;
+        }
+        final FriendsPlaceholderData data = dataProvider == null
+                ? FriendsPlaceholderData.empty()
+                : Objects.requireNonNullElse(dataProvider.resolve(viewer), FriendsPlaceholderData.empty());
+        final Map<String, String> placeholders = data.toPlaceholderMap();
+
+        for (FriendsMenuItem definition : configuration.getItems()) {
+            final ItemStack itemStack = createItem(definition, placeholders);
+            if (itemStack == null) {
+                continue;
+            }
+            inventory.setItem(definition.getSlot(), itemStack);
+        }
+        viewer.updateInventory();
+    }
+
+    private ItemStack createItem(final FriendsMenuItem definition, final Map<String, String> placeholders) {
+        final ItemStack base = resolveItem(definition.getMaterialKey());
+        if (base == null) {
+            return null;
+        }
+        final ItemMeta meta = base.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(colorize(apply(definition.getDisplayName(), placeholders)));
+            final List<String> lore = definition.getLore().stream()
+                    .map(line -> colorize(apply(line, placeholders)))
+                    .toList();
+            if (!lore.isEmpty()) {
+                meta.setLore(lore);
+            }
+            final boolean shouldEnchant = shouldApplyEnchantment(definition, placeholders);
+            if (shouldEnchant) {
+                meta.addEnchant(Enchantment.DURABILITY, 1, true);
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            } else {
+                meta.removeEnchant(Enchantment.DURABILITY);
+            }
+            base.setItemMeta(meta);
+        }
+        return base;
+    }
+
+    private boolean shouldApplyEnchantment(final FriendsMenuItem definition, final Map<String, String> placeholders) {
+        if (!definition.isEnchanted()) {
+            return false;
+        }
+        final String requests = placeholders.get("nouvelles_demandes");
+        if (requests == null) {
+            return true;
+        }
+        try {
+            return Integer.parseInt(requests) > 0;
+        } catch (NumberFormatException exception) {
+            return true;
+        }
+    }
+
+    private ItemStack resolveItem(final String materialKey) {
+        if (materialKey == null || materialKey.isBlank()) {
+            return new ItemStack(Material.BARRIER);
+        }
+        final String normalized = materialKey.trim().toLowerCase(Locale.ROOT);
+        if (normalized.startsWith("hdb:")) {
+            return assetManager.getHead(normalized);
+        }
+        final Material material = Material.matchMaterial(normalized.toUpperCase(Locale.ROOT));
+        if (material == null) {
+            return new ItemStack(Material.BARRIER);
+        }
+        return new ItemStack(material);
+    }
+
+    private String apply(final String input, final Map<String, String> placeholders) {
+        if (input == null) {
+            return "";
+        }
+        String result = input;
+        for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+            result = result.replace("{" + entry.getKey() + "}", entry.getValue());
+        }
+        return result;
+    }
+
+    private void playSound(final Player player, final Sound sound) {
+        if (player == null || sound == null) {
+            return;
+        }
+        player.playSound(player.getLocation(), sound, 1.0f, 1.0f);
+    }
+
+    private String colorize(final String input) {
+        if (input == null) {
+            return "";
+        }
+        return ChatColor.translateAlternateColorCodes('&', input);
+    }
+}
+

--- a/src/main/java/com/lobby/friends/menu/FriendsMenuActionHandler.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMenuActionHandler.java
@@ -1,0 +1,21 @@
+package com.lobby.friends.menu;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Handles interactions triggered from the friends main menu.
+ */
+@FunctionalInterface
+public interface FriendsMenuActionHandler {
+
+    /**
+     * Processes the requested action for the given player.
+     *
+     * @param player the player who clicked the item
+     * @param action the configured action identifier
+     * @return {@code true} if the action was handled successfully, {@code false}
+     * otherwise
+     */
+    boolean handle(Player player, String action);
+}
+

--- a/src/main/java/com/lobby/friends/menu/FriendsMenuConfiguration.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMenuConfiguration.java
@@ -1,0 +1,73 @@
+package com.lobby.friends.menu;
+
+import org.bukkit.Sound;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class FriendsMenuConfiguration {
+
+    private final String title;
+    private final int size;
+    private final int updateIntervalSeconds;
+    private final Sound openSound;
+    private final Sound clickSound;
+    private final Sound errorSound;
+    private final List<FriendsMenuDecoration> decorations;
+    private final List<FriendsMenuItem> items;
+
+    public FriendsMenuConfiguration(final String title,
+                                    final int size,
+                                    final int updateIntervalSeconds,
+                                    final Sound openSound,
+                                    final Sound clickSound,
+                                    final Sound errorSound,
+                                    final List<FriendsMenuDecoration> decorations,
+                                    final List<FriendsMenuItem> items) {
+        this.title = title == null || title.isBlank() ? "§8» §aMenu des Amis" : title;
+        this.size = Math.max(9, Math.min(54, size));
+        this.updateIntervalSeconds = Math.max(1, updateIntervalSeconds);
+        this.openSound = openSound;
+        this.clickSound = clickSound;
+        this.errorSound = errorSound;
+        this.decorations = decorations == null ? List.of() : List.copyOf(decorations);
+        this.items = items == null ? List.of() : List.copyOf(items);
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public int getUpdateIntervalSeconds() {
+        return updateIntervalSeconds;
+    }
+
+    public int getUpdateIntervalTicks() {
+        return updateIntervalSeconds * 20;
+    }
+
+    public Sound getOpenSound() {
+        return openSound;
+    }
+
+    public Sound getClickSound() {
+        return clickSound;
+    }
+
+    public Sound getErrorSound() {
+        return errorSound;
+    }
+
+    public List<FriendsMenuDecoration> getDecorations() {
+        return Collections.unmodifiableList(decorations);
+    }
+
+    public List<FriendsMenuItem> getItems() {
+        return Collections.unmodifiableList(items);
+    }
+}
+

--- a/src/main/java/com/lobby/friends/menu/FriendsMenuConfigurationLoader.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMenuConfigurationLoader.java
@@ -1,0 +1,157 @@
+package com.lobby.friends.menu;
+
+import com.lobby.LobbyPlugin;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public final class FriendsMenuConfigurationLoader {
+
+    private static final String RESOURCE_PATH = "friends/main_menu.yml";
+
+    private FriendsMenuConfigurationLoader() {
+    }
+
+    public static FriendsMenuConfiguration load(final LobbyPlugin plugin) {
+        final File dataFolder = plugin.getDataFolder();
+        final File directory = new File(dataFolder, "friends");
+        if (!directory.exists() && !directory.mkdirs()) {
+            plugin.getLogger().warning("Impossible de créer le dossier des menus d'amis.");
+        }
+        final File file = new File(directory, "main_menu.yml");
+        if (!file.exists()) {
+            try {
+                plugin.saveResource(RESOURCE_PATH, false);
+            } catch (final IllegalArgumentException ignored) {
+                // No default resource packaged
+            }
+        }
+        if (!file.exists()) {
+            plugin.getLogger().warning("La configuration du menu d'amis est introuvable: " + file.getAbsolutePath());
+            return buildFallback();
+        }
+
+        final YamlConfiguration configuration = new YamlConfiguration();
+        try {
+            configuration.load(file);
+        } catch (IOException | InvalidConfigurationException exception) {
+            plugin.getLogger().warning("Impossible de charger '" + file.getName() + "': " + exception.getMessage());
+            return buildFallback();
+        }
+
+        final ConfigurationSection menuSection = configuration.getConfigurationSection("menu");
+        if (menuSection == null) {
+            plugin.getLogger().warning("La section 'menu' est absente du fichier " + file.getName());
+            return buildFallback();
+        }
+
+        final String title = menuSection.getString("title", "§8» §aMenu des Amis");
+        final int size = menuSection.getInt("size", 54);
+        final int updateInterval = menuSection.getInt("update_interval", 5);
+
+        final Map<String, Sound> sounds = parseSounds(configuration.getConfigurationSection("sounds"));
+        final List<FriendsMenuDecoration> decorations = parseDecorations(configuration.getConfigurationSection("decoration"));
+        final List<FriendsMenuItem> items = parseItems(configuration.getConfigurationSection("items"));
+
+        return new FriendsMenuConfiguration(title, size, updateInterval,
+                sounds.get("open_menu"), sounds.get("click_item"), sounds.get("error"),
+                decorations, items);
+    }
+
+    private static Map<String, Sound> parseSounds(final ConfigurationSection section) {
+        final Map<String, Sound> sounds = new HashMap<>();
+        if (section == null) {
+            return sounds;
+        }
+        for (String key : section.getKeys(false)) {
+            final String value = section.getString(key);
+            if (value == null || value.isBlank()) {
+                continue;
+            }
+            try {
+                sounds.put(key, Sound.valueOf(value.trim().toUpperCase(Locale.ROOT)));
+            } catch (final IllegalArgumentException exception) {
+                // ignore invalid sound names but keep log for debugging
+                final LobbyPlugin plugin = LobbyPlugin.getInstance();
+                if (plugin != null) {
+                    plugin.getLogger().warning("Son invalide pour le menu d'amis ('" + key + "'): " + value);
+                }
+            }
+        }
+        return sounds;
+    }
+
+    private static List<FriendsMenuDecoration> parseDecorations(final ConfigurationSection section) {
+        if (section == null) {
+            return List.of();
+        }
+        final List<FriendsMenuDecoration> list = new ArrayList<>();
+        for (String key : section.getKeys(false)) {
+            final ConfigurationSection decorationSection = section.getConfigurationSection(key);
+            if (decorationSection == null) {
+                continue;
+            }
+            final String materialName = decorationSection.getString("material", "BLACK_STAINED_GLASS_PANE");
+            Material material = Material.matchMaterial(materialName.toUpperCase(Locale.ROOT));
+            if (material == null) {
+                material = Material.BLACK_STAINED_GLASS_PANE;
+            }
+            final String name = decorationSection.getString("name", " ");
+            final List<Integer> slots = decorationSection.getIntegerList("slots");
+            list.add(new FriendsMenuDecoration(material, name, slots));
+        }
+        return list;
+    }
+
+    private static List<FriendsMenuItem> parseItems(final ConfigurationSection section) {
+        if (section == null) {
+            return List.of();
+        }
+        final List<FriendsMenuItem> items = new ArrayList<>();
+        for (String key : section.getKeys(false)) {
+            final ConfigurationSection itemSection = section.getConfigurationSection(key);
+            if (itemSection == null) {
+                continue;
+            }
+            final int slot = itemSection.getInt("slot", -1);
+            if (slot < 0 || slot >= 54) {
+                continue;
+            }
+            final String material = resolveMaterialKey(itemSection);
+            final String name = itemSection.getString("name", " ");
+            final List<String> lore = itemSection.getStringList("lore");
+            final String action = itemSection.getString("action", "");
+            final boolean enchanted = itemSection.getBoolean("enchanted", false);
+            items.add(new FriendsMenuItem(slot, material, name, lore, action, enchanted));
+        }
+        return items;
+    }
+
+    private static String resolveMaterialKey(final ConfigurationSection section) {
+        final String hdb = section.getString("hdb_id");
+        if (hdb != null && !hdb.isBlank()) {
+            return "hdb:" + hdb.trim();
+        }
+        final String material = section.getString("material", "BARRIER");
+        if (material == null) {
+            return "BARRIER";
+        }
+        return material.trim();
+    }
+
+    private static FriendsMenuConfiguration buildFallback() {
+        return new FriendsMenuConfiguration("§8» §aMenu des Amis", 54, 5,
+                null, null, null, List.of(), List.of());
+    }
+}
+

--- a/src/main/java/com/lobby/friends/menu/FriendsMenuController.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMenuController.java
@@ -1,0 +1,51 @@
+package com.lobby.friends.menu;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.friends.FriendsDataProvider;
+import com.lobby.menus.AssetManager;
+import com.lobby.menus.MenuManager;
+import org.bukkit.entity.Player;
+
+/**
+ * Entry point used to open the friends main menu for players.
+ */
+public class FriendsMenuController {
+
+    private final LobbyPlugin plugin;
+    private final MenuManager menuManager;
+    private final AssetManager assetManager;
+    private final FriendsDataProvider dataProvider;
+    private FriendsMenuActionHandler actionHandler;
+    private FriendsMenuConfiguration configuration;
+
+    public FriendsMenuController(final LobbyPlugin plugin,
+                                 final MenuManager menuManager,
+                                 final AssetManager assetManager,
+                                 final FriendsDataProvider dataProvider,
+                                 final FriendsMenuActionHandler actionHandler) {
+        this.plugin = plugin;
+        this.menuManager = menuManager;
+        this.assetManager = assetManager;
+        this.dataProvider = dataProvider;
+        this.actionHandler = actionHandler;
+        reload();
+    }
+
+    public void reload() {
+        configuration = FriendsMenuConfigurationLoader.load(plugin);
+    }
+
+    public void setActionHandler(final FriendsMenuActionHandler actionHandler) {
+        this.actionHandler = actionHandler;
+    }
+
+    public boolean openMainMenu(final Player player) {
+        if (player == null || configuration == null) {
+            return false;
+        }
+        final FriendsMainMenu menu = new FriendsMainMenu(plugin, assetManager, configuration, dataProvider, actionHandler);
+        menuManager.displayMenu(player, menu);
+        return true;
+    }
+}
+

--- a/src/main/java/com/lobby/friends/menu/FriendsMenuDecoration.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMenuDecoration.java
@@ -1,0 +1,30 @@
+package com.lobby.friends.menu;
+
+import org.bukkit.Material;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents decorative items (typically glass panes) used to build the border
+ * of the friends menu.
+ */
+public record FriendsMenuDecoration(Material material, String displayName, List<Integer> slots) {
+
+    public FriendsMenuDecoration {
+        if (material == null) {
+            material = Material.BLACK_STAINED_GLASS_PANE;
+        }
+        if (displayName == null) {
+            displayName = " ";
+        }
+        if (slots == null) {
+            slots = List.of();
+        }
+    }
+
+    public List<Integer> slots() {
+        return Collections.unmodifiableList(slots);
+    }
+}
+

--- a/src/main/java/com/lobby/friends/menu/FriendsMenuItem.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMenuItem.java
@@ -1,0 +1,56 @@
+package com.lobby.friends.menu;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Configuration of a clickable friends menu item.
+ */
+public final class FriendsMenuItem {
+
+    private final int slot;
+    private final String materialKey;
+    private final String displayName;
+    private final List<String> lore;
+    private final String action;
+    private final boolean enchanted;
+
+    public FriendsMenuItem(final int slot,
+                           final String materialKey,
+                           final String displayName,
+                           final List<String> lore,
+                           final String action,
+                           final boolean enchanted) {
+        this.slot = slot;
+        this.materialKey = materialKey;
+        this.displayName = displayName;
+        this.lore = lore == null ? List.of() : List.copyOf(lore);
+        this.action = action;
+        this.enchanted = enchanted;
+    }
+
+    public int getSlot() {
+        return slot;
+    }
+
+    public String getMaterialKey() {
+        return materialKey;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public List<String> getLore() {
+        return Collections.unmodifiableList(lore);
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public boolean isEnchanted() {
+        return enchanted;
+    }
+}
+

--- a/src/main/java/com/lobby/friends/menu/NoopFriendsMenuActionHandler.java
+++ b/src/main/java/com/lobby/friends/menu/NoopFriendsMenuActionHandler.java
@@ -1,0 +1,19 @@
+package com.lobby.friends.menu;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Default fallback action handler used until dedicated implementations are
+ * provided for each friends feature.
+ */
+public class NoopFriendsMenuActionHandler implements FriendsMenuActionHandler {
+
+    @Override
+    public boolean handle(final Player player, final String action) {
+        if (player != null) {
+            player.sendMessage("§cCette fonctionnalité n'est pas encore disponible.");
+        }
+        return false;
+    }
+}
+

--- a/src/main/java/com/lobby/menus/AssetManager.java
+++ b/src/main/java/com/lobby/menus/AssetManager.java
@@ -55,7 +55,14 @@ public class AssetManager {
             "hdb:13389",
             "hdb:1455",
             "hdb:32010",
-            "hdb:176"
+            "hdb:176",
+            "hdb:1452",
+            "hdb:5694",
+            "hdb:3583",
+            "hdb:5464",
+            "hdb:1275",
+            "hdb:6156",
+            "hdb:2967"
     );
     private static final Map<String, String> SERVER_PLACEHOLDER_KEYS = Map.of(
             "%lobby_online_bedwars%", "bedwars",
@@ -177,25 +184,29 @@ public class AssetManager {
 
     private Set<String> scanConfiguredHeadIds() {
         final Set<String> collected = new HashSet<>();
-        final File menusDirectory = new File(plugin.getDataFolder(), "menus");
-        if (!menusDirectory.exists() || !menusDirectory.isDirectory()) {
-            return collected;
+        scanDirectory(new File(plugin.getDataFolder(), "menus"), collected);
+        scanDirectory(new File(plugin.getDataFolder(), "friends"), collected);
+        return collected;
+    }
+
+    private void scanDirectory(final File directory, final Set<String> sink) {
+        if (directory == null || sink == null || !directory.exists() || !directory.isDirectory()) {
+            return;
         }
-        final File[] files = menusDirectory.listFiles((dir, name) -> name != null && name.endsWith(".yml"));
+        final File[] files = directory.listFiles((dir, name) -> name != null && name.endsWith(".yml"));
         if (files == null || files.length == 0) {
-            return collected;
+            return;
         }
         for (File file : files) {
             final YamlConfiguration configuration = new YamlConfiguration();
             try {
                 configuration.load(file);
-                collectHeadIdentifiers(configuration, collected);
+                collectHeadIdentifiers(configuration, sink);
             } catch (IOException | InvalidConfigurationException exception) {
                 plugin.getLogger().warning("Unable to parse menu configuration '" + file.getName() + "': "
                         + exception.getMessage());
             }
         }
-        return collected;
     }
 
     private void collectHeadIdentifiers(final ConfigurationSection section, final Set<String> sink) {

--- a/src/main/java/com/lobby/menus/CloseableMenu.java
+++ b/src/main/java/com/lobby/menus/CloseableMenu.java
@@ -1,0 +1,19 @@
+package com.lobby.menus;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Extension point for menus that need to execute custom logic when the
+ * underlying inventory is closed. This is especially useful for menus that
+ * schedule repeating tasks or keep per-player state while opened.
+ */
+public interface CloseableMenu extends Menu {
+
+    /**
+     * Invoked when the menu inventory is closed by the given player.
+     *
+     * @param player the player who closed the menu
+     */
+    void handleClose(Player player);
+}
+

--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -73,7 +73,10 @@ public class MenuManager {
         if (player == null) {
             return;
         }
-        openMenus.remove(player.getUniqueId());
+        final Menu menu = openMenus.remove(player.getUniqueId());
+        if (menu instanceof CloseableMenu closeableMenu) {
+            closeableMenu.handleClose(player);
+        }
     }
 
     public void closeAll() {

--- a/src/main/resources/friends/main_menu.yml
+++ b/src/main/resources/friends/main_menu.yml
@@ -1,0 +1,121 @@
+menu:
+  title: "§8» §aMenu des Amis"
+  size: 54
+  update_interval: 5
+
+decoration:
+  green_glass:
+    material: "GREEN_STAINED_GLASS_PANE"
+    name: " "
+    slots: [0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 46, 52, 53]
+  gray_glass:
+    material: "GRAY_STAINED_GLASS_PANE"
+    name: " "
+    slots: [39, 40, 41]
+
+sounds:
+  open_menu: "BLOCK_CHEST_OPEN"
+  click_item: "UI_BUTTON_CLICK"
+  error: "BLOCK_ANVIL_LAND"
+
+items:
+  friends_list:
+    slot: 10
+    hdb_id: 1452
+    name: "§a§l📋 Liste de mes Amis"
+    lore:
+      - "§7Consultez votre liste d'amis"
+      - "§7et interagissez avec eux"
+      - ""
+      - "§a▸ Amis connectés: §2{amis_en_ligne}"
+      - "§c▸ Amis hors-ligne: §4{amis_hors_ligne}"
+      - "§e▸ Total: §6{total_amis}§7/§6{limite_amis}"
+      - ""
+      - "§8» §aCliquez pour ouvrir"
+    action: "open_friends_list"
+
+  add_friend:
+    slot: 11
+    hdb_id: 5694
+    name: "§a§l➕ Ajouter un Ami"
+    lore:
+      - "§7Envoyez une demande d'ami"
+      - "§7à un autre joueur"
+      - ""
+      - "§a▸ Demandes envoyées: §2{demandes_envoyees}"
+      - "§e▸ En attente: §6{demandes_en_attente}"
+      - ""
+      - "§8» §aCliquez pour ajouter"
+    action: "open_add_friend"
+
+  requests:
+    slot: 12
+    hdb_id: 3583
+    name: "§e§l📨 Demandes d'Amitié"
+    enchanted: true
+    lore:
+      - "§7Gérez vos demandes d'amitié"
+      - "§7en attente de réponse"
+      - ""
+      - "§e▸ Nouvelles demandes: §6{nouvelles_demandes}"
+      - "§7▸ Total en attente: §8{total_demandes}"
+      - ""
+      - "§8» §eCliquez pour gérer"
+    action: "open_requests"
+
+  blocked:
+    slot: 13
+    hdb_id: 5464
+    name: "§c§l🚫 Joueurs Bloqués"
+    lore:
+      - "§7Gérez votre liste de"
+      - "§7joueurs bloqués"
+      - ""
+      - "§c▸ Joueurs bloqués: §4{joueurs_bloques}"
+      - ""
+      - "§8» §cCliquez pour gérer"
+    action: "open_blocked"
+
+  settings:
+    slot: 14
+    hdb_id: 1275
+    name: "§6§l⚙️ Paramètres d'Amitié"
+    lore:
+      - "§7Configurez vos préférences"
+      - "§7concernant les amis"
+      - ""
+      - "§6▸ Demandes auto: §e{demandes_auto}"
+      - "§6▸ Notifications: §e{notifications}"
+      - "§6▸ Visibilité: §e{visibilite}"
+      - ""
+      - "§8» §6Cliquez pour configurer"
+    action: "open_settings"
+
+  favorites:
+    slot: 15
+    hdb_id: 6156
+    name: "§e§l🏆 Amis Favoris"
+    lore:
+      - "§7Vos amis les plus proches"
+      - "§7marqués comme favoris"
+      - ""
+      - "§e▸ Amis favoris: §6{amis_favoris}"
+      - "§a▸ En ligne: §2{favoris_en_ligne}"
+      - ""
+      - "§8» §eCliquez pour voir"
+    action: "open_favorites"
+
+  statistics:
+    slot: 16
+    hdb_id: 2967
+    name: "§b§l📊 Statistiques"
+    lore:
+      - "§7Consultez vos statistiques"
+      - "§7d'amitié détaillées"
+      - ""
+      - "§b▸ Temps total en jeu ensemble: §3{temps_total}"
+      - "§b▸ Messages échangés: §3{messages_total}"
+      - "§b▸ Ami depuis le plus longtemps: §3{ami_ancien}"
+      - ""
+      - "§8» §bCliquez pour plus de détails"
+    action: "open_statistics"


### PR DESCRIPTION
## Summary
- add a configurable friends main menu backed by HeadDatabase heads and placeholder-driven lore
- introduce menu infrastructure (controller, data provider, refresh logic) to keep the UI updated and reusable
- wire the friends menu into the plugin lifecycle and /lobby friends command while extending asset caching

## Testing
- `mvn -q -DskipTests package` *(fails: dependency downloads are forbidden in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a48aba4883299aa90ce0e162a48b