### PR TITLE
Add fallback social rank resolution

### DIFF
--- a/src/main/java/com/lobby/friends/menu/statistics/FriendStatisticsMenu.java
+++ b/src/main/java/com/lobby/friends/menu/statistics/FriendStatisticsMenu.java
@@ -447,6 +447,22 @@ public final class FriendStatisticsMenu implements Listener {
         return hours + "h " + remaining + "m";
     }
 
+    private String resolveSocialRank(final int points) {
+        if (points >= 5000) {
+            return "Maître Social";
+        }
+        if (points >= 3000) {
+            return "Expert";
+        }
+        if (points >= 2000) {
+            return "Avancé";
+        }
+        if (points >= 1000) {
+            return "Intermédiaire";
+        }
+        return "Débutant";
+    }
+
     private String apply(final String input, final Map<String, String> placeholders) {
         if (input == null) {
             return "";


### PR DESCRIPTION
## Summary
- add a deterministic social rank resolver for the friend statistics menu

## Testing
- `mvn -q -DskipTests package` *(fails: 403 Forbidden while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c7aff5608329a42b2115608fa2f6