### PR TITLE
Add friend list menu configuration loaders

### DIFF
--- a/src/main/java/com/lobby/friends/menu/list/FriendsListMenuConfiguration.java
+++ b/src/main/java/com/lobby/friends/menu/list/FriendsListMenuConfiguration.java
@@ -1,0 +1,322 @@
+package com.lobby.friends.menu.list;
+
+import com.lobby.friends.menu.FriendsMenuDecoration;
+import org.bukkit.Sound;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable view over the configuration driving the friends list menu. The
+ * structure mirrors the YAML schema described in {@code friends_list.yml} and
+ * exposes strongly typed accessors for every configurable aspect of the menu
+ * including pagination, navigation controls, friend templates and advanced
+ * integrations.
+ */
+public final class FriendsListMenuConfiguration {
+
+    private final Settings settings;
+    private final List<FriendsMenuDecoration> decorations;
+    private final List<Integer> friendSlots;
+    private final Navigation navigation;
+    private final Sorting sorting;
+    private final Filters filters;
+    private final FriendTemplate onlineTemplate;
+    private final FriendTemplate offlineTemplate;
+    private final FavoriteDecorations favoriteDecorations;
+    private final Map<String, StatusDecoration> statusesByKey;
+    private final Sounds sounds;
+    private final Map<String, String> messages;
+    private final List<String> placeholders;
+    private final AdvancedSettings advancedSettings;
+    private final Integrations integrations;
+
+    public FriendsListMenuConfiguration(final Settings settings,
+                                        final List<FriendsMenuDecoration> decorations,
+                                        final List<Integer> friendSlots,
+                                        final Navigation navigation,
+                                        final Sorting sorting,
+                                        final Filters filters,
+                                        final FriendTemplate onlineTemplate,
+                                        final FriendTemplate offlineTemplate,
+                                        final FavoriteDecorations favoriteDecorations,
+                                        final Map<String, StatusDecoration> statusesByKey,
+                                        final Sounds sounds,
+                                        final Map<String, String> messages,
+                                        final List<String> placeholders,
+                                        final AdvancedSettings advancedSettings,
+                                        final Integrations integrations) {
+        this.settings = Objects.requireNonNull(settings, "settings");
+        this.decorations = decorations == null ? List.of() : List.copyOf(decorations);
+        this.friendSlots = friendSlots == null ? List.of() : List.copyOf(friendSlots);
+        this.navigation = Objects.requireNonNullElse(navigation, Navigation.empty());
+        this.sorting = Objects.requireNonNullElse(sorting, Sorting.empty());
+        this.filters = Objects.requireNonNullElse(filters, Filters.empty());
+        this.onlineTemplate = Objects.requireNonNullElse(onlineTemplate, FriendTemplate.empty());
+        this.offlineTemplate = Objects.requireNonNullElse(offlineTemplate, FriendTemplate.empty());
+        this.favoriteDecorations = Objects.requireNonNullElse(favoriteDecorations, FavoriteDecorations.empty());
+        this.statusesByKey = statusesByKey == null ? Map.of() : Map.copyOf(statusesByKey);
+        this.sounds = Objects.requireNonNullElse(sounds, Sounds.empty());
+        this.messages = messages == null ? Map.of() : Map.copyOf(messages);
+        this.placeholders = placeholders == null ? List.of() : List.copyOf(placeholders);
+        this.advancedSettings = Objects.requireNonNullElse(advancedSettings, AdvancedSettings.empty());
+        this.integrations = Objects.requireNonNullElse(integrations, Integrations.empty());
+    }
+
+    public Settings getSettings() {
+        return settings;
+    }
+
+    public List<FriendsMenuDecoration> getDecorations() {
+        return Collections.unmodifiableList(decorations);
+    }
+
+    public List<Integer> getFriendSlots() {
+        return Collections.unmodifiableList(friendSlots);
+    }
+
+    public Navigation getNavigation() {
+        return navigation;
+    }
+
+    public Sorting getSorting() {
+        return sorting;
+    }
+
+    public Filters getFilters() {
+        return filters;
+    }
+
+    public FriendTemplate getOnlineTemplate() {
+        return onlineTemplate;
+    }
+
+    public FriendTemplate getOfflineTemplate() {
+        return offlineTemplate;
+    }
+
+    public FavoriteDecorations getFavoriteDecorations() {
+        return favoriteDecorations;
+    }
+
+    public Map<String, StatusDecoration> getStatusesByKey() {
+        return Collections.unmodifiableMap(statusesByKey);
+    }
+
+    public Sounds getSounds() {
+        return sounds;
+    }
+
+    public Map<String, String> getMessages() {
+        return Collections.unmodifiableMap(messages);
+    }
+
+    public List<String> getPlaceholders() {
+        return Collections.unmodifiableList(placeholders);
+    }
+
+    public AdvancedSettings getAdvancedSettings() {
+        return advancedSettings;
+    }
+
+    public Integrations getIntegrations() {
+        return integrations;
+    }
+
+    /**
+     * General settings for the menu layout.
+     */
+    public record Settings(String title,
+                           int size,
+                           int itemsPerPage,
+                           boolean autoRefresh,
+                           int refreshIntervalSeconds) {
+
+        public Settings {
+            title = (title == null || title.isBlank()) ? "§8» §aListe des Amis" : title;
+            size = Math.max(9, Math.min(54, size));
+            itemsPerPage = Math.max(1, Math.min(size, itemsPerPage));
+            refreshIntervalSeconds = Math.max(1, refreshIntervalSeconds);
+        }
+    }
+
+    /**
+     * Representation of navigation controls. Each button is optional and may be
+     * absent depending on the configuration file.
+     */
+    public record Navigation(Button previousPage,
+                             Button backToMain,
+                             Button nextPage) {
+
+        public static Navigation empty() {
+            return new Navigation(null, null, null);
+        }
+    }
+
+    /**
+     * Sorting configuration containing the current strategy and available
+     * options.
+     */
+    public record Sorting(String currentSort,
+                          Button sortButton,
+                          Map<String, SortingOption> options) {
+
+        public Sorting {
+            currentSort = currentSort == null ? "online_first" : currentSort;
+            options = options == null ? Map.of() : Map.copyOf(options);
+        }
+
+        public static Sorting empty() {
+            return new Sorting("online_first", null, Map.of());
+        }
+    }
+
+    /**
+     * Single sorting option exposed to the player.
+     */
+    public record SortingOption(String key, String name, String description) {
+
+        public SortingOption {
+            key = key == null ? "" : key;
+            name = name == null ? "" : name;
+            description = description == null ? "" : description;
+        }
+    }
+
+    /**
+     * Filter configuration, containing default toggle values and the button used
+     * to open the filter sub-menu.
+     */
+    public record Filters(boolean showOnlineOnly,
+                          boolean showFavoritesOnly,
+                          boolean hideAway,
+                          boolean hideBusy,
+                          Button filterButton) {
+
+        public static Filters empty() {
+            return new Filters(false, false, false, false, null);
+        }
+    }
+
+    /**
+     * Template describing how a friend entry should be rendered.
+     */
+    public record FriendTemplate(String itemKey,
+                                 String displayName,
+                                 List<String> lore,
+                                 Map<String, String> actions) {
+
+        public FriendTemplate {
+            itemKey = itemKey == null ? "PLAYER_HEAD" : itemKey;
+            displayName = displayName == null ? "" : displayName;
+            lore = lore == null ? List.of() : List.copyOf(lore);
+            actions = actions == null ? Map.of() : Map.copyOf(actions);
+        }
+
+        public static FriendTemplate empty() {
+            return new FriendTemplate("PLAYER_HEAD", "", List.of(), Map.of());
+        }
+    }
+
+    /**
+     * Optional decorations applied to favourite friends.
+     */
+    public record FavoriteDecorations(boolean enchanted,
+                                      String particles,
+                                      String namePrefix,
+                                      List<String> loreAddition) {
+
+        public FavoriteDecorations {
+            particles = particles == null ? "" : particles;
+            namePrefix = namePrefix == null ? "" : namePrefix;
+            loreAddition = loreAddition == null ? List.of() : List.copyOf(loreAddition);
+        }
+
+        public static FavoriteDecorations empty() {
+            return new FavoriteDecorations(false, "", "", List.of());
+        }
+    }
+
+    /**
+     * Additional text decorations applied depending on friend status (away,
+     * busy, etc.).
+     */
+    public record StatusDecoration(String nameSuffix, String statusColor) {
+
+        public StatusDecoration {
+            nameSuffix = nameSuffix == null ? "" : nameSuffix;
+            statusColor = statusColor == null ? "" : statusColor;
+        }
+    }
+
+    /**
+     * Sounds used by the friends list menu.
+     */
+    public record Sounds(Sound openList,
+                         Sound pageTurn,
+                         Sound friendClick,
+                         Sound teleportSuccess,
+                         Sound teleportFailed,
+                         Sound messageSent) {
+
+        public static Sounds empty() {
+            return new Sounds(null, null, null, null, null, null);
+        }
+    }
+
+    /**
+     * Various technical settings that influence the behaviour of the menu.
+     */
+    public record AdvancedSettings(int maxFriendsPerPage,
+                                   int headCacheDurationSeconds,
+                                   int statusUpdateIntervalSeconds,
+                                   boolean offlineHeadGrayscale,
+                                   boolean favoriteGlowEffect,
+                                   boolean animateStatusChanges) {
+
+        public AdvancedSettings {
+            maxFriendsPerPage = Math.max(1, maxFriendsPerPage);
+            headCacheDurationSeconds = Math.max(0, headCacheDurationSeconds);
+            statusUpdateIntervalSeconds = Math.max(1, statusUpdateIntervalSeconds);
+        }
+
+        public static AdvancedSettings empty() {
+            return new AdvancedSettings(28, 300, 5, true, true, true);
+        }
+    }
+
+    /**
+     * External integrations toggles.
+     */
+    public record Integrations(boolean placeholderApi,
+                               boolean headDatabase,
+                               boolean bungeeMessaging) {
+
+        public static Integrations empty() {
+            return new Integrations(true, true, true);
+        }
+    }
+
+    /**
+     * Generic clickable button representation.
+     */
+    public record Button(int slot,
+                         String itemKey,
+                         String displayName,
+                         List<String> lore,
+                         Map<String, String> actions,
+                         String visibleWhen) {
+
+        public Button {
+            slot = Math.max(0, slot);
+            itemKey = itemKey == null ? "BARRIER" : itemKey;
+            displayName = displayName == null ? "" : displayName;
+            lore = lore == null ? List.of() : List.copyOf(lore);
+            actions = actions == null ? Map.of() : Map.copyOf(actions);
+            visibleWhen = visibleWhen == null ? "" : visibleWhen;
+        }
+    }
+}
+

--- a/src/main/java/com/lobby/friends/menu/list/FriendsListMenuConfigurationLoader.java
+++ b/src/main/java/com/lobby/friends/menu/list/FriendsListMenuConfigurationLoader.java
@@ -1,0 +1,355 @@
+package com.lobby.friends.menu.list;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.friends.menu.FriendsMenuDecoration;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Utility in charge of loading the friends list configuration from the plugin
+ * data folder. The loader is defensive against missing or malformed entries
+ * and guarantees that the resulting {@link FriendsListMenuConfiguration}
+ * instance always exposes sane defaults.
+ */
+public final class FriendsListMenuConfigurationLoader {
+
+    private static final String RESOURCE_PATH = "friends/friends_list.yml";
+
+    private FriendsListMenuConfigurationLoader() {
+    }
+
+    public static FriendsListMenuConfiguration load(final LobbyPlugin plugin) {
+        final File directory = ensureDirectory(plugin);
+        final File file = new File(directory, "friends_list.yml");
+        ensureResource(plugin, file);
+
+        final YamlConfiguration configuration = new YamlConfiguration();
+        try {
+            configuration.load(file);
+        } catch (IOException | InvalidConfigurationException exception) {
+            plugin.getLogger().warning("Impossible de charger '" + file.getName() + "': " + exception.getMessage());
+            return buildFallback();
+        }
+
+        final FriendsListMenuConfiguration.Settings settings = parseSettings(configuration.getConfigurationSection("menu"));
+        final List<FriendsMenuDecoration> decorations = parseDecorations(configuration.getConfigurationSection("decoration"));
+        final List<Integer> friendSlots = parseFriendSlots(configuration.getIntegerList("friend_slots"), settings.size());
+        final FriendsListMenuConfiguration.Navigation navigation = parseNavigation(configuration.getConfigurationSection("navigation"));
+        final FriendsListMenuConfiguration.Sorting sorting = parseSorting(configuration.getConfigurationSection("sorting"));
+        final FriendsListMenuConfiguration.Filters filters = parseFilters(configuration.getConfigurationSection("filters"));
+        final FriendsListMenuConfiguration.FriendTemplate onlineTemplate = parseFriendTemplate(configuration.getConfigurationSection("friend_online"));
+        final FriendsListMenuConfiguration.FriendTemplate offlineTemplate = parseFriendTemplate(configuration.getConfigurationSection("friend_offline"));
+        final FriendsListMenuConfiguration.FavoriteDecorations favoriteDecorations = parseFavoriteDecorations(configuration.getConfigurationSection("friend_favorite"));
+        final Map<String, FriendsListMenuConfiguration.StatusDecoration> statuses = parseStatuses(configuration.getConfigurationSection("friend_statuses"));
+        final FriendsListMenuConfiguration.Sounds sounds = parseSounds(configuration.getConfigurationSection("sounds"));
+        final Map<String, String> messages = parseMessages(configuration.getConfigurationSection("messages"));
+        final List<String> placeholders = parseStringList(configuration.getStringList("placeholders"));
+        final FriendsListMenuConfiguration.AdvancedSettings advanced = parseAdvancedSettings(configuration.getConfigurationSection("advanced"), settings.itemsPerPage());
+        final FriendsListMenuConfiguration.Integrations integrations = parseIntegrations(configuration.getConfigurationSection("integrations"));
+
+        return new FriendsListMenuConfiguration(settings, decorations, friendSlots, navigation, sorting, filters,
+                onlineTemplate, offlineTemplate, favoriteDecorations, statuses, sounds, messages,
+                placeholders, advanced, integrations);
+    }
+
+    private static File ensureDirectory(final LobbyPlugin plugin) {
+        final File dataFolder = plugin.getDataFolder();
+        final File directory = new File(dataFolder, "friends");
+        if (!directory.exists() && !directory.mkdirs()) {
+            plugin.getLogger().warning("Impossible de créer le dossier des amis: " + directory.getAbsolutePath());
+        }
+        return directory;
+    }
+
+    private static void ensureResource(final LobbyPlugin plugin, final File file) {
+        if (file.exists()) {
+            return;
+        }
+        try {
+            plugin.saveResource(RESOURCE_PATH, false);
+        } catch (final IllegalArgumentException ignored) {
+            // No default resource packaged, continue with fallback values.
+        }
+    }
+
+    private static FriendsListMenuConfiguration buildFallback() {
+        final FriendsListMenuConfiguration.Settings settings = new FriendsListMenuConfiguration.Settings(
+                "§8» §aListe des Amis", 54, 28, true, 10);
+        return new FriendsListMenuConfiguration(settings, List.of(), List.of(),
+                FriendsListMenuConfiguration.Navigation.empty(), FriendsListMenuConfiguration.Sorting.empty(),
+                FriendsListMenuConfiguration.Filters.empty(), FriendsListMenuConfiguration.FriendTemplate.empty(),
+                FriendsListMenuConfiguration.FriendTemplate.empty(), FriendsListMenuConfiguration.FavoriteDecorations.empty(),
+                Map.of(), FriendsListMenuConfiguration.Sounds.empty(), Map.of(), List.of(),
+                FriendsListMenuConfiguration.AdvancedSettings.empty(), FriendsListMenuConfiguration.Integrations.empty());
+    }
+
+    private static FriendsListMenuConfiguration.Settings parseSettings(final ConfigurationSection section) {
+        if (section == null) {
+            return new FriendsListMenuConfiguration.Settings("§8» §aListe des Amis", 54, 28, true, 10);
+        }
+        final String title = section.getString("title", "§8» §aListe des Amis");
+        final int size = section.getInt("size", 54);
+        final int itemsPerPage = section.getInt("items_per_page", 28);
+        final boolean autoRefresh = section.getBoolean("auto_refresh", true);
+        final int refreshInterval = section.getInt("refresh_interval", 10);
+        return new FriendsListMenuConfiguration.Settings(title, size, itemsPerPage, autoRefresh, refreshInterval);
+    }
+
+    private static List<FriendsMenuDecoration> parseDecorations(final ConfigurationSection section) {
+        if (section == null) {
+            return List.of();
+        }
+        final List<FriendsMenuDecoration> decorations = new ArrayList<>();
+        for (String key : section.getKeys(false)) {
+            final ConfigurationSection decorationSection = section.getConfigurationSection(key);
+            if (decorationSection == null) {
+                continue;
+            }
+            final String materialName = decorationSection.getString("material", "BLACK_STAINED_GLASS_PANE");
+            Material material = Material.matchMaterial(materialName.toUpperCase(Locale.ROOT));
+            if (material == null) {
+                material = Material.BLACK_STAINED_GLASS_PANE;
+            }
+            final String name = decorationSection.getString("name", " ");
+            final List<Integer> slots = decorationSection.getIntegerList("slots");
+            decorations.add(new FriendsMenuDecoration(material, name, slots));
+        }
+        return decorations;
+    }
+
+    private static List<Integer> parseFriendSlots(final List<Integer> slots, final int menuSize) {
+        if (slots == null || slots.isEmpty()) {
+            return List.of();
+        }
+        final List<Integer> sanitized = new ArrayList<>(slots.size());
+        for (Integer slot : slots) {
+            if (slot == null) {
+                continue;
+            }
+            final int value = slot;
+            if (value < 0 || value >= menuSize) {
+                continue;
+            }
+            if (!sanitized.contains(value)) {
+                sanitized.add(value);
+            }
+        }
+        Collections.sort(sanitized);
+        return List.copyOf(sanitized);
+    }
+
+    private static FriendsListMenuConfiguration.Navigation parseNavigation(final ConfigurationSection section) {
+        if (section == null) {
+            return FriendsListMenuConfiguration.Navigation.empty();
+        }
+        final FriendsListMenuConfiguration.Button previous = parseButton(section.getConfigurationSection("previous_page"));
+        final FriendsListMenuConfiguration.Button back = parseButton(section.getConfigurationSection("back_to_main"));
+        final FriendsListMenuConfiguration.Button next = parseButton(section.getConfigurationSection("next_page"));
+        return new FriendsListMenuConfiguration.Navigation(previous, back, next);
+    }
+
+    private static FriendsListMenuConfiguration.Button parseButton(final ConfigurationSection section) {
+        if (section == null) {
+            return null;
+        }
+        final int slot = section.getInt("slot", 0);
+        final String itemKey = resolveItemKey(section);
+        final String name = section.getString("name", "");
+        final List<String> lore = section.getStringList("lore");
+        final Map<String, String> actions = parseActions(section.getConfigurationSection("actions"));
+        final String visibleWhen = section.getString("visible_when", "");
+        return new FriendsListMenuConfiguration.Button(slot, itemKey, name, lore, actions, visibleWhen);
+    }
+
+    private static Map<String, String> parseActions(final ConfigurationSection section) {
+        if (section == null) {
+            return Map.of();
+        }
+        final Map<String, String> actions = new HashMap<>();
+        for (String key : section.getKeys(false)) {
+            final String action = section.getString(key);
+            if (action == null || action.isBlank()) {
+                continue;
+            }
+            actions.put(key.toLowerCase(Locale.ROOT), action.trim());
+        }
+        return Map.copyOf(actions);
+    }
+
+    private static FriendsListMenuConfiguration.Sorting parseSorting(final ConfigurationSection section) {
+        if (section == null) {
+            return FriendsListMenuConfiguration.Sorting.empty();
+        }
+        final String currentSort = section.getString("current_sort", "online_first");
+        final FriendsListMenuConfiguration.Button sortButton = parseButton(section.getConfigurationSection("sort_button"));
+        final Map<String, FriendsListMenuConfiguration.SortingOption> options = new HashMap<>();
+        final ConfigurationSection optionsSection = section.getConfigurationSection("options");
+        if (optionsSection != null) {
+            for (String key : optionsSection.getKeys(false)) {
+                final ConfigurationSection optionSection = optionsSection.getConfigurationSection(key);
+                if (optionSection == null) {
+                    continue;
+                }
+                final String name = optionSection.getString("name", key);
+                final String description = optionSection.getString("description", "");
+                options.put(key, new FriendsListMenuConfiguration.SortingOption(key, name, description));
+            }
+        }
+        return new FriendsListMenuConfiguration.Sorting(currentSort, sortButton, options);
+    }
+
+    private static FriendsListMenuConfiguration.Filters parseFilters(final ConfigurationSection section) {
+        if (section == null) {
+            return FriendsListMenuConfiguration.Filters.empty();
+        }
+        final boolean showOnlineOnly = section.getBoolean("show_online_only", false);
+        final boolean showFavoritesOnly = section.getBoolean("show_favorites_only", false);
+        final boolean hideAway = section.getBoolean("hide_away", false);
+        final boolean hideBusy = section.getBoolean("hide_busy", false);
+        final FriendsListMenuConfiguration.Button filterButton = parseButton(section.getConfigurationSection("filter_button"));
+        return new FriendsListMenuConfiguration.Filters(showOnlineOnly, showFavoritesOnly, hideAway, hideBusy, filterButton);
+    }
+
+    private static FriendsListMenuConfiguration.FriendTemplate parseFriendTemplate(final ConfigurationSection section) {
+        if (section == null) {
+            return FriendsListMenuConfiguration.FriendTemplate.empty();
+        }
+        final String itemKey = resolveItemKey(section, "item");
+        final String name = section.getString("name", "");
+        final List<String> lore = section.getStringList("lore");
+        final Map<String, String> actions = parseActions(section.getConfigurationSection("actions"));
+        return new FriendsListMenuConfiguration.FriendTemplate(itemKey, name, lore, actions);
+    }
+
+    private static FriendsListMenuConfiguration.FavoriteDecorations parseFavoriteDecorations(final ConfigurationSection section) {
+        if (section == null) {
+            return FriendsListMenuConfiguration.FavoriteDecorations.empty();
+        }
+        final boolean enchanted = section.getBoolean("enchanted", false);
+        final String particles = section.getString("particles", "");
+        final String namePrefix = section.getString("name_prefix", "");
+        final List<String> loreAddition = section.getStringList("lore_addition");
+        return new FriendsListMenuConfiguration.FavoriteDecorations(enchanted, particles, namePrefix, loreAddition);
+    }
+
+    private static Map<String, FriendsListMenuConfiguration.StatusDecoration> parseStatuses(final ConfigurationSection section) {
+        if (section == null) {
+            return Map.of();
+        }
+        final Map<String, FriendsListMenuConfiguration.StatusDecoration> statuses = new HashMap<>();
+        for (String key : section.getKeys(false)) {
+            final ConfigurationSection statusSection = section.getConfigurationSection(key);
+            if (statusSection == null) {
+                continue;
+            }
+            final String suffix = statusSection.getString("name_suffix", "");
+            final String color = statusSection.getString("status_color", "");
+            statuses.put(key, new FriendsListMenuConfiguration.StatusDecoration(suffix, color));
+        }
+        return Map.copyOf(statuses);
+    }
+
+    private static FriendsListMenuConfiguration.Sounds parseSounds(final ConfigurationSection section) {
+        if (section == null) {
+            return FriendsListMenuConfiguration.Sounds.empty();
+        }
+        final Sound open = resolveSound(section.getString("open_list"));
+        final Sound pageTurn = resolveSound(section.getString("page_turn"));
+        final Sound friendClick = resolveSound(section.getString("friend_click"));
+        final Sound teleportSuccess = resolveSound(section.getString("teleport_success"));
+        final Sound teleportFailed = resolveSound(section.getString("teleport_failed"));
+        final Sound messageSent = resolveSound(section.getString("message_sent"));
+        return new FriendsListMenuConfiguration.Sounds(open, pageTurn, friendClick, teleportSuccess, teleportFailed, messageSent);
+    }
+
+    private static Map<String, String> parseMessages(final ConfigurationSection section) {
+        if (section == null) {
+            return Map.of();
+        }
+        final Map<String, String> messages = new HashMap<>();
+        for (String key : section.getKeys(false)) {
+            final String value = section.getString(key);
+            if (value == null) {
+                continue;
+            }
+            messages.put(key, value);
+        }
+        return Map.copyOf(messages);
+    }
+
+    private static List<String> parseStringList(final List<String> list) {
+        if (list == null || list.isEmpty()) {
+            return List.of();
+        }
+        return List.copyOf(list);
+    }
+
+    private static FriendsListMenuConfiguration.AdvancedSettings parseAdvancedSettings(final ConfigurationSection section,
+                                                                                      final int defaultItemsPerPage) {
+        if (section == null) {
+            return new FriendsListMenuConfiguration.AdvancedSettings(defaultItemsPerPage, 300, 5, true, true, true);
+        }
+        final int maxPerPage = section.getInt("max_friends_per_page", defaultItemsPerPage);
+        final int headCacheDuration = section.getInt("head_cache_duration", 300);
+        final int statusInterval = section.getInt("status_update_interval", 5);
+        final boolean offlineGrayscale = section.getBoolean("offline_head_grayscale", true);
+        final boolean favoriteGlow = section.getBoolean("favorite_glow_effect", true);
+        final boolean animateStatus = section.getBoolean("animate_status_changes", true);
+        return new FriendsListMenuConfiguration.AdvancedSettings(maxPerPage, headCacheDuration, statusInterval,
+                offlineGrayscale, favoriteGlow, animateStatus);
+    }
+
+    private static FriendsListMenuConfiguration.Integrations parseIntegrations(final ConfigurationSection section) {
+        if (section == null) {
+            return FriendsListMenuConfiguration.Integrations.empty();
+        }
+        final boolean placeholderApi = section.getBoolean("placeholderapi", true);
+        final boolean headDatabase = section.getBoolean("headdatabase", true);
+        final boolean bungeeMessaging = section.getBoolean("bungee_messaging", true);
+        return new FriendsListMenuConfiguration.Integrations(placeholderApi, headDatabase, bungeeMessaging);
+    }
+
+    private static String resolveItemKey(final ConfigurationSection section) {
+        return resolveItemKey(section, "material");
+    }
+
+    private static String resolveItemKey(final ConfigurationSection section, final String materialKey) {
+        if (section == null) {
+            return "BARRIER";
+        }
+        final String hdbId = section.getString("hdb_id");
+        if (hdbId != null && !hdbId.isBlank()) {
+            return "hdb:" + hdbId.trim();
+        }
+        final String materialName = section.getString(materialKey, "BARRIER");
+        if (materialName == null || materialName.isBlank()) {
+            return "BARRIER";
+        }
+        return materialName.trim();
+    }
+
+    private static Sound resolveSound(final String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Sound.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            return null;
+        }
+    }
+}
+

--- a/src/main/java/com/lobby/friends/menu/options/FriendOptionsMenuConfiguration.java
+++ b/src/main/java/com/lobby/friends/menu/options/FriendOptionsMenuConfiguration.java
@@ -1,0 +1,90 @@
+package com.lobby.friends.menu.options;
+
+import com.lobby.friends.menu.FriendsMenuDecoration;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable representation of the friend options menu (opened via right click
+ * on a friend entry). The configuration contains layout decorations, individual
+ * actionable items and confirmation prompts.
+ */
+public final class FriendOptionsMenuConfiguration {
+
+    private final String title;
+    private final int size;
+    private final List<FriendsMenuDecoration> decorations;
+    private final List<MenuItem> items;
+    private final Map<String, ConfirmationPrompt> confirmations;
+
+    public FriendOptionsMenuConfiguration(final String title,
+                                          final int size,
+                                          final List<FriendsMenuDecoration> decorations,
+                                          final List<MenuItem> items,
+                                          final Map<String, ConfirmationPrompt> confirmations) {
+        this.title = title == null || title.isBlank() ? "§8» §7Options d'Ami" : title;
+        this.size = Math.max(9, Math.min(54, size));
+        this.decorations = decorations == null ? List.of() : List.copyOf(decorations);
+        this.items = items == null ? List.of() : List.copyOf(items);
+        this.confirmations = confirmations == null ? Map.of() : Map.copyOf(confirmations);
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public List<FriendsMenuDecoration> getDecorations() {
+        return Collections.unmodifiableList(decorations);
+    }
+
+    public List<MenuItem> getItems() {
+        return Collections.unmodifiableList(items);
+    }
+
+    public Map<String, ConfirmationPrompt> getConfirmations() {
+        return Collections.unmodifiableMap(confirmations);
+    }
+
+    /**
+     * Describes an item displayed in the friend options menu.
+     */
+    public record MenuItem(int slot,
+                           String itemKey,
+                           String displayName,
+                           List<String> lore,
+                           Map<String, String> actions) {
+
+        public MenuItem {
+            slot = Math.max(0, slot);
+            itemKey = itemKey == null ? "BARRIER" : itemKey;
+            displayName = displayName == null ? "" : displayName;
+            lore = lore == null ? List.of() : List.copyOf(lore);
+            actions = actions == null ? Map.of() : Map.copyOf(actions);
+        }
+    }
+
+    /**
+     * Confirmation prompt triggered before executing sensitive actions such as
+     * removing or blocking a friend.
+     */
+    public record ConfirmationPrompt(String title,
+                                     String message,
+                                     String confirmButton,
+                                     String cancelButton) {
+
+        public ConfirmationPrompt {
+            title = Objects.requireNonNullElse(title, "");
+            message = Objects.requireNonNullElse(message, "");
+            confirmButton = Objects.requireNonNullElse(confirmButton, "");
+            cancelButton = Objects.requireNonNullElse(cancelButton, "");
+        }
+    }
+}
+

--- a/src/main/java/com/lobby/friends/menu/options/FriendOptionsMenuConfigurationLoader.java
+++ b/src/main/java/com/lobby/friends/menu/options/FriendOptionsMenuConfigurationLoader.java
@@ -1,0 +1,163 @@
+package com.lobby.friends.menu.options;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.friends.menu.FriendsMenuDecoration;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Loader responsible for the {@code friend_options.yml} configuration file.
+ */
+public final class FriendOptionsMenuConfigurationLoader {
+
+    private static final String RESOURCE_PATH = "friends/friend_options.yml";
+
+    private FriendOptionsMenuConfigurationLoader() {
+    }
+
+    public static FriendOptionsMenuConfiguration load(final LobbyPlugin plugin) {
+        final File directory = ensureDirectory(plugin);
+        final File file = new File(directory, "friend_options.yml");
+        ensureResource(plugin, file);
+
+        final YamlConfiguration configuration = new YamlConfiguration();
+        try {
+            configuration.load(file);
+        } catch (IOException | InvalidConfigurationException exception) {
+            plugin.getLogger().warning("Impossible de charger '" + file.getName() + "': " + exception.getMessage());
+            return buildFallback();
+        }
+
+        final ConfigurationSection menuSection = configuration.getConfigurationSection("menu");
+        final String title = menuSection != null ? menuSection.getString("title") : null;
+        final int size = menuSection != null ? menuSection.getInt("size", 27) : 27;
+        final List<FriendsMenuDecoration> decorations = parseDecorations(configuration.getConfigurationSection("decoration"));
+        final List<FriendOptionsMenuConfiguration.MenuItem> items = parseItems(configuration.getConfigurationSection("items"));
+        final Map<String, FriendOptionsMenuConfiguration.ConfirmationPrompt> confirmations = parseConfirmations(configuration.getConfigurationSection("confirmations"));
+
+        return new FriendOptionsMenuConfiguration(title, size, decorations, items, confirmations);
+    }
+
+    private static File ensureDirectory(final LobbyPlugin plugin) {
+        final File dataFolder = plugin.getDataFolder();
+        final File directory = new File(dataFolder, "friends");
+        if (!directory.exists() && !directory.mkdirs()) {
+            plugin.getLogger().warning("Impossible de créer le dossier des amis: " + directory.getAbsolutePath());
+        }
+        return directory;
+    }
+
+    private static void ensureResource(final LobbyPlugin plugin, final File file) {
+        if (file.exists()) {
+            return;
+        }
+        try {
+            plugin.saveResource(RESOURCE_PATH, false);
+        } catch (final IllegalArgumentException ignored) {
+            // Resource not packaged; rely on fallback values.
+        }
+    }
+
+    private static FriendOptionsMenuConfiguration buildFallback() {
+        return new FriendOptionsMenuConfiguration("§8» §7Options d'Ami", 27, List.of(), List.of(), Map.of());
+    }
+
+    private static List<FriendsMenuDecoration> parseDecorations(final ConfigurationSection section) {
+        if (section == null) {
+            return List.of();
+        }
+        final List<FriendsMenuDecoration> decorations = new ArrayList<>();
+        for (String key : section.getKeys(false)) {
+            final ConfigurationSection decorationSection = section.getConfigurationSection(key);
+            if (decorationSection == null) {
+                continue;
+            }
+            final String materialName = decorationSection.getString("material", "GRAY_STAINED_GLASS_PANE");
+            Material material = Material.matchMaterial(materialName.toUpperCase(Locale.ROOT));
+            if (material == null) {
+                material = Material.GRAY_STAINED_GLASS_PANE;
+            }
+            final String name = decorationSection.getString("name", " ");
+            final List<Integer> slots = decorationSection.getIntegerList("slots");
+            decorations.add(new FriendsMenuDecoration(material, name, slots));
+        }
+        return decorations;
+    }
+
+    private static List<FriendOptionsMenuConfiguration.MenuItem> parseItems(final ConfigurationSection section) {
+        if (section == null) {
+            return List.of();
+        }
+        final List<FriendOptionsMenuConfiguration.MenuItem> items = new ArrayList<>();
+        for (String key : section.getKeys(false)) {
+            final ConfigurationSection itemSection = section.getConfigurationSection(key);
+            if (itemSection == null) {
+                continue;
+            }
+            final int slot = itemSection.getInt("slot", 0);
+            final String itemKey = resolveItemKey(itemSection);
+            final String name = itemSection.getString("name", "");
+            final List<String> lore = itemSection.getStringList("lore");
+            final Map<String, String> actions = parseActions(itemSection.getConfigurationSection("actions"));
+            items.add(new FriendOptionsMenuConfiguration.MenuItem(slot, itemKey, name, lore, actions));
+        }
+        return items;
+    }
+
+    private static Map<String, FriendOptionsMenuConfiguration.ConfirmationPrompt> parseConfirmations(final ConfigurationSection section) {
+        if (section == null) {
+            return Map.of();
+        }
+        final Map<String, FriendOptionsMenuConfiguration.ConfirmationPrompt> confirmations = new HashMap<>();
+        for (String key : section.getKeys(false)) {
+            final ConfigurationSection confirmationSection = section.getConfigurationSection(key);
+            if (confirmationSection == null) {
+                continue;
+            }
+            final String title = confirmationSection.getString("title", "");
+            final String message = confirmationSection.getString("message", "");
+            final String confirm = confirmationSection.getString("confirm_button", "");
+            final String cancel = confirmationSection.getString("cancel_button", "");
+            confirmations.put(key, new FriendOptionsMenuConfiguration.ConfirmationPrompt(title, message, confirm, cancel));
+        }
+        return Map.copyOf(confirmations);
+    }
+
+    private static Map<String, String> parseActions(final ConfigurationSection section) {
+        if (section == null) {
+            return Map.of();
+        }
+        final Map<String, String> actions = new HashMap<>();
+        for (String key : section.getKeys(false)) {
+            final String action = section.getString(key);
+            if (action == null || action.isBlank()) {
+                continue;
+            }
+            actions.put(key.toLowerCase(Locale.ROOT), action.trim());
+        }
+        return Map.copyOf(actions);
+    }
+
+    private static String resolveItemKey(final ConfigurationSection section) {
+        final String hdbId = section.getString("hdb_id");
+        if (hdbId != null && !hdbId.isBlank()) {
+            return "hdb:" + hdbId.trim();
+        }
+        final String materialName = section.getString("material", "BARRIER");
+        if (materialName == null || materialName.isBlank()) {
+            return "BARRIER";
+        }
+        return materialName.trim();
+    }
+}
+

--- a/src/main/java/com/lobby/friends/notifications/FriendsNotificationsConfiguration.java
+++ b/src/main/java/com/lobby/friends/notifications/FriendsNotificationsConfiguration.java
@@ -1,0 +1,73 @@
+package com.lobby.friends.notifications;
+
+import org.bukkit.Sound;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable container for the notifications system configuration. Each
+ * notification entry describes the feedback sent to players when specific
+ * friend events occur (online, offline, etc.).
+ */
+public final class FriendsNotificationsConfiguration {
+
+    private final Map<String, NotificationSettings> notifications;
+    private final AutoUpdateSettings autoUpdateSettings;
+
+    public FriendsNotificationsConfiguration(final Map<String, NotificationSettings> notifications,
+                                             final AutoUpdateSettings autoUpdateSettings) {
+        this.notifications = notifications == null ? Map.of() : Map.copyOf(notifications);
+        this.autoUpdateSettings = Objects.requireNonNullElse(autoUpdateSettings, AutoUpdateSettings.disabled());
+    }
+
+    public Map<String, NotificationSettings> getNotifications() {
+        return Collections.unmodifiableMap(notifications);
+    }
+
+    public AutoUpdateSettings getAutoUpdateSettings() {
+        return autoUpdateSettings;
+    }
+
+    /**
+     * Single notification entry configuration.
+     */
+    public record NotificationSettings(boolean enabled,
+                                       String message,
+                                       Sound sound,
+                                       double volume,
+                                       double pitch,
+                                       String actionBar,
+                                       int durationSeconds,
+                                       String chatNotification) {
+
+        public NotificationSettings {
+            volume = Math.max(0.0d, volume);
+            pitch = Math.max(0.0d, pitch);
+            durationSeconds = Math.max(0, durationSeconds);
+            message = message == null ? "" : message;
+            actionBar = actionBar == null ? "" : actionBar;
+            chatNotification = chatNotification == null ? "" : chatNotification;
+        }
+    }
+
+    /**
+     * Settings controlling the automatic status refresh behaviour.
+     */
+    public record AutoUpdateSettings(boolean enabled,
+                                     int intervalSeconds,
+                                     boolean updateOfflineStatus,
+                                     boolean updateServerStatus,
+                                     boolean refreshHeads) {
+
+        public AutoUpdateSettings {
+            intervalSeconds = Math.max(1, intervalSeconds);
+        }
+
+        public static AutoUpdateSettings disabled() {
+            return new AutoUpdateSettings(false, 5, true, true, true);
+        }
+    }
+}
+

--- a/src/main/java/com/lobby/friends/notifications/FriendsNotificationsConfigurationLoader.java
+++ b/src/main/java/com/lobby/friends/notifications/FriendsNotificationsConfigurationLoader.java
@@ -1,0 +1,116 @@
+package com.lobby.friends.notifications;
+
+import com.lobby.LobbyPlugin;
+import org.bukkit.Sound;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Loader for {@code notifications.yml}. The configuration powers real-time
+ * notifications about friend activity.
+ */
+public final class FriendsNotificationsConfigurationLoader {
+
+    private static final String RESOURCE_PATH = "friends/notifications.yml";
+
+    private FriendsNotificationsConfigurationLoader() {
+    }
+
+    public static FriendsNotificationsConfiguration load(final LobbyPlugin plugin) {
+        final File directory = ensureDirectory(plugin);
+        final File file = new File(directory, "notifications.yml");
+        ensureResource(plugin, file);
+
+        final YamlConfiguration configuration = new YamlConfiguration();
+        try {
+            configuration.load(file);
+        } catch (IOException | InvalidConfigurationException exception) {
+            plugin.getLogger().warning("Impossible de charger '" + file.getName() + "': " + exception.getMessage());
+            return buildFallback();
+        }
+
+        final Map<String, FriendsNotificationsConfiguration.NotificationSettings> notifications = parseNotifications(configuration.getConfigurationSection("notifications"));
+        final FriendsNotificationsConfiguration.AutoUpdateSettings autoUpdate = parseAutoUpdate(configuration.getConfigurationSection("auto_update"));
+
+        return new FriendsNotificationsConfiguration(notifications, autoUpdate);
+    }
+
+    private static File ensureDirectory(final LobbyPlugin plugin) {
+        final File dataFolder = plugin.getDataFolder();
+        final File directory = new File(dataFolder, "friends");
+        if (!directory.exists() && !directory.mkdirs()) {
+            plugin.getLogger().warning("Impossible de créer le dossier des amis: " + directory.getAbsolutePath());
+        }
+        return directory;
+    }
+
+    private static void ensureResource(final LobbyPlugin plugin, final File file) {
+        if (file.exists()) {
+            return;
+        }
+        try {
+            plugin.saveResource(RESOURCE_PATH, false);
+        } catch (final IllegalArgumentException ignored) {
+            // Resource not packaged; rely on fallback.
+        }
+    }
+
+    private static FriendsNotificationsConfiguration buildFallback() {
+        return new FriendsNotificationsConfiguration(Map.of(), FriendsNotificationsConfiguration.AutoUpdateSettings.disabled());
+    }
+
+    private static Map<String, FriendsNotificationsConfiguration.NotificationSettings> parseNotifications(final ConfigurationSection section) {
+        if (section == null) {
+            return Map.of();
+        }
+        final Map<String, FriendsNotificationsConfiguration.NotificationSettings> notifications = new HashMap<>();
+        for (String key : section.getKeys(false)) {
+            final ConfigurationSection notificationSection = section.getConfigurationSection(key);
+            if (notificationSection == null) {
+                continue;
+            }
+            final boolean enabled = notificationSection.getBoolean("enabled", true);
+            final String message = notificationSection.getString("message", "");
+            final Sound sound = resolveSound(notificationSection.getString("sound"));
+            final double volume = notificationSection.getDouble("volume", 1.0d);
+            final double pitch = notificationSection.getDouble("pitch", 1.0d);
+            final String actionBar = notificationSection.getString("actionbar", "");
+            final int duration = notificationSection.getInt("duration", 0);
+            final String chat = notificationSection.getString("chat_notification", "");
+            notifications.put(key, new FriendsNotificationsConfiguration.NotificationSettings(enabled, message, sound,
+                    volume, pitch, actionBar, duration, chat));
+        }
+        return Map.copyOf(notifications);
+    }
+
+    private static FriendsNotificationsConfiguration.AutoUpdateSettings parseAutoUpdate(final ConfigurationSection section) {
+        if (section == null) {
+            return FriendsNotificationsConfiguration.AutoUpdateSettings.disabled();
+        }
+        final boolean enabled = section.getBoolean("enabled", true);
+        final int interval = section.getInt("interval", 5);
+        final boolean updateOffline = section.getBoolean("update_offline_status", true);
+        final boolean updateServer = section.getBoolean("update_server_status", true);
+        final boolean refreshHeads = section.getBoolean("refresh_heads", true);
+        return new FriendsNotificationsConfiguration.AutoUpdateSettings(enabled, interval, updateOffline, updateServer, refreshHeads);
+    }
+
+    private static Sound resolveSound(final String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Sound.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            return null;
+        }
+    }
+}
+

--- a/src/main/resources/friends/friend_options.yml
+++ b/src/main/resources/friends/friend_options.yml
@@ -1,0 +1,147 @@
+# ===============================
+# MENU OPTIONS POUR UN AMI
+# ===============================
+
+menu:
+  title: "§8» §7Options pour §a{nom_ami}"
+  size: 27
+
+decoration:
+  gray_glass:
+    material: "GRAY_STAINED_GLASS_PANE"
+    name: " "
+    slots: [0, 1, 2, 3, 5, 6, 7, 8, 9, 17, 18, 19, 20, 24, 25, 26]
+
+items:
+  teleport:
+    slot: 10
+    hdb_id: 2018
+    name: "§a🚀 Se Téléporter"
+    lore:
+      - "§7Téléportez-vous instantanément"
+      - "§7vers votre ami"
+      - ""
+      - "§7Statut: §e{teleport_status}"
+      - ""
+      - "§8» §aCliquez pour vous téléporter"
+    actions:
+      left_click: "teleport_to_friend"
+
+  send_message:
+    slot: 11
+    hdb_id: 5315
+    name: "§e💬 Envoyer un Message"
+    lore:
+      - "§7Envoyez un message privé"
+      - "§7à votre ami"
+      - ""
+      - "§e▸ Dernier message: §f{dernier_message}"
+      - "§7▸ Il y a: §8{temps_dernier_message}"
+      - ""
+      - "§8» §eCliquez pour écrire"
+    actions:
+      left_click: "send_private_message"
+
+  toggle_favorite:
+    slot: 12
+    hdb_id: 6156
+    name: "§6🏆 {favorite_action}"
+    lore:
+      - "§7Marquez cet ami comme favori"
+      - "§7pour un accès rapide"
+      - ""
+      - "§6▸ Statut actuel: §e{est_favori_text}"
+      - "§7▸ Favoris actuels: §8{nb_favoris}§7/§8{limite_favoris}"
+      - ""
+      - "§8» §6Cliquez pour {favorite_action_verb}"
+    actions:
+      left_click: "toggle_favorite"
+
+  view_profile:
+    slot: 13
+    hdb_id: 1452
+    name: "§b👤 Voir le Profil"
+    lore:
+      - "§7Consultez le profil détaillé"
+      - "§7de votre ami"
+      - ""
+      - "§b▸ Niveau: §3{niveau_ami}"
+      - "§b▸ Temps de jeu: §3{temps_jeu_ami}"
+      - "§b▸ Dernière connexion: §3{derniere_co_ami}"
+      - ""
+      - "§8» §bCliquez pour voir plus"
+    actions:
+      left_click: "view_friend_profile"
+
+  friendship_stats:
+    slot: 14
+    hdb_id: 2967
+    name: "§d📊 Statistiques d'Amitié"
+    lore:
+      - "§7Consultez vos statistiques"
+      - "§7avec cet ami"
+      - ""
+      - "§d▸ Amis depuis: §5{duree_amitie}"
+      - "§d▸ Messages échangés: §5{messages_total}"
+      - "§d▸ Temps joué ensemble: §5{temps_ensemble}"
+      - ""
+      - "§8» §dCliquez pour plus de détails"
+    actions:
+      left_click: "view_friendship_stats"
+
+  remove_friend:
+    slot: 15
+    hdb_id: 5464
+    name: "§c💔 Retirer des Amis"
+    lore:
+      - "§cRetirez cette personne"
+      - "§cde votre liste d'amis"
+      - ""
+      - "§c⚠ Cette action est irréversible !"
+      - "§7Vous devrez renvoyer une demande"
+      - "§7pour redevenir amis"
+      - ""
+      - "§8» §cCliquez pour confirmer"
+    actions:
+      left_click: "remove_friend"
+
+  block_player:
+    slot: 16
+    hdb_id: 8127
+    name: "§8🚫 Bloquer le Joueur"
+    lore:
+      - "§8Bloquez ce joueur pour:"
+      - "§7▸ Empêcher les messages"
+      - "§7▸ Masquer votre statut"
+      - "§7▸ Refuser les téléportations"
+      - ""
+      - "§8⚠ Cela retirera aussi l'amitié !"
+      - ""
+      - "§8» §8Cliquez pour bloquer"
+    actions:
+      left_click: "block_player"
+
+  back:
+    slot: 22
+    hdb_id: 3593
+    name: "§7◀ Retour à la Liste"
+    lore:
+      - "§7Revenir à la liste des amis"
+      - ""
+      - "§8» §7Cliquez pour retourner"
+    actions:
+      left_click: "back_to_friends_list"
+
+confirmations:
+  remove_friend:
+    title: "§c⚠ Confirmer la suppression"
+    message: "§7Êtes-vous sûr de vouloir retirer §c{nom_ami} §7de vos amis ?"
+    confirm_button: "§c✓ Oui, retirer"
+    cancel_button: "§a✗ Annuler"
+
+  block_player:
+    title: "§8⚠ Confirmer le blocage"
+    message: "§7Êtes-vous sûr de vouloir bloquer §8{nom_ami} §7?"
+    confirm_button: "§8✓ Oui, bloquer"
+    cancel_button: "§a✗ Annuler"
+

--- a/src/main/resources/friends/friends_list.yml
+++ b/src/main/resources/friends/friends_list.yml
@@ -1,0 +1,235 @@
+# ===============================
+# CONFIGURATION LISTE DES AMIS
+# ===============================
+
+menu:
+  title: "§8» §aListe des Amis ({page}/{total_pages})"
+  size: 54
+  items_per_page: 28
+  auto_refresh: true
+  refresh_interval: 10
+
+decoration:
+  green_glass:
+    material: "GREEN_STAINED_GLASS_PANE"
+    name: " "
+    slots: [0, 1, 2, 6, 7, 8, 9, 17, 45, 46, 52, 53]
+
+friend_slots: [10, 11, 12, 13, 14, 15, 16, 19, 20, 21, 22, 23, 24, 25, 28, 29, 30, 31, 32, 33, 34, 37, 38, 39, 40, 41, 42, 43]
+
+navigation:
+  previous_page:
+    slot: 47
+    hdb_id: 7827
+    name: "§c◀ Page Précédente"
+    lore:
+      - "§7Aller à la page {page_precedente}"
+      - ""
+      - "§8» §cCliquez pour revenir"
+    visible_when: "{page_actuelle} > 1"
+    actions:
+      left_click: "previous_page"
+
+  back_to_main:
+    slot: 49
+    hdb_id: 3593
+    name: "§e🏠 Retour Menu Principal"
+    lore:
+      - "§7Revenir au menu principal"
+      - "§7des amis"
+      - ""
+      - "§8» §eCliquez pour retourner"
+    actions:
+      left_click: "back_to_main"
+
+  next_page:
+    slot: 51
+    hdb_id: 7828
+    name: "§a▶ Page Suivante"
+    lore:
+      - "§7Aller à la page {page_suivante}"
+      - ""
+      - "§8» §aCliquez pour continuer"
+    visible_when: "{page_actuelle} < {total_pages}"
+    actions:
+      left_click: "next_page"
+
+sorting:
+  current_sort: "online_first"
+  sort_button:
+    slot: 46
+    hdb_id: 1619
+    name: "§6§l📋 Tri: §e{tri_actuel}"
+    lore:
+      - "§7Trier la liste des amis"
+      - ""
+      - "§6▸ Tri actuel: §e{tri_actuel}"
+      - "§7▸ Total d'amis: §8{total_amis}"
+      - ""
+      - "§7Options disponibles:"
+      - "§8▸ §aEn ligne d'abord"
+      - "§8▸ §7Alphabétique (A-Z)"
+      - "§8▸ §bDate d'amitié"
+      - "§8▸ §eDernière connexion"
+      - "§8▸ §6Favoris d'abord"
+      - "§8▸ §dPlus de messages"
+      - ""
+      - "§8» §6Cliquez pour changer"
+    actions:
+      left_click: "change_sorting"
+
+  options:
+    online_first:
+      name: "En ligne d'abord"
+      description: "Amis connectés en premier"
+    alphabetical:
+      name: "Alphabétique (A-Z)"
+      description: "Ordre alphabétique des noms"
+    friendship_date:
+      name: "Date d'amitié"
+      description: "Plus récents en premier"
+    last_seen:
+      name: "Dernière connexion"
+      description: "Plus récemment vus en premier"
+    favorites_first:
+      name: "Favoris d'abord"
+      description: "Favoris en priorité"
+    most_messages:
+      name: "Plus de messages"
+      description: "Plus actifs en premier"
+
+filters:
+  show_online_only: false
+  show_favorites_only: false
+  hide_away: false
+  hide_busy: false
+
+  filter_button:
+    slot: 52
+    hdb_id: 8726
+    name: "§b§l🔍 Filtres"
+    lore:
+      - "§7Filtrer l'affichage des amis"
+      - ""
+      - "§b▸ En ligne seulement: §3{filtre_en_ligne}"
+      - "§e▸ Favoris seulement: §6{filtre_favoris}"
+      - "§c▸ Masquer absents: §4{filtre_absents}"
+      - "§7▸ Masquer occupés: §8{filtre_occupes}"
+      - ""
+      - "§8» §bCliquez pour configurer"
+    actions:
+      left_click: "open_filters"
+
+friend_online:
+  item: "PLAYER_HEAD"
+  name: "§a§l{nom_joueur} §2●"
+  lore:
+    - "§7Statut: §aEn ligne"
+    - "§7Serveur: §e{serveur_actuel}"
+    - "§7Ami depuis: §b{date_amitie}"
+    - ""
+    - "§6🏆 Favori: §e{est_favori_text}"
+    - "§3📊 Messages échangés: §b{nb_messages}"
+    - "§d💌 Dernier message: §5{dernier_message}"
+    - "§b⏰ En ligne depuis: §3{temps_en_ligne}"
+    - ""
+    - "§8▸ §aClique gauche §8: §7Téléporter"
+    - "§8▸ §eClique milieu §8: §7Message privé"
+    - "§8▸ §cClique droit §8: §7Plus d'options"
+  actions:
+    left_click: "teleport_to_friend"
+    middle_click: "send_private_message"
+    right_click: "open_friend_options"
+
+friend_offline:
+  item: "PLAYER_HEAD"
+  name: "§7§l{nom_joueur} §8●"
+  lore:
+    - "§7Statut: §cHors ligne"
+    - "§7Dernière connexion: §e{derniere_co}"
+    - "§7Ami depuis: §b{date_amitie}"
+    - ""
+    - "§6🏆 Favori: §e{est_favori_text}"
+    - "§3📊 Messages échangés: §b{nb_messages}"
+    - "§d💌 Dernier message: §5{dernier_message}"
+    - "§c⏰ Hors ligne depuis: §4{temps_hors_ligne}"
+    - ""
+    - "§8▸ §eClique milieu §8: §7Message hors-ligne"
+    - "§8▸ §cClique droit §8: §7Plus d'options"
+  actions:
+    middle_click: "send_offline_message"
+    right_click: "open_friend_options"
+
+friend_favorite:
+  enchanted: true
+  particles: "VILLAGER_HAPPY"
+  name_prefix: "§e⭐ "
+  lore_addition:
+    - "§6✨ AMI FAVORI ✨"
+
+friend_statuses:
+  away:
+    name_suffix: " §7(Absent)"
+    status_color: "§7"
+  busy:
+    name_suffix: " §c(Occupé)"
+    status_color: "§c"
+  do_not_disturb:
+    name_suffix: " §8(Ne pas déranger)"
+    status_color: "§8"
+
+sounds:
+  open_list: "ENTITY_EXPERIENCE_ORB_PICKUP"
+  page_turn: "ITEM_BOOK_PAGE_TURN"
+  friend_click: "UI_BUTTON_CLICK"
+  teleport_success: "ENTITY_ENDERMAN_TELEPORT"
+  teleport_failed: "BLOCK_ANVIL_LAND"
+  message_sent: "ENTITY_EXPERIENCE_ORB_PICKUP"
+
+messages:
+  no_friends: "§7Vous n'avez pas encore d'amis !"
+  loading: "§7Chargement des amis..."
+  friend_not_found: "§cAmi introuvable !"
+  teleport_success: "§aVous avez été téléporté chez {ami} !"
+  teleport_failed: "§cImpossible de se téléporter chez {ami}"
+  teleport_offline: "§c{ami} n'est pas en ligne !"
+  teleport_same_server: "§c{ami} n'est pas sur le même serveur !"
+  teleport_disabled: "§c{ami} a désactivé la téléportation"
+  message_sent: "§aMessage envoyé à {ami} !"
+  message_failed: "§cImpossible d'envoyer le message"
+  friend_blocked_you: "§cCet ami vous a bloqué"
+
+placeholders:
+  - "{page}"
+  - "{total_pages}"
+  - "{page_precedente}"
+  - "{page_suivante}"
+  - "{total_amis}"
+  - "{tri_actuel}"
+  - "{filtre_en_ligne}"
+  - "{filtre_favoris}"
+  - "{filtre_absents}"
+  - "{filtre_occupes}"
+  - "{nom_joueur}"
+  - "{serveur_actuel}"
+  - "{date_amitie}"
+  - "{est_favori_text}"
+  - "{nb_messages}"
+  - "{dernier_message}"
+  - "{temps_en_ligne}"
+  - "{temps_hors_ligne}"
+  - "{derniere_co}"
+
+advanced:
+  max_friends_per_page: 28
+  head_cache_duration: 300
+  status_update_interval: 5
+  offline_head_grayscale: true
+  favorite_glow_effect: true
+  animate_status_changes: true
+
+integrations:
+  placeholderapi: true
+  headdatabase: true
+  bungee_messaging: true
+

--- a/src/main/resources/friends/notifications.yml
+++ b/src/main/resources/friends/notifications.yml
@@ -1,0 +1,38 @@
+# ===============================
+# NOTIFICATIONS AMIS EN TEMPS RÉEL
+# ===============================
+
+notifications:
+  friend_online:
+    enabled: true
+    message: "§a{ami} §7vient de se connecter !"
+    sound: "ENTITY_PLAYER_LEVELUP"
+    volume: 1.0
+    pitch: 1.5
+    actionbar: "§a▶ §7{ami} est maintenant en ligne"
+    duration: 3
+
+  friend_offline:
+    enabled: false
+    message: "§c{ami} §7s'est déconnecté"
+    sound: "BLOCK_NOTE_BLOCK_BASS"
+    actionbar: "§c◀ §7{ami} s'est déconnecté"
+
+  friend_server_change:
+    enabled: true
+    message: "§e{ami} §7a changé de serveur: §e{nouveau_serveur}"
+    actionbar: "§e↔ §7{ami} → {nouveau_serveur}"
+
+  message_received:
+    enabled: true
+    sound: "ENTITY_EXPERIENCE_ORB_PICKUP"
+    actionbar: "§d💬 §7Message de {ami}"
+    chat_notification: "§d[✉] {ami} §8» §f{apercu_message}"
+
+auto_update:
+  enabled: true
+  interval: 5
+  update_offline_status: true
+  update_server_status: true
+  refresh_heads: true
+


### PR DESCRIPTION
## Summary
- add strongly typed configuration objects for the paginated friends list, friend options menu and notifications
- implement loaders that read the new YAML schemas and provide sane fallbacks
- ship default configuration files for the friends list UI, friend options menu and notifications

## Testing
- `mvn -q -DskipTests package` *(fails: remote repository responds 403 while fetching Paper and PlaceholderAPI dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b84cfe90832993dbf8475ae3b3df