### PR TITLE
Add temporary friends menus

### DIFF
--- a/src/main/java/com/lobby/friends/menu/AddFriendMenu.java
+++ b/src/main/java/com/lobby/friends/menu/AddFriendMenu.java
@@ -1,0 +1,128 @@
+package com.lobby.friends.menu;
+
+import com.lobby.LobbyPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Temporary menu used while the real add-friend workflow is under
+ * construction. Provides informative placeholders and a back button that
+ * returns to the friends main menu.
+ */
+public class AddFriendMenu implements Listener {
+
+    private static final String TITLE = "§8» §aAjouter un Ami";
+    private static final int SIZE = 36;
+    private static final int BACK_BUTTON_SLOT = 31;
+    private static final int SEARCH_BUTTON_SLOT = 10;
+
+    private final LobbyPlugin plugin;
+    private final Map<Integer, ItemStack> layout = new HashMap<>();
+
+    public AddFriendMenu(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+        setupLayout();
+    }
+
+    private void setupLayout() {
+        final ItemStack greenGlass = createItem(Material.GREEN_STAINED_GLASS_PANE, " ");
+        final int[] greenSlots = {0, 1, 2, 6, 7, 8, 9, 17, 18, 26, 27, 28, 29, 33, 34, 35};
+        for (int slot : greenSlots) {
+            layout.put(slot, greenGlass.clone());
+        }
+
+        final ItemStack searchButton = createItem(Material.COMPASS, "§a§l🔍 Rechercher un Joueur", List.of(
+                "§7Recherchez un joueur par son nom",
+                "§7pour lui envoyer une demande d'ami",
+                "",
+                "§e⚠ Fonctionnalité en développement",
+                "§7Utilisez §b/msg <joueur>§7 en attendant",
+                "",
+                "§8» §aCliquez pour plus d'infos"
+        ));
+        layout.put(SEARCH_BUTTON_SLOT, searchButton);
+
+        final ItemStack suggestionsButton = createItem(Material.BOOK, "§e§l📝 Suggestions (Bientôt)");
+        layout.put(11, suggestionsButton);
+
+        final ItemStack nearbyButton = createItem(Material.COMPASS, "§b§l📍 Joueurs Proches (Bientôt)");
+        layout.put(12, nearbyButton);
+
+        final ItemStack backButton = createItem(Material.BARRIER, "§e🏠 Retour Menu Principal", List.of(
+                "§7Revenir au menu principal",
+                "",
+                "§8» §eCliquez pour retourner"
+        ));
+        layout.put(BACK_BUTTON_SLOT, backButton);
+    }
+
+    private ItemStack createItem(final Material material, final String name) {
+        return createItem(material, name, List.of());
+    }
+
+    private ItemStack createItem(final Material material, final String name, final List<String> lore) {
+        final ItemStack item = new ItemStack(material);
+        final ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            if (lore != null && !lore.isEmpty()) {
+                meta.setLore(lore);
+            }
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    public void open(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final Inventory menu = Bukkit.createInventory(null, SIZE, TITLE);
+        for (Map.Entry<Integer, ItemStack> entry : layout.entrySet()) {
+            menu.setItem(entry.getKey(), entry.getValue().clone());
+        }
+        player.openInventory(menu);
+        player.playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
+    }
+
+    @EventHandler
+    public void onInventoryClick(final InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (!TITLE.equals(event.getView().getTitle())) {
+            return;
+        }
+        event.setCancelled(true);
+        final int slot = event.getSlot();
+        if (slot == BACK_BUTTON_SLOT) {
+            player.closeInventory();
+            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                final FriendsMenuController controller = plugin.getFriendsMenuController();
+                if (controller != null) {
+                    controller.openMainMenu(player);
+                }
+            }, 1L);
+            return;
+        }
+        if (slot == SEARCH_BUTTON_SLOT) {
+            player.closeInventory();
+            player.sendMessage("§e🔍 Fonction de recherche en développement !");
+            player.sendMessage("§7Utilisez §b/msg <nom_joueur> §7pour contacter quelqu'un en attendant");
+        }
+    }
+}

--- a/src/main/java/com/lobby/friends/menu/DefaultFriendsMenuActionHandler.java
+++ b/src/main/java/com/lobby/friends/menu/DefaultFriendsMenuActionHandler.java
@@ -16,6 +16,8 @@ import java.util.Locale;
 public class DefaultFriendsMenuActionHandler implements FriendsMenuActionHandler {
 
     private final LobbyPlugin plugin;
+    private FriendsListMenu friendsListMenu;
+    private AddFriendMenu addFriendMenu;
 
     public DefaultFriendsMenuActionHandler(final LobbyPlugin plugin) {
         this.plugin = plugin;
@@ -43,11 +45,10 @@ public class DefaultFriendsMenuActionHandler implements FriendsMenuActionHandler
     private boolean openFriendsList(final Player player) {
         closeInventory(player);
         runLater(player, () -> {
-            playSound(player, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.5f);
-            player.sendMessage("§a✓ §7Menu liste des amis ouvert !");
-            player.sendMessage("§e⚠ §7En cours de développement - Configuration créée");
-            player.sendMessage("§7Fichier: §bfriends_list.yml §7disponible");
-            // TODO: Implémenter FriendsListMenu.java
+            if (friendsListMenu == null) {
+                friendsListMenu = new FriendsListMenu(plugin);
+            }
+            friendsListMenu.open(player);
         });
         return true;
     }
@@ -55,11 +56,10 @@ public class DefaultFriendsMenuActionHandler implements FriendsMenuActionHandler
     private boolean openAddFriend(final Player player) {
         closeInventory(player);
         runLater(player, () -> {
-            playSound(player, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.5f);
-            player.sendMessage("§a✓ §7Menu ajout d'ami ouvert !");
-            player.sendMessage("§e⚠ §7En cours de développement - Configuration créée");
-            player.sendMessage("§7Fichier: §badd_friend.yml §7disponible");
-            // TODO: Implémenter AddFriendMenu.java
+            if (addFriendMenu == null) {
+                addFriendMenu = new AddFriendMenu(plugin);
+            }
+            addFriendMenu.open(player);
         });
         return true;
     }

--- a/src/main/java/com/lobby/friends/menu/FriendsListMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsListMenu.java
@@ -1,0 +1,119 @@
+package com.lobby.friends.menu;
+
+import com.lobby.LobbyPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Temporary friends list menu displayed while the full implementation is
+ * under development. Provides visual feedback and a way to return to the main
+ * friends menu.
+ */
+public class FriendsListMenu implements Listener {
+
+    private static final String TITLE = "§8» §aListe des Amis (1/1)";
+    private static final int SIZE = 54;
+    private static final int BACK_BUTTON_SLOT = 49;
+
+    private final LobbyPlugin plugin;
+    private final Map<Integer, ItemStack> layout = new HashMap<>();
+
+    public FriendsListMenu(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+        setupLayout();
+    }
+
+    private void setupLayout() {
+        final ItemStack greenGlass = createItem(Material.GREEN_STAINED_GLASS_PANE, " ");
+        final int[] greenSlots = {0, 1, 2, 6, 7, 8, 9, 17, 45, 46, 52, 53};
+        for (int slot : greenSlots) {
+            layout.put(slot, greenGlass.clone());
+        }
+
+        final ItemStack noFriends = createItem(Material.PAPER, "§7§lAucun ami pour le moment", List.of(
+                "§7Vous n'avez pas encore d'amis",
+                "§7ajoutés à votre liste",
+                "",
+                "§e💡 Utilisez le menu d'ajout",
+                "§epour trouver des amis !"
+        ));
+        layout.put(22, noFriends);
+
+        final ItemStack backButton = createItem(Material.PLAYER_HEAD, "§e🏠 Retour Menu Principal", List.of(
+                "§7Revenir au menu principal",
+                "§7des amis",
+                "",
+                "§8» §eCliquez pour retourner"
+        ));
+        layout.put(BACK_BUTTON_SLOT, backButton);
+    }
+
+    private ItemStack createItem(final Material material, final String name) {
+        return createItem(material, name, List.of());
+    }
+
+    private ItemStack createItem(final Material material, final String name, final List<String> lore) {
+        final ItemStack item = new ItemStack(material);
+        final ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            if (lore != null && !lore.isEmpty()) {
+                meta.setLore(lore);
+            }
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    /**
+     * Opens the menu for the specified player.
+     *
+     * @param player the viewer
+     */
+    public void open(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final Inventory menu = Bukkit.createInventory(null, SIZE, TITLE);
+        for (Map.Entry<Integer, ItemStack> entry : layout.entrySet()) {
+            menu.setItem(entry.getKey(), entry.getValue().clone());
+        }
+        player.openInventory(menu);
+        player.playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
+    }
+
+    @EventHandler
+    public void onInventoryClick(final InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (!TITLE.equals(event.getView().getTitle())) {
+            return;
+        }
+        event.setCancelled(true);
+        final int slot = event.getSlot();
+        if (slot == BACK_BUTTON_SLOT) {
+            player.closeInventory();
+            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                final FriendsMenuController controller = plugin.getFriendsMenuController();
+                if (controller != null) {
+                    controller.openMainMenu(player);
+                }
+            }, 1L);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a temporary friends list menu with decorative layout, sounds, and return handling
- add a temporary add friend menu that highlights upcoming features and provides guidance
- update the default friends menu action handler to open the new temporary menus

## Testing
- mvn -q -DskipTests package *(fails: dependencies blocked by remote repository permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ae4a1df88329b37207e3ee542360