### PR TITLE
Fix enchantment compatibility in friends menu

### DIFF
--- a/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
@@ -163,14 +163,45 @@ public final class FriendsMainMenu implements Menu, InventoryHolder, CloseableMe
             }
             final boolean shouldEnchant = shouldApplyEnchantment(definition, placeholders);
             if (shouldEnchant) {
-                meta.addEnchant(Enchantment.DURABILITY, 1, true);
-                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                boolean applied = addEnchantment(meta, Enchantment.UNBREAKING);
+                if (!applied) {
+                    final Enchantment legacy = Enchantment.getByName("DURABILITY");
+                    if (legacy != null) {
+                        applied = addEnchantment(meta, legacy);
+                    }
+                }
+                if (!applied) {
+                    for (Enchantment fallback : Enchantment.values()) {
+                        if (addEnchantment(meta, fallback)) {
+                            applied = true;
+                            break;
+                        }
+                    }
+                }
+                if (applied) {
+                    meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                }
             } else {
-                meta.removeEnchant(Enchantment.DURABILITY);
+                meta.removeEnchant(Enchantment.UNBREAKING);
+                final Enchantment legacy = Enchantment.getByName("DURABILITY");
+                if (legacy != null) {
+                    meta.removeEnchant(legacy);
+                }
             }
             base.setItemMeta(meta);
         }
         return base;
+    }
+
+    private boolean addEnchantment(final ItemMeta meta, final Enchantment enchantment) {
+        if (meta == null || enchantment == null) {
+            return false;
+        }
+        try {
+            return meta.addEnchant(enchantment, 1, true);
+        } catch (RuntimeException exception) {
+            return false;
+        }
     }
 
     private boolean shouldApplyEnchantment(final FriendsMenuItem definition, final Map<String, String> placeholders) {


### PR DESCRIPTION
## Summary
- replace deprecated Enchantment.DURABILITY usage with version-agnostic handling in FriendsMainMenu
- add a helper that falls back to legacy and other enchantments when UNBREAKING is unavailable
- ensure glow removal clears both modern and legacy enchantments

## Testing
- `mvn -q -DskipTests package` *(fails: dependency repository returns HTTP 403 when resolving paper-api and placeholderapi)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a99ff34c832985764a826b7348d9