### PR TITLE
feat: enhance friends menu navigation

### DIFF
--- a/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
@@ -6,6 +6,7 @@ import com.lobby.friends.FriendsPlaceholderData;
 import com.lobby.menus.AssetManager;
 import com.lobby.menus.CloseableMenu;
 import com.lobby.menus.Menu;
+import com.lobby.menus.MenuManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
@@ -69,7 +70,7 @@ public final class FriendsMainMenu implements Menu, InventoryHolder, CloseableMe
         buildStaticLayout();
         refreshDynamicContent();
         scheduleUpdates();
-        playSound(player, configuration.getOpenSound());
+        playSound(player, configuration.getOpenSound(), 1.5f);
         player.openInventory(inventory);
     }
 
@@ -78,9 +79,16 @@ public final class FriendsMainMenu implements Menu, InventoryHolder, CloseableMe
         if (!(event.getWhoClicked() instanceof Player player)) {
             return;
         }
+        event.setCancelled(true);
         final FriendsMenuItem item = itemBySlot.get(event.getSlot());
         if (item == null || item.getAction() == null || item.getAction().isBlank()) {
             playSound(player, configuration.getErrorSound());
+            return;
+        }
+        if ("back_to_profile".equalsIgnoreCase(item.getAction())) {
+            playSound(player, configuration.getClickSound());
+            player.closeInventory();
+            Bukkit.getScheduler().runTaskLater(plugin, () -> openProfileMenu(player), 1L);
             return;
         }
         final boolean handled = actionHandler != null && actionHandler.handle(player, item.getAction());
@@ -246,10 +254,25 @@ public final class FriendsMainMenu implements Menu, InventoryHolder, CloseableMe
     }
 
     private void playSound(final Player player, final Sound sound) {
+        playSound(player, sound, 1.0f);
+    }
+
+    private void playSound(final Player player, final Sound sound, final float pitch) {
         if (player == null || sound == null) {
             return;
         }
-        player.playSound(player.getLocation(), sound, 1.0f, 1.0f);
+        player.playSound(player.getLocation(), sound, 1.0f, pitch);
+    }
+
+    private void openProfileMenu(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final MenuManager menuManager = plugin.getMenuManager();
+        if (menuManager == null) {
+            return;
+        }
+        menuManager.openMenu(player, "profil_menu");
     }
 
     private String colorize(final String input) {

--- a/src/main/resources/friends/main_menu.yml
+++ b/src/main/resources/friends/main_menu.yml
@@ -3,6 +3,14 @@ menu:
   size: 54
   update_interval: 5
 
+# Layout (54 slots):
+# [V][V][V][ ][ ][ ][V][V][V]
+# [V][ ][ ][ ][ ][ ][ ][ ][V]
+# [ ][ ][ ][ ][ ][ ][ ][ ][ ]
+# [ ][ ][ ][ ][ ][ ][ ][ ][ ]
+# [ ][G][G][G][ ][ ][ ][ ][ ]
+# [V][V][V][ ][🏠][ ][V][V][V]
+
 decoration:
   green_glass:
     material: "GREEN_STAINED_GLASS_PANE"
@@ -14,7 +22,7 @@ decoration:
     slots: [39, 40, 41]
 
 sounds:
-  open_menu: "BLOCK_CHEST_OPEN"
+  open_menu: "ENTITY_EXPERIENCE_ORB_PICKUP"
   click_item: "UI_BUTTON_CLICK"
   error: "BLOCK_ANVIL_LAND"
 
@@ -119,3 +127,14 @@ items:
       - ""
       - "§8» §bCliquez pour plus de détails"
     action: "open_statistics"
+
+  back_to_profile:
+    slot: 49
+    hdb_id: 3593
+    name: "§e§l🏠 Retour au Profil"
+    lore:
+      - "§7Revenir au menu de"
+      - "§7votre profil"
+      - ""
+      - "§8» §eCliquez pour retourner"
+    action: "back_to_profile"


### PR DESCRIPTION
## Summary
- replace the friends menu opening sound with the experience orb pickup cue and document the updated layout
- add a new configuration entry for a profile return button in the friends menu
- handle profile return clicks directly in the friends menu with a delayed reopen and higher-pitched opening sound

## Testing
- mvn -q -DskipTests package *(fails: dependency repository returned HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b0624c508329b0419679e8772b0d