### PR TITLE
Add friends menu test command and enhance main menu actions

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -17,6 +17,7 @@ import com.lobby.menus.MenuManager;
 import com.lobby.menus.prompt.ChatPromptManager;
 import com.lobby.menus.confirmation.ConfirmationManager;
 import com.lobby.friends.DefaultFriendsDataProvider;
+import com.lobby.friends.commands.FriendsTestCommand;
 import com.lobby.friends.manager.FriendsManager;
 import com.lobby.friends.menu.DefaultFriendsMenuActionHandler;
 import com.lobby.friends.menu.FriendsMenuController;
@@ -373,6 +374,8 @@ public final class LobbyPlugin extends JavaPlugin {
 
         final NPCCommands npcCommands = new NPCCommands(this);
         registerCommand("npc", npcCommands);
+
+        registerCommand("friendstest", new FriendsTestCommand(this, friendsManager));
     }
 
     private void registerCommand(final String name, final CommandExecutor executor) {

--- a/src/main/java/com/lobby/friends/commands/FriendsTestCommand.java
+++ b/src/main/java/com/lobby/friends/commands/FriendsTestCommand.java
@@ -1,0 +1,170 @@
+package com.lobby.friends.commands;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.friends.manager.FriendsManager;
+import com.lobby.friends.menu.AddFriendMenu;
+import com.lobby.friends.menu.BlockedPlayersMenu;
+import com.lobby.friends.menu.FavoriteFriendsMenu;
+import com.lobby.friends.menu.FriendRequestsMenu;
+import com.lobby.friends.menu.FriendSettingsMenu;
+import com.lobby.friends.menu.FriendsListMenu;
+import com.lobby.friends.menu.statistics.FriendStatisticsMenu;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Development-only helper command that opens the different friends menus
+ * without having to navigate through the profile menu first. The command is
+ * intended for QA and developers to quickly check that the menus load without
+ * throwing exceptions.
+ */
+public final class FriendsTestCommand implements CommandExecutor {
+
+    private final LobbyPlugin plugin;
+    private final FriendsManager friendsManager;
+
+    public FriendsTestCommand(final LobbyPlugin plugin, final FriendsManager friendsManager) {
+        this.plugin = plugin;
+        this.friendsManager = friendsManager;
+    }
+
+    @Override
+    public boolean onCommand(final CommandSender sender,
+                             final Command command,
+                             final String label,
+                             final String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("§cSeuls les joueurs peuvent utiliser cette commande !");
+            return true;
+        }
+
+        if (args.length == 0) {
+            sendUsage(player);
+            return true;
+        }
+
+        final String subCommand = args[0].toLowerCase();
+
+        try {
+            switch (subCommand) {
+                case "main" -> openMainMenu(player);
+                case "list" -> {
+                    new FriendsListMenu(plugin, friendsManager, player).open();
+                    player.sendMessage("§a✓ Liste des amis ouverte");
+                }
+                case "add" -> {
+                    new AddFriendMenu(plugin, friendsManager, player).open();
+                    player.sendMessage("§a✓ Menu d'ajout d'amis ouvert");
+                }
+                case "requests" -> {
+                    new FriendRequestsMenu(plugin, friendsManager, player).open();
+                    player.sendMessage("§a✓ Menu des demandes ouvert");
+                }
+                case "settings" -> {
+                    new FriendSettingsMenu(plugin, friendsManager, player).open();
+                    player.sendMessage("§a✓ Menu des paramètres ouvert");
+                }
+                case "stats" -> {
+                    new FriendStatisticsMenu(plugin, friendsManager, player).open();
+                    player.sendMessage("§a✓ Menu des statistiques ouvert");
+                }
+                case "blocked" -> {
+                    new BlockedPlayersMenu(plugin, friendsManager, player).open();
+                    player.sendMessage("§a✓ Menu des joueurs bloqués ouvert");
+                }
+                case "favorites" -> {
+                    new FavoriteFriendsMenu(plugin, friendsManager, player);
+                    player.sendMessage("§a✓ Menu des favoris ouvert");
+                }
+                case "all" -> testAllMenus(player);
+                default -> player.sendMessage("§cCommande inconnue. Utilisez /friendstest pour voir la liste");
+            }
+        } catch (Exception exception) {
+            player.sendMessage("§cErreur lors de l'ouverture du menu: " + exception.getMessage());
+            exception.printStackTrace();
+        }
+
+        return true;
+    }
+
+    private void sendUsage(final Player player) {
+        player.sendMessage("§e📋 Commandes de test disponibles:");
+        player.sendMessage("§7/friendstest main §8- Menu principal");
+        player.sendMessage("§7/friendstest list §8- Liste des amis");
+        player.sendMessage("§7/friendstest add §8- Ajouter un ami");
+        player.sendMessage("§7/friendstest requests §8- Demandes d'amitié");
+        player.sendMessage("§7/friendstest settings §8- Paramètres");
+        player.sendMessage("§7/friendstest stats §8- Statistiques");
+        player.sendMessage("§7/friendstest blocked §8- Joueurs bloqués");
+        player.sendMessage("§7/friendstest favorites §8- Amis favoris");
+        player.sendMessage("§7/friendstest all §8- Test de tous les menus");
+    }
+
+    private void openMainMenu(final Player player) {
+        if (plugin.getFriendsMenuController() == null) {
+            player.sendMessage("§cLe menu principal des amis n'est pas disponible.");
+            return;
+        }
+        final boolean opened = plugin.getFriendsMenuController().openMainMenu(player);
+        if (opened) {
+            player.sendMessage("§a✓ Menu principal ouvert");
+        } else {
+            player.sendMessage("§cImpossible d'ouvrir le menu principal des amis.");
+        }
+    }
+
+    private void testAllMenus(final Player player) {
+        player.sendMessage("§b🧪 Test de tous les menus en cours...");
+        testMenuSequentially(player, 0);
+    }
+
+    private void testMenuSequentially(final Player player, final int menuIndex) {
+        final String[] menuNames = {
+                "Menu Principal",
+                "Liste des Amis",
+                "Ajout d'Amis",
+                "Demandes",
+                "Paramètres",
+                "Statistiques",
+                "Joueurs Bloqués",
+                "Favoris"
+        };
+
+        if (menuIndex >= menuNames.length) {
+            player.sendMessage("§a✅ Test de tous les menus terminé avec succès !");
+            player.sendMessage("§7Tous les menus se sont ouverts sans erreur.");
+            return;
+        }
+
+        player.sendMessage("§e⏳ Test du menu: §6" + menuNames[menuIndex]);
+
+        try {
+            switch (menuIndex) {
+                case 0 -> openMainMenu(player);
+                case 1 -> new FriendsListMenu(plugin, friendsManager, player).open();
+                case 2 -> new AddFriendMenu(plugin, friendsManager, player).open();
+                case 3 -> new FriendRequestsMenu(plugin, friendsManager, player).open();
+                case 4 -> new FriendSettingsMenu(plugin, friendsManager, player).open();
+                case 5 -> new FriendStatisticsMenu(plugin, friendsManager, player).open();
+                case 6 -> new BlockedPlayersMenu(plugin, friendsManager, player).open();
+                case 7 -> new FavoriteFriendsMenu(plugin, friendsManager, player);
+                default -> {
+                    return;
+                }
+            }
+
+            player.sendMessage("§a✓ " + menuNames[menuIndex] + " - §2OK");
+
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                player.closeInventory();
+                testMenuSequentially(player, menuIndex + 1);
+            }, 20L);
+        } catch (Exception exception) {
+            player.sendMessage("§c✗ " + menuNames[menuIndex] + " - §4ERREUR: " + exception.getMessage());
+            Bukkit.getScheduler().runTaskLater(plugin, () -> testMenuSequentially(player, menuIndex + 1), 20L);
+        }
+    }
+}

--- a/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
@@ -8,6 +8,7 @@ import com.lobby.menus.AssetManager;
 import com.lobby.menus.CloseableMenu;
 import com.lobby.menus.Menu;
 import com.lobby.menus.MenuManager;
+import com.lobby.friends.menu.statistics.FriendStatisticsMenu;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
@@ -89,13 +90,18 @@ public final class FriendsMainMenu implements Menu, InventoryHolder, CloseableMe
             playSound(player, configuration.getErrorSound());
             return;
         }
-        if ("back_to_profile".equalsIgnoreCase(item.getAction())) {
+        final String action = item.getAction();
+        if ("back_to_profile".equalsIgnoreCase(action)) {
             playSound(player, configuration.getClickSound());
             player.closeInventory();
             Bukkit.getScheduler().runTaskLater(plugin, () -> openProfileMenu(player), 1L);
             return;
         }
-        final boolean handled = actionHandler != null && actionHandler.handle(player, item.getAction());
+        if (handleInternalAction(player, action)) {
+            playSound(player, configuration.getClickSound());
+            return;
+        }
+        final boolean handled = actionHandler != null && actionHandler.handle(player, action);
         playSound(player, handled ? configuration.getClickSound() : configuration.getErrorSound());
     }
 
@@ -277,6 +283,79 @@ public final class FriendsMainMenu implements Menu, InventoryHolder, CloseableMe
             return;
         }
         menuManager.openMenu(player, "profil_menu");
+    }
+
+    private boolean handleInternalAction(final Player player, final String action) {
+        if (action == null || action.isBlank()) {
+            return false;
+        }
+        return switch (action.toLowerCase(Locale.ROOT)) {
+            case "open_settings" -> {
+                openSettings(player);
+                yield true;
+            }
+            case "open_statistics" -> {
+                openStatistics(player);
+                yield true;
+            }
+            case "open_blocked" -> {
+                openBlocked(player);
+                yield true;
+            }
+            case "open_favorites" -> {
+                openFavorites(player);
+                yield true;
+            }
+            default -> false;
+        };
+    }
+
+    private void openSettings(final Player player) {
+        try {
+            player.closeInventory();
+            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () ->
+                    new FriendSettingsMenu(plugin, friendsManager, player).open(), 3L);
+        } catch (Exception exception) {
+            player.sendMessage("§cErreur lors de l'ouverture des paramètres");
+            exception.printStackTrace();
+        }
+    }
+
+    private void openStatistics(final Player player) {
+        try {
+            player.closeInventory();
+            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () ->
+                    new FriendStatisticsMenu(plugin, friendsManager, player).open(), 3L);
+        } catch (Exception exception) {
+            player.sendMessage("§cErreur lors de l'ouverture des statistiques");
+            exception.printStackTrace();
+        }
+    }
+
+    private void openBlocked(final Player player) {
+        try {
+            player.closeInventory();
+            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () ->
+                    new BlockedPlayersMenu(plugin, friendsManager, player).open(), 3L);
+        } catch (Exception exception) {
+            player.sendMessage("§cErreur lors de l'ouverture de la liste des bloqués");
+            exception.printStackTrace();
+        }
+    }
+
+    private void openFavorites(final Player player) {
+        try {
+            player.closeInventory();
+            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () ->
+                    new FavoriteFriendsMenu(plugin, friendsManager, player), 3L);
+        } catch (Exception exception) {
+            player.sendMessage("§cErreur lors de l'ouverture des favoris");
+            exception.printStackTrace();
+        }
     }
 
     private String colorize(final String input) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -44,6 +44,10 @@ commands:
   npc:
     description: Gestion des PNJ
     permission: lobby.admin.npc
+  friendstest:
+    description: Ouvre les menus d'amis pour les tests
+    permission: lobby.friends.test
+    usage: /friendstest <menu>
 permissions:
   lobby.use:
     default: true
@@ -68,4 +72,6 @@ permissions:
   lobby.admin.bypass:
     default: op
   lobby.admin.shop:
+    default: op
+  lobby.friends.test:
     default: op


### PR DESCRIPTION
## Summary
- add a `/friendstest` helper command to rapidly open the various friends menus
- register the command and declare its permission in the plugin descriptor
- enhance the friends main menu with direct handlers for settings, statistics, blocked, and favorites entries

## Testing
- `mvn -q -DskipTests compile` *(fails: dependency repository returns HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c86592188329a7639db3e5b7357c