### PR TITLE
Connect profile friends button to new friends menu

### DIFF
--- a/src/main/java/com/lobby/menus/MenuManager.java
+++ b/src/main/java/com/lobby/menus/MenuManager.java
@@ -1,9 +1,12 @@
 package com.lobby.menus;
 
 import com.lobby.LobbyPlugin;
+import com.lobby.friends.FriendsDataProvider;
+import com.lobby.friends.FriendsPlaceholderData;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -49,12 +52,17 @@ public class MenuManager {
             return false;
         }
         final String menuId = rawMenuId.toLowerCase(Locale.ROOT);
+        final Map<String, String> resolvedPlaceholders = new HashMap<>();
+        if (placeholders != null && !placeholders.isEmpty()) {
+            resolvedPlaceholders.putAll(placeholders);
+        }
+        populateMenuSpecificPlaceholders(player, menuId, resolvedPlaceholders);
 
         if (isSimpleMenu(menuId)) {
-            return buildAndOpenSimpleMenu(player, menuId, placeholders, context);
+            return buildAndOpenSimpleMenu(player, menuId, resolvedPlaceholders, context);
         }
 
-        final Menu menu = ConfiguredMenu.fromConfiguration(plugin, this, assetManager, menuId, placeholders, context);
+        final Menu menu = ConfiguredMenu.fromConfiguration(plugin, this, assetManager, menuId, resolvedPlaceholders, context);
         if (menu == null) {
             return false;
         }
@@ -123,6 +131,31 @@ public class MenuManager {
         }
         displayMenu(player, menu);
         return true;
+    }
+
+    private void populateMenuSpecificPlaceholders(final Player player,
+                                                  final String menuId,
+                                                  final Map<String, String> placeholders) {
+        if (player == null || menuId == null || placeholders == null) {
+            return;
+        }
+        if (!"profil_menu".equals(menuId)) {
+            return;
+        }
+        final FriendsDataProvider dataProvider = plugin.getFriendsDataProvider();
+        if (dataProvider == null) {
+            return;
+        }
+        final FriendsPlaceholderData data = dataProvider.resolve(player);
+        if (data == null) {
+            return;
+        }
+        data.toPlaceholderMap().forEach((key, value) -> {
+            if (key == null || key.isBlank()) {
+                return;
+            }
+            placeholders.put('%' + key + '%', value == null ? "" : value);
+        });
     }
 
     public void displayMenu(final Player player, final Menu menu) {

--- a/src/main/resources/menus/profil_menu.yml
+++ b/src/main/resources/menus/profil_menu.yml
@@ -20,11 +20,15 @@ items:
     material: 'hdb:9945'
     name: '&a&lAmis'
     lore:
-      - '&7Cette section sociale est en cours de'
-      - '&7reconstruction complète.'
+      - '&7Gérez vos amis et'
+      - '&7vos relations sociales'
       - '&r'
-      - '&cFonctionnalité temporairement indisponible'
-    action: '[MESSAGE] &cLes fonctionnalités sociales sont momentanément désactivées.'
+      - '&a▸ Amis connectés: &2%amis_en_ligne%'
+      - '&c▸ Amis hors-ligne: &4%amis_hors_ligne%'
+      - '&e▸ Total: &6%total_amis%&7/&6%limite_amis%'
+      - '&r'
+      - '&8» &aCliquez pour ouvrir'
+    action: '[COMMAND] lobby friends'
 
   party-button:
     slot: 4


### PR DESCRIPTION
## Summary
- inject friends placeholder values when rendering the profile menu so dynamic stats can be shown
- update the profile menu "Amis" entry to display live counts and open the friends menu via `/lobby friends`

## Testing
- `mvn -q -DskipTests package` *(fails: dependency downloads forbidden from papermc repository in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6accb352c8329a37bea474d2965c1