### PR TITLE
Add friend menu configs and placeholder feedback

### DIFF
--- a/plugins/LobbyCore/friends/add_friend.yml
+++ b/plugins/LobbyCore/friends/add_friend.yml
@@ -1,0 +1,39 @@
+# ===============================
+# CONFIGURATION AJOUT D'AMIS
+# ===============================
+
+menu:
+  title: "§8» §aAjouter un Ami"
+  size: 36
+  
+decoration:
+  green_glass:
+    material: "GREEN_STAINED_GLASS_PANE"
+    name: " "
+    slots: [0,1,2,6,7,8,9,17,18,26,27,28,29,33,34,35]
+
+items:
+  search_player:
+    slot: 10
+    hdb_id: 8726
+    name: "§a§l🔍 Rechercher un Joueur"
+    lore:
+      - "§7Tapez le nom du joueur"
+      - "§7que vous voulez ajouter"
+      - ""
+      - "§8» §aCliquez pour rechercher"
+      
+  back_to_main:
+    slot: 31
+    hdb_id: 3593
+    name: "§e🏠 Retour Menu Principal"
+    lore:
+      - "§7Revenir au menu principal"
+      - ""
+      - "§8» §eCliquez pour retourner"
+
+sounds:
+  open_menu: "ENTITY_EXPERIENCE_ORB_PICKUP"
+
+messages:
+  search_prompt: "§aTapez le nom du joueur à rechercher:"

--- a/plugins/LobbyCore/friends/blocked.yml
+++ b/plugins/LobbyCore/friends/blocked.yml
@@ -1,0 +1,10 @@
+menu:
+  title: "§8» §cJoueurs Bloqués"
+  size: 54
+navigation:
+  back_to_main:
+    slot: 49
+    hdb_id: 3593
+    name: "§e🏠 Retour Menu Principal"
+sounds:
+  open_blocked: "ENTITY_EXPERIENCE_ORB_PICKUP"

--- a/plugins/LobbyCore/friends/favorites.yml
+++ b/plugins/LobbyCore/friends/favorites.yml
@@ -1,0 +1,10 @@
+menu:
+  title: "§8» §eAmis Favoris"
+  size: 54
+navigation:
+  back_to_main:
+    slot: 49
+    hdb_id: 3593
+    name: "§e🏠 Retour Menu Principal"
+sounds:
+  open_favorites: "ENTITY_EXPERIENCE_ORB_PICKUP"

--- a/plugins/LobbyCore/friends/friend_requests.yml
+++ b/plugins/LobbyCore/friends/friend_requests.yml
@@ -1,0 +1,28 @@
+# ===============================
+# CONFIGURATION DEMANDES D'AMIS
+# ===============================
+
+menu:
+  title: "§8» §eDemandes d'Amitié"
+  size: 54
+  auto_refresh: true
+  refresh_interval: 5
+
+decoration:
+  green_glass:
+    material: "GREEN_STAINED_GLASS_PANE"
+    name: " "
+    slots: [0,1,2,6,7,8,9,17,36,44,53]
+
+navigation:
+  back_to_main:
+    slot: 49
+    hdb_id: 3593
+    name: "§e🏠 Retour Menu Principal"
+
+messages:
+  no_requests: "§7Aucune demande d'amitié en attente"
+  loading_requests: "§7Chargement des demandes..."
+
+sounds:
+  open_requests: "ENTITY_EXPERIENCE_ORB_PICKUP"

--- a/plugins/LobbyCore/friends/friends_list.yml
+++ b/plugins/LobbyCore/friends/friends_list.yml
@@ -1,0 +1,48 @@
+# ===============================
+# CONFIGURATION LISTE DES AMIS
+# ===============================
+
+menu:
+  title: "§8» §aListe des Amis ({page}/{total_pages})"
+  size: 54
+  items_per_page: 28
+  auto_refresh: true
+  refresh_interval: 10
+
+decoration:
+  green_glass:
+    material: "GREEN_STAINED_GLASS_PANE"
+    name: " "
+    slots: [0,1,2,6,7,8,9,17,45,46,52,53]
+
+friend_slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34,37,38,39,40,41,42,43]
+
+navigation:
+  previous_page:
+    slot: 47
+    hdb_id: 7827
+    name: "§c◀ Page Précédente"
+  back_to_main:
+    slot: 49
+    hdb_id: 3593
+    name: "§e🏠 Retour Menu Principal"
+  next_page:
+    slot: 51
+    hdb_id: 7828
+    name: "§a▶ Page Suivante"
+
+friend_online:
+  name: "§a§l{nom_joueur} §2●"
+  lore:
+    - "§7Statut: §aEn ligne"
+    - "§7Serveur: §e{serveur_actuel}"
+    - "§7Ami depuis: §b{date_amitie}"
+    - ""
+    - "§8» §aCliquez pour interagir"
+
+messages:
+  no_friends: "§7Vous n'avez pas encore d'amis !"
+  loading: "§7Chargement des amis..."
+
+sounds:
+  open_list: "ENTITY_EXPERIENCE_ORB_PICKUP"

--- a/plugins/LobbyCore/friends/settings.yml
+++ b/plugins/LobbyCore/friends/settings.yml
@@ -1,0 +1,10 @@
+menu:
+  title: "§8» §6Paramètres d'Amitié"
+  size: 36
+navigation:
+  back_to_main:
+    slot: 31
+    hdb_id: 3593
+    name: "§e🏠 Retour Menu Principal"
+sounds:
+  open_settings: "ENTITY_EXPERIENCE_ORB_PICKUP"

--- a/plugins/LobbyCore/friends/statistics.yml
+++ b/plugins/LobbyCore/friends/statistics.yml
@@ -1,0 +1,10 @@
+menu:
+  title: "§8» §bStatistiques d'Amitié"
+  size: 54
+navigation:
+  back_to_main:
+    slot: 49
+    hdb_id: 3593
+    name: "§e🏠 Retour Menu Principal"
+sounds:
+  open_stats: "ENTITY_EXPERIENCE_ORB_PICKUP"

--- a/src/main/java/com/lobby/friends/menu/DefaultFriendsMenuActionHandler.java
+++ b/src/main/java/com/lobby/friends/menu/DefaultFriendsMenuActionHandler.java
@@ -2,6 +2,7 @@ package com.lobby.friends.menu;
 
 import com.lobby.LobbyPlugin;
 import org.bukkit.Bukkit;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 import java.util.Locale;
@@ -41,43 +42,81 @@ public class DefaultFriendsMenuActionHandler implements FriendsMenuActionHandler
 
     private boolean openFriendsList(final Player player) {
         closeInventory(player);
-        runLater(player, () -> player.sendMessage("§a✓ Menu liste des amis (en cours de développement)"));
+        runLater(player, () -> {
+            playSound(player, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.5f);
+            player.sendMessage("§a✓ §7Menu liste des amis ouvert !");
+            player.sendMessage("§e⚠ §7En cours de développement - Configuration créée");
+            player.sendMessage("§7Fichier: §bfriends_list.yml §7disponible");
+            // TODO: Implémenter FriendsListMenu.java
+        });
         return true;
     }
 
     private boolean openAddFriend(final Player player) {
         closeInventory(player);
-        runLater(player, () -> player.sendMessage("§a✓ Menu ajout d'ami (en cours de développement)"));
+        runLater(player, () -> {
+            playSound(player, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.5f);
+            player.sendMessage("§a✓ §7Menu ajout d'ami ouvert !");
+            player.sendMessage("§e⚠ §7En cours de développement - Configuration créée");
+            player.sendMessage("§7Fichier: §badd_friend.yml §7disponible");
+            // TODO: Implémenter AddFriendMenu.java
+        });
         return true;
     }
 
     private boolean openFriendRequests(final Player player) {
         closeInventory(player);
-        runLater(player, () -> player.sendMessage("§a✓ Menu demandes d'amitié (en cours de développement)"));
+        runLater(player, () -> {
+            playSound(player, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.5f);
+            player.sendMessage("§a✓ §7Menu demandes d'amitié ouvert !");
+            player.sendMessage("§e⚠ §7En cours de développement - Configuration créée");
+            player.sendMessage("§7Fichier: §bfriend_requests.yml §7disponible");
+            // TODO: Implémenter FriendRequestsMenu.java
+        });
         return true;
     }
 
     private boolean openBlockedList(final Player player) {
         closeInventory(player);
-        runLater(player, () -> player.sendMessage("§a✓ Menu joueurs bloqués (en cours de développement)"));
+        runLater(player, () -> {
+            playSound(player, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.5f);
+            player.sendMessage("§a✓ §7Menu joueurs bloqués ouvert !");
+            player.sendMessage("§e⚠ §7En cours de développement - Configuration créée");
+            player.sendMessage("§7Fichier: §bblocked.yml §7disponible");
+        });
         return true;
     }
 
     private boolean openSettings(final Player player) {
         closeInventory(player);
-        runLater(player, () -> player.sendMessage("§a✓ Menu paramètres d'amitié (en cours de développement)"));
+        runLater(player, () -> {
+            playSound(player, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.5f);
+            player.sendMessage("§a✓ §7Menu paramètres ouvert !");
+            player.sendMessage("§e⚠ §7En cours de développement - Configuration créée");
+            player.sendMessage("§7Fichier: §bsettings.yml §7disponible");
+        });
         return true;
     }
 
     private boolean openFavorites(final Player player) {
         closeInventory(player);
-        runLater(player, () -> player.sendMessage("§a✓ Menu amis favoris (en cours de développement)"));
+        runLater(player, () -> {
+            playSound(player, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.5f);
+            player.sendMessage("§a✓ §7Menu amis favoris ouvert !");
+            player.sendMessage("§e⚠ §7En cours de développement - Configuration créée");
+            player.sendMessage("§7Fichier: §bfavorites.yml §7disponible");
+        });
         return true;
     }
 
     private boolean openStatistics(final Player player) {
         closeInventory(player);
-        runLater(player, () -> player.sendMessage("§a✓ Menu statistiques d'amitié (en cours de développement)"));
+        runLater(player, () -> {
+            playSound(player, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.5f);
+            player.sendMessage("§a✓ §7Menu statistiques ouvert !");
+            player.sendMessage("§e⚠ §7En cours de développement - Configuration créée");
+            player.sendMessage("§7Fichier: §bstatistics.yml §7disponible");
+        });
         return true;
     }
 
@@ -113,6 +152,13 @@ public class DefaultFriendsMenuActionHandler implements FriendsMenuActionHandler
                 runnable.run();
             }
         }, 1L);
+    }
+
+    private void playSound(final Player player, final Sound sound, final float pitch) {
+        if (player == null || sound == null) {
+            return;
+        }
+        player.playSound(player.getLocation(), sound, 1.0f, pitch);
     }
 }
 


### PR DESCRIPTION
## Summary
- add initial YAML configurations for all friends sub-menus under plugins/LobbyCore/friends
- provide temporary feedback and sounds when opening friends-related menus while implementation is pending

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7a7254c188329b89da058b28b3867