### PR TITLE
Revamp friends menus

### DIFF
--- a/src/main/java/com/lobby/friends/commands/FriendsTestCommand.java
+++ b/src/main/java/com/lobby/friends/commands/FriendsTestCommand.java
@@ -52,7 +52,7 @@ public final class FriendsTestCommand implements CommandExecutor {
             switch (subCommand) {
                 case "main" -> openMainMenu(player);
                 case "list" -> {
-                    new FriendsListMenu(plugin, friendsManager, player).open();
+                    new FriendsListMenu(plugin, friendsManager, player);
                     player.sendMessage("§a✓ Liste des amis ouverte");
                 }
                 case "add" -> {
@@ -144,7 +144,7 @@ public final class FriendsTestCommand implements CommandExecutor {
         try {
             switch (menuIndex) {
                 case 0 -> openMainMenu(player);
-                case 1 -> new FriendsListMenu(plugin, friendsManager, player).open();
+                case 1 -> new FriendsListMenu(plugin, friendsManager, player);
                 case 2 -> new AddFriendMenu(plugin, friendsManager, player).open();
                 case 3 -> new FriendRequestsMenu(plugin, friendsManager, player).open();
                 case 4 -> new FriendSettingsMenu(plugin, friendsManager, player).open();

--- a/src/main/java/com/lobby/friends/menu/DefaultFriendsMenuActionHandler.java
+++ b/src/main/java/com/lobby/friends/menu/DefaultFriendsMenuActionHandler.java
@@ -45,7 +45,7 @@ public class DefaultFriendsMenuActionHandler implements FriendsMenuActionHandler
 
     private boolean openFriendsList(final Player player) {
         closeInventory(player);
-        runLater(player, () -> new FriendsListMenu(plugin, friendsManager, player).open());
+        runLater(player, () -> new FriendsListMenu(plugin, friendsManager, player));
         return true;
     }
 

--- a/src/main/java/com/lobby/friends/menu/FriendsListMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsListMenu.java
@@ -3,11 +3,9 @@ package com.lobby.friends.menu;
 import com.lobby.LobbyPlugin;
 import com.lobby.friends.data.FriendData;
 import com.lobby.friends.manager.FriendsManager;
-import com.lobby.friends.menu.options.FriendOptionsMenu;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
-import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
@@ -16,24 +14,27 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.UUID;
+import java.util.logging.Level;
 
 /**
- * Fully featured friends list menu backed by the friends manager/database.
+ * Paginated friends list menu with rich lore and quick actions inspired by the
+ * design specification provided by the product team.
  */
 public class FriendsListMenu implements Listener {
 
     private static final int INVENTORY_SIZE = 54;
     private static final int ITEMS_PER_PAGE = 28;
+    private static final String TITLE_FORMAT = "§8» §aListe des Amis (%d) - Page %d/%d";
+    private static final String TITLE_PREFIX = "§8» §aListe des Amis";
+
     private static final int[] FRIEND_SLOTS = {
             10, 11, 12, 13, 14, 15, 16,
             19, 20, 21, 22, 23, 24, 25,
@@ -44,11 +45,13 @@ public class FriendsListMenu implements Listener {
     private final LobbyPlugin plugin;
     private final FriendsManager friendsManager;
     private final Player player;
+
     private Inventory inventory;
-    private String inventoryTitle;
-    private List<FriendData> allFriends = Collections.emptyList();
+    private List<FriendData> allFriends = new ArrayList<>();
     private int currentPage = 1;
-    private final AtomicBoolean opened = new AtomicBoolean(false);
+    private boolean active = true;
+    private boolean switchingInventory;
+    private boolean firstRender = true;
 
     public FriendsListMenu(final LobbyPlugin plugin, final FriendsManager friendsManager, final Player player) {
         this.plugin = plugin;
@@ -60,36 +63,47 @@ public class FriendsListMenu implements Listener {
 
     private void loadFriendsAndCreateMenu() {
         friendsManager.getFriends(player).thenAccept(friends -> {
-            this.allFriends = friends != null ? friends : Collections.emptyList();
+            allFriends = friends != null ? new ArrayList<>(friends) : new ArrayList<>();
             Bukkit.getScheduler().runTask(plugin, () -> {
-                createInventory();
-                setupMenu();
-                if (opened.compareAndSet(false, true)) {
-                    open();
-                } else {
-                    player.updateInventory();
+                if (!active || !player.isOnline()) {
+                    return;
                 }
+                renderMenu();
             });
         }).exceptionally(throwable -> {
-            plugin.getLogger().severe("Erreur lors du chargement des amis : " + throwable.getMessage());
-            this.allFriends = Collections.emptyList();
+            plugin.getLogger().log(Level.SEVERE, "Erreur chargement amis: " + throwable.getMessage(), throwable);
+            allFriends = new ArrayList<>();
             Bukkit.getScheduler().runTask(plugin, () -> {
-                createInventory();
-                setupMenu();
-                if (opened.compareAndSet(false, true)) {
-                    open();
-                } else {
-                    player.updateInventory();
+                if (!active || !player.isOnline()) {
+                    return;
                 }
+                renderMenu();
             });
             return null;
         });
     }
 
-    private void createInventory() {
+    private void renderMenu() {
         final int totalPages = Math.max(1, (int) Math.ceil((double) allFriends.size() / ITEMS_PER_PAGE));
-        inventoryTitle = "§8» §aListe des Amis (" + currentPage + "/" + totalPages + ")";
-        inventory = Bukkit.createInventory(null, INVENTORY_SIZE, inventoryTitle);
+        if (currentPage > totalPages) {
+            currentPage = totalPages;
+        }
+        if (currentPage < 1) {
+            currentPage = 1;
+        }
+        final String title = String.format(TITLE_FORMAT, allFriends.size(), currentPage, totalPages);
+        inventory = Bukkit.createInventory(null, INVENTORY_SIZE, title);
+        setupMenu();
+        if (!player.isOnline()) {
+            return;
+        }
+        switchingInventory = true;
+        player.openInventory(inventory);
+        Bukkit.getScheduler().runTask(plugin, () -> switchingInventory = false);
+        if (firstRender) {
+            player.playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
+            firstRender = false;
+        }
     }
 
     private void setupMenu() {
@@ -99,31 +113,29 @@ public class FriendsListMenu implements Listener {
         inventory.clear();
 
         final ItemStack greenGlass = createItem(Material.GREEN_STAINED_GLASS_PANE, " ");
-        final int[] greenSlots = {0, 1, 2, 6, 7, 8, 9, 17, 45, 46, 52, 53};
+        final int[] greenSlots = {0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 53};
         for (int slot : greenSlots) {
             inventory.setItem(slot, greenGlass);
         }
 
         displayFriends();
         setupNavigation();
-        setupOptions();
     }
 
     private void displayFriends() {
         if (allFriends.isEmpty()) {
-            final ItemStack noFriends = createItem(Material.PAPER, "§7§lAucun ami pour le moment");
+            final ItemStack noFriends = createItem(Material.PAPER, "§7§lAucun ami trouvé");
             final ItemMeta meta = noFriends.getItemMeta();
             if (meta != null) {
                 meta.setLore(Arrays.asList(
                         "§7Vous n'avez pas encore d'amis",
-                        "§7ajoutés à votre liste",
                         "",
-                        "§e💡 Conseil:",
-                        "§7Utilisez le menu §e'Ajouter un ami'",
-                        "§7pour trouver et ajouter des amis !",
+                        "§e💡 Comment ajouter des amis ?",
+                        "§8▸ §7Utilisez le menu 'Ajouter un Ami'",
+                        "§8▸ §7Recherchez des joueurs",
+                        "§8▸ §7Consultez les suggestions",
                         "",
-                        "§8▸ §eCommande: §6/friends add <nom>",
-                        "§8▸ §eMenu: §6Retour → Ajouter un ami"
+                        "§8» §aCommencez à vous faire des amis !"
                 ));
                 noFriends.setItemMeta(meta);
             }
@@ -133,7 +145,8 @@ public class FriendsListMenu implements Listener {
 
         final int startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
         final int endIndex = Math.min(startIndex + ITEMS_PER_PAGE, allFriends.size());
-        for (int i = 0; i < FRIEND_SLOTS.length && startIndex + i < endIndex; i++) {
+
+        for (int i = 0; i < FRIEND_SLOTS.length && (startIndex + i) < endIndex; i++) {
             final FriendData friend = allFriends.get(startIndex + i);
             inventory.setItem(FRIEND_SLOTS[i], createFriendItem(friend));
         }
@@ -142,39 +155,32 @@ public class FriendsListMenu implements Listener {
     private ItemStack createFriendItem(final FriendData friend) {
         final ItemStack head = new ItemStack(Material.PLAYER_HEAD);
         final ItemMeta itemMeta = head.getItemMeta();
-        if (itemMeta instanceof SkullMeta skullMeta) {
-            try {
-                skullMeta.setOwningPlayer(Bukkit.getOfflinePlayer(java.util.UUID.fromString(friend.getUuid())));
-            } catch (IllegalArgumentException ignored) {
-                // keep default skin if uuid invalid
-            }
-            skullMeta.setDisplayName(buildFriendDisplayName(friend));
-            skullMeta.setLore(buildFriendLore(friend));
-            if (friend.isFavorite()) {
-                skullMeta.addEnchant(Enchantment.UNBREAKING, 1, true);
-                skullMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-            }
-            head.setItemMeta(skullMeta);
+        if (!(itemMeta instanceof SkullMeta meta)) {
+            return head;
         }
-        return head;
-    }
 
-    private String buildFriendDisplayName(final FriendData friend) {
+        try {
+            meta.setOwningPlayer(Bukkit.getOfflinePlayer(UUID.fromString(friend.getUuid())));
+        } catch (IllegalArgumentException ignored) {
+            // keep default skin when UUID is invalid
+        }
+
+        final boolean online = friend.isOnline();
+        final boolean favorite = friend.isFavorite();
         final String baseName = friend.getPlayerName();
-        final String indicator = friend.getStatusIndicator();
-        if (friend.isOnline()) {
-            return friend.isFavorite() ? "§e⭐ §a§l" + baseName + " " + indicator : "§a§l" + baseName + " " + indicator;
-        }
-        return friend.isFavorite() ? "§e⭐ §7§l" + baseName + " " + indicator : "§7§l" + baseName + " " + indicator;
-    }
+        final String statusDot = online ? " §2●" : " §8●";
+        final String name = switch ((favorite ? 2 : 0) + (online ? 1 : 0)) {
+            case 3 -> "§e⭐ §a§l" + baseName + statusDot;
+            case 1 -> "§a§l" + baseName + statusDot;
+            case 2 -> "§e⭐ §7§l" + baseName + statusDot;
+            default -> "§7§l" + baseName + statusDot;
+        };
+        meta.setDisplayName(name);
 
-    private List<String> buildFriendLore(final FriendData friend) {
         final List<String> lore = new ArrayList<>();
-        if (friend.isFavorite()) {
-            lore.add("§6✨ AMI FAVORI ✨");
-            lore.add("");
-        }
-        if (friend.isOnline()) {
+        lore.add(favorite ? "§6✨ AMI FAVORI" : "§7Ami");
+        lore.add("");
+        if (online) {
             lore.add("§7Statut: §aEn ligne");
             lore.add("§7Serveur: §eLobby");
         } else {
@@ -182,172 +188,105 @@ public class FriendsListMenu implements Listener {
             lore.add("§7Dernière connexion: §e" + friend.getRelativeLastInteraction());
         }
         lore.add("§7Ami depuis: §b" + friend.getFormattedFriendshipDate());
+        lore.add("§7Messages échangés: §d" + friend.getMessagesExchanged());
         lore.add("");
-        lore.add("§3📊 Statistiques d'amitié:");
-        lore.add("§8▸ §7Messages échangés: §b" + friend.getMessagesExchanged());
-        lore.add("§8▸ §7Temps joué ensemble: §b" + friend.getFormattedTimeTogether());
-        lore.add("§8▸ §7Dernière interaction: §b" + friend.getRelativeLastInteraction());
-        if (friend.isFavorite()) {
-            lore.add("§8▸ §6Statut: §eAmi favori ⭐");
-        }
-        lore.add("");
-        if (friend.isOnline()) {
-            lore.add("§8▸ §aClique gauche §8: §7Se téléporter");
-            lore.add("§8▸ §eClique milieu §8: §7Envoyer un message");
+        if (online) {
+            lore.add("§8▸ §aClique gauche §8: §7Téléportation");
+            lore.add("§8▸ §eClique milieu §8: §7Message privé");
         } else {
             lore.add("§8▸ §eClique milieu §8: §7Message hors-ligne");
         }
-        lore.add("§8▸ §cClique droit §8: §7Plus d'options");
-        lore.add(friend.isFavorite()
-                ? "§8▸ §7Shift+Clic §8: §7Retirer des favoris"
-                : "§8▸ §7Shift+Clic §8: §6Ajouter aux favoris");
-        return lore;
+        lore.add("§8▸ §cClique droit §8: §7Menu d'options");
+        lore.add("§8▸ §6Shift-Clic §8: §7Toggle favori");
+
+        meta.setLore(lore);
+        head.setItemMeta(meta);
+        return head;
     }
 
     private void setupNavigation() {
         final int totalPages = Math.max(1, (int) Math.ceil((double) allFriends.size() / ITEMS_PER_PAGE));
+
         if (currentPage > 1) {
-            final ItemStack previous = createItem(Material.ARROW, "§c◀ Page Précédente", Arrays.asList(
-                    "§7Aller à la page " + (currentPage - 1),
-                    "",
-                    "§8» §cCliquez pour revenir"
-            ));
+            final ItemStack previous = createItem(Material.ARROW, "§c◀ Page Précédente");
             inventory.setItem(47, previous);
         }
 
-        final int onlineCount = (int) allFriends.stream().filter(FriendData::isOnline).count();
-        final int favoriteCount = (int) allFriends.stream().filter(FriendData::isFavorite).count();
-        final ItemStack back = createItem(Material.PLAYER_HEAD, "§e🏠 Retour Menu Principal", Arrays.asList(
-                "§7Revenir au menu principal",
-                "§7des amis",
-                "",
-                "§e▸ Total d'amis: §6" + allFriends.size(),
-                "§e▸ En ligne: §6" + onlineCount,
-                "§e▸ Favoris: §6" + favoriteCount,
-                "",
-                "§8» §eCliquez pour retourner"
-        ));
+        final ItemStack back = createItem(Material.BARRIER, "§e🏠 Retour Menu Principal");
+        final ItemMeta backMeta = back.getItemMeta();
+        if (backMeta != null) {
+            backMeta.setLore(Arrays.asList(
+                    "§7Revenir au menu principal des amis",
+                    "",
+                    "§8» §eCliquez pour retourner"
+            ));
+            back.setItemMeta(backMeta);
+        }
         inventory.setItem(49, back);
 
+        final ItemStack refresh = createItem(Material.CLOCK, "§b🔄 Actualiser");
+        inventory.setItem(50, refresh);
+
         if (currentPage < totalPages) {
-            final ItemStack next = createItem(Material.ARROW, "§a▶ Page Suivante", Arrays.asList(
-                    "§7Aller à la page " + (currentPage + 1),
-                    "",
-                    "§8» §aCliquez pour continuer"
-            ));
+            final ItemStack next = createItem(Material.ARROW, "§a▶ Page Suivante");
             inventory.setItem(51, next);
         }
     }
 
-    private void setupOptions() {
-        final ItemStack sort = createItem(Material.HOPPER, "§6📋 Tri: En ligne d'abord", Arrays.asList(
-                "§7Trier la liste des amis",
-                "",
-                "§6▸ Tri actuel: §eEn ligne d'abord",
-                "§7▸ Total d'amis: §8" + allFriends.size(),
-                "",
-                "§7Options de tri:",
-                "§8▸ §aEn ligne d'abord",
-                "§8▸ §7Alphabétique (A-Z)",
-                "§8▸ §bDate d'amitié",
-                "§8▸ §6Favoris d'abord",
-                "",
-                "§8» §6Cliquez pour changer"
-        ));
-        inventory.setItem(48, sort);
-
-        final ItemStack refresh = createItem(Material.CLOCK, "§b🔄 Actualiser", Arrays.asList(
-                "§7Actualiser la liste des amis",
-                "§7et les statuts en ligne",
-                "",
-                "§b▸ Dernière MAJ: §3À l'instant",
-                "",
-                "§8» §bCliquez pour actualiser"
-        ));
-        inventory.setItem(50, refresh);
-    }
-
     private ItemStack createItem(final Material material, final String name) {
-        return createItem(material, name, new ArrayList<>());
-    }
-
-    private ItemStack createItem(final Material material, final String name, final List<String> lore) {
         final ItemStack item = new ItemStack(material);
         final ItemMeta meta = item.getItemMeta();
         if (meta != null) {
             meta.setDisplayName(name);
-            if (lore != null && !lore.isEmpty()) {
-                meta.setLore(lore);
-            }
             item.setItemMeta(meta);
         }
         return item;
     }
 
-    public void open() {
-        if (inventory == null) {
-            Bukkit.getScheduler().runTaskLater(plugin, this::open, 2L);
-            return;
-        }
-        player.openInventory(inventory);
-        player.playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
-    }
-
     @EventHandler
     public void onInventoryClick(final InventoryClickEvent event) {
-        final String title = event.getView().getTitle();
-        if (title == null || !title.contains("§8» §aListe des Amis")) {
-            return;
-        }
         if (!(event.getWhoClicked() instanceof Player clicker)) {
             return;
         }
         if (!clicker.getUniqueId().equals(player.getUniqueId())) {
             return;
         }
-        if (inventory == null || inventoryTitle == null || !title.equals(inventoryTitle)) {
+        final String title = event.getView().getTitle();
+        if (!title.startsWith(TITLE_PREFIX)) {
             return;
         }
 
         event.setCancelled(true);
 
         final int slot = event.getSlot();
-        clicker.sendMessage("§7[DEBUG] Clic sur slot: " + slot + " | Type: " + event.getClick());
-
         if (slot == 47 && currentPage > 1) {
             currentPage--;
-            setupMenu();
+            renderMenu();
             player.playSound(player.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1.0f, 1.0f);
             return;
         }
         if (slot == 49) {
             player.closeInventory();
-            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
+            player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
                 final FriendsMenuController controller = plugin.getFriendsMenuController();
                 if (controller != null) {
                     controller.openMainMenu(player);
                 }
-            }, 2L);
-            return;
-        }
-
-        final int totalPages = Math.max(1, (int) Math.ceil((double) allFriends.size() / ITEMS_PER_PAGE));
-        if (slot == 51 && currentPage < totalPages) {
-            currentPage++;
-            setupMenu();
-            player.playSound(player.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1.0f, 1.0f);
-            return;
-        }
-        if (slot == 48) {
-            player.sendMessage("§6🔄 Tri des amis en cours de développement !");
-            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
+            }, 3L);
             return;
         }
         if (slot == 50) {
-            player.sendMessage("§b🔄 Actualisation de la liste des amis...");
+            player.sendMessage("§b🔄 Actualisation de la liste...");
             player.playSound(player.getLocation(), Sound.BLOCK_ENCHANTMENT_TABLE_USE, 1.0f, 1.0f);
             loadFriendsAndCreateMenu();
+            return;
+        }
+        final int totalPages = Math.max(1, (int) Math.ceil((double) allFriends.size() / ITEMS_PER_PAGE));
+        if (slot == 51 && currentPage < totalPages) {
+            currentPage++;
+            renderMenu();
+            player.playSound(player.getLocation(), Sound.ITEM_BOOK_PAGE_TURN, 1.0f, 1.0f);
             return;
         }
 
@@ -359,8 +298,8 @@ public class FriendsListMenu implements Listener {
             if (friendIndex >= allFriends.size()) {
                 return;
             }
-            handleFriendInteraction(allFriends.get(friendIndex), event.getClick());
-            break;
+            handleFriendClick(allFriends.get(friendIndex), event.getClick());
+            return;
         }
     }
 
@@ -372,53 +311,76 @@ public class FriendsListMenu implements Listener {
         if (!viewer.getUniqueId().equals(player.getUniqueId())) {
             return;
         }
-        if (inventory != null && inventoryTitle != null && event.getView().getTitle().equals(inventoryTitle)) {
-            HandlerList.unregisterAll(this);
+        if (!event.getView().getTitle().startsWith(TITLE_PREFIX)) {
+            return;
         }
+        if (switchingInventory) {
+            return;
+        }
+        active = false;
+        HandlerList.unregisterAll(this);
     }
 
-    private void handleFriendInteraction(final FriendData friend, final ClickType clickType) {
+    private void handleFriendClick(final FriendData friend, final ClickType clickType) {
+        if (friend == null) {
+            return;
+        }
         switch (clickType) {
             case LEFT -> handleTeleport(friend);
             case MIDDLE -> handleMessage(friend);
-            case RIGHT -> openFriendOptions(friend);
-            case SHIFT_LEFT, SHIFT_RIGHT -> toggleFavorite(friend);
+            case RIGHT -> handleOptions(friend);
+            case SHIFT_LEFT -> toggleFavorite(friend);
             default -> {
             }
         }
     }
 
     private void handleTeleport(final FriendData friend) {
-        final Player target = friend.getPlayer();
-        if (target == null || !target.isOnline()) {
+        final Player targetPlayer = friend.getPlayer();
+        if (targetPlayer == null || !targetPlayer.isOnline()) {
             player.sendMessage("§c" + friend.getPlayerName() + " n'est pas en ligne !");
             player.playSound(player.getLocation(), Sound.BLOCK_ANVIL_LAND, 1.0f, 1.0f);
             return;
         }
         player.closeInventory();
-        player.teleport(target.getLocation());
-        player.sendMessage("§aVous avez été téléporté chez " + friend.getPlayerName() + " !");
-        player.playSound(player.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 1.0f, 1.0f);
+        player.teleport(targetPlayer.getLocation());
+        player.sendMessage("§a🚀 Téléportation vers " + friend.getPlayerName() + " !");
+        player.playSound(player.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 1.0f, 1.5f);
     }
 
     private void handleMessage(final FriendData friend) {
         player.closeInventory();
-        player.sendMessage("§e💬 Tapez votre message pour " + friend.getPlayerName() + " dans le chat :");
-        player.sendMessage("§7(ou tapez 'cancel' pour annuler)");
-        // future integration with ChatPromptManager
+        player.sendMessage("§e💬 Message à " + friend.getPlayerName() + ":");
+        player.sendMessage("§7Tapez votre message dans le chat:");
+        player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1.0f, 1.5f);
     }
 
-    private void openFriendOptions(final FriendData friend) {
-        player.closeInventory();
-        Bukkit.getScheduler().runTaskLater(plugin, () -> new FriendOptionsMenu(plugin, friendsManager, player, friend).open(), 1L);
+    private void handleOptions(final FriendData friend) {
+        player.sendMessage("§6⚙️ Options pour " + friend.getPlayerName() + ":");
+        player.sendMessage("§7- Voir le profil détaillé");
+        player.sendMessage("§7- Supprimer de la liste d'amis");
+        player.sendMessage("§7- Bloquer ce joueur");
+        player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
     }
 
     private void toggleFavorite(final FriendData friend) {
-        friendsManager.toggleFavorite(player, friend.getPlayerName()).thenAccept(success -> {
-            if (!success) {
+        friendsManager.toggleFavorite(player, friend.getPlayerName()).whenComplete((ignored, throwable) -> {
+            if (throwable != null) {
+                plugin.getLogger().log(Level.SEVERE, "Erreur toggle favori", throwable);
+                player.sendMessage("§cImpossible de modifier le statut favori maintenant.");
                 return;
             }
-            Bukkit.getScheduler().runTask(plugin, this::loadFriendsAndCreateMenu);
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                final boolean newStatus = !friend.isFavorite();
+                friend.setFavorite(newStatus);
+                if (newStatus) {
+                    player.sendMessage("§e⭐ " + friend.getPlayerName() + " ajouté aux favoris !");
+                } else {
+                    player.sendMessage("§7💔 " + friend.getPlayerName() + " retiré des favoris");
+                }
+                renderMenu();
+                player.playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
+            });
         });
     }
 }

--- a/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
@@ -1,368 +1,360 @@
 package com.lobby.friends.menu;
 
 import com.lobby.LobbyPlugin;
-import com.lobby.friends.FriendsDataProvider;
-import com.lobby.friends.FriendsPlaceholderData;
 import com.lobby.friends.manager.FriendsManager;
-import com.lobby.menus.AssetManager;
-import com.lobby.menus.CloseableMenu;
-import com.lobby.menus.Menu;
-import com.lobby.menus.MenuManager;
 import com.lobby.friends.menu.statistics.FriendStatisticsMenu;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
-import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.InventoryHolder;
-import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.scheduler.BukkitTask;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
-public final class FriendsMainMenu implements Menu, InventoryHolder, CloseableMenu {
+/**
+ * Modernised friends main menu that focuses on providing immediate feedback
+ * to the player while asynchronous data is being fetched.
+ */
+public class FriendsMainMenu implements Listener {
 
-    private static final LegacyComponentSerializer SERIALIZER = LegacyComponentSerializer.legacySection();
+    private static final String MENU_TITLE = "§8» §aMenu des Amis";
+    private static final int INVENTORY_SIZE = 54;
 
     private final LobbyPlugin plugin;
-    private final AssetManager assetManager;
-    private final FriendsMenuConfiguration configuration;
-    private final FriendsDataProvider dataProvider;
     private final FriendsManager friendsManager;
-    private final FriendsMenuActionHandler actionHandler;
-    private final Map<Integer, FriendsMenuItem> itemBySlot = new HashMap<>();
 
     private Inventory inventory;
     private Player viewer;
-    private BukkitTask updateTask;
+    private int totalFriends;
+    private int onlineFriends;
+    private int pendingRequests;
 
-    public FriendsMainMenu(final LobbyPlugin plugin,
-                           final AssetManager assetManager,
-                           final FriendsMenuConfiguration configuration,
-                           final FriendsDataProvider dataProvider,
-                           final FriendsManager friendsManager,
-                           final FriendsMenuActionHandler actionHandler) {
+    public FriendsMainMenu(final LobbyPlugin plugin, final FriendsManager friendsManager) {
         this.plugin = plugin;
-        this.assetManager = assetManager;
-        this.configuration = configuration;
-        this.dataProvider = dataProvider;
         this.friendsManager = friendsManager;
-        this.actionHandler = actionHandler;
-        for (FriendsMenuItem item : configuration.getItems()) {
-            itemBySlot.put(item.getSlot(), item);
-        }
+        Bukkit.getPluginManager().registerEvents(this, plugin);
     }
 
-    @Override
     public void open(final Player player) {
         if (player == null) {
             return;
         }
         this.viewer = player;
-        final Component title = SERIALIZER.deserialize(colorize(configuration.getTitle()));
-        this.inventory = Bukkit.createInventory(this, configuration.getSize(), title);
-        buildStaticLayout();
-        refreshDynamicContent();
-        scheduleUpdates();
-        playSound(player, configuration.getOpenSound(), 1.5f);
+        this.inventory = Bukkit.createInventory(null, INVENTORY_SIZE, MENU_TITLE);
         player.openInventory(inventory);
+        player.playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
+        loadDataAndCreateMenu(player);
     }
 
-    @Override
-    public void handleClick(final InventoryClickEvent event) {
-        if (!(event.getWhoClicked() instanceof Player player)) {
-            return;
-        }
-        event.setCancelled(true);
-        final FriendsMenuItem item = itemBySlot.get(event.getSlot());
-        if (item == null || item.getAction() == null || item.getAction().isBlank()) {
-            playSound(player, configuration.getErrorSound());
-            return;
-        }
-        final String action = item.getAction();
-        if ("back_to_profile".equalsIgnoreCase(action)) {
-            playSound(player, configuration.getClickSound());
-            player.closeInventory();
-            Bukkit.getScheduler().runTaskLater(plugin, () -> openProfileMenu(player), 1L);
-            return;
-        }
-        if (handleInternalAction(player, action)) {
-            playSound(player, configuration.getClickSound());
-            return;
-        }
-        final boolean handled = actionHandler != null && actionHandler.handle(player, action);
-        playSound(player, handled ? configuration.getClickSound() : configuration.getErrorSound());
+    private void loadDataAndCreateMenu(final Player player) {
+        totalFriends = 0;
+        onlineFriends = 0;
+        pendingRequests = 0;
+
+        final CompletableFuture<?> friendsFuture = friendsManager.getFriends(player)
+                .thenAccept(friends -> {
+                    final int size = friends != null ? friends.size() : 0;
+                    totalFriends = size;
+                    if (friends != null && !friends.isEmpty()) {
+                        onlineFriends = (int) friends.stream().filter(friend -> friend != null && friend.isOnline()).count();
+                    }
+                });
+        final CompletableFuture<?> requestsFuture = friendsManager.getPendingRequests(player)
+                .thenAccept(requests -> pendingRequests = requests != null ? requests.size() : 0);
+
+        CompletableFuture.allOf(friendsFuture, requestsFuture)
+                .whenComplete((ignored, throwable) -> Bukkit.getScheduler().runTask(plugin, () -> {
+                    if (throwable != null) {
+                        plugin.getLogger().log(Level.SEVERE, "Erreur lors du chargement des données du menu des amis", throwable);
+                    }
+                    if (viewer == null || !viewer.isOnline()) {
+                        return;
+                    }
+                    setupMenu();
+                    viewer.updateInventory();
+                }));
     }
 
-    @Override
-    public Inventory getInventory() {
-        return inventory;
-    }
-
-    @Override
-    public void handleClose(final Player player) {
-        if (updateTask != null) {
-            updateTask.cancel();
-            updateTask = null;
-        }
-    }
-
-    private void scheduleUpdates() {
-        if (configuration.getUpdateIntervalSeconds() <= 0) {
-            return;
-        }
-        updateTask = Bukkit.getScheduler().runTaskTimer(plugin, this::refreshDynamicContent,
-                configuration.getUpdateIntervalTicks(), configuration.getUpdateIntervalTicks());
-    }
-
-    private void buildStaticLayout() {
+    private void setupMenu() {
         if (inventory == null) {
             return;
         }
-        for (FriendsMenuDecoration decoration : configuration.getDecorations()) {
-            final ItemStack pane = new ItemStack(decoration.material());
-            final ItemMeta meta = pane.getItemMeta();
-            if (meta != null) {
-                meta.setDisplayName(decoration.displayName());
-                pane.setItemMeta(meta);
-            }
-            for (Integer slot : decoration.slots()) {
-                if (slot == null || slot < 0 || slot >= configuration.getSize()) {
-                    continue;
-                }
-                inventory.setItem(slot, pane);
-            }
+        inventory.clear();
+
+        final ItemStack greenGlass = createItem(Material.GREEN_STAINED_GLASS_PANE, " ");
+        final int[] glassSlots = {0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 53};
+        for (int slot : glassSlots) {
+            inventory.setItem(slot, greenGlass);
         }
+
+        setupMainItems();
     }
 
-    private void refreshDynamicContent() {
-        if (inventory == null || viewer == null) {
+    private void setupMainItems() {
+        if (inventory == null) {
             return;
         }
-        final FriendsPlaceholderData data = dataProvider == null
-                ? FriendsPlaceholderData.empty()
-                : Objects.requireNonNullElse(dataProvider.resolve(viewer), FriendsPlaceholderData.empty());
-        final Map<String, String> placeholders = data.toPlaceholderMap();
 
-        for (FriendsMenuItem definition : configuration.getItems()) {
-            final ItemStack itemStack = createItem(definition, placeholders);
-            if (itemStack == null) {
-                continue;
-            }
-            inventory.setItem(definition.getSlot(), itemStack);
+        final ItemStack friendsList = createItem(Material.PLAYER_HEAD, "§a§l👥 Liste des Amis");
+        final ItemMeta friendsMeta = friendsList.getItemMeta();
+        if (friendsMeta != null) {
+            friendsMeta.setLore(Arrays.asList(
+                    "§7Consultez et gérez votre liste d'amis",
+                    "",
+                    "§a▸ Total d'amis: §2" + totalFriends,
+                    "§a▸ En ligne: §2" + onlineFriends,
+                    "§a▸ Hors ligne: §8" + Math.max(0, totalFriends - onlineFriends),
+                    "",
+                    "§8» §aCliquez pour ouvrir"
+            ));
+            friendsList.setItemMeta(friendsMeta);
         }
-        viewer.updateInventory();
+        inventory.setItem(11, friendsList);
+
+        final ItemStack addFriend = createItem(Material.EMERALD, "§e§l➕ Ajouter un Ami");
+        final ItemMeta addMeta = addFriend.getItemMeta();
+        if (addMeta != null) {
+            addMeta.setLore(Arrays.asList(
+                    "§7Ajoutez de nouveaux amis",
+                    "",
+                    "§e▸ Recherche par nom",
+                    "§e▸ Suggestions intelligentes",
+                    "§e▸ Joueurs à proximité",
+                    "",
+                    "§8» §eCliquez pour explorer"
+            ));
+            addFriend.setItemMeta(addMeta);
+        }
+        inventory.setItem(13, addFriend);
+
+        final ItemStack requests = createItem(Material.WRITABLE_BOOK, "§6§l📨 Demandes d'Amitié");
+        final ItemMeta requestsMeta = requests.getItemMeta();
+        if (requestsMeta != null) {
+            requestsMeta.setLore(Arrays.asList(
+                    "§7Gérez vos demandes d'amitié",
+                    "",
+                    "§6▸ Demandes reçues: §c" + pendingRequests,
+                    pendingRequests > 0 ? "§c⚠ Demandes en attente !" : "§7Aucune demande",
+                    "",
+                    "§8» §6Cliquez pour gérer"
+            ));
+            requests.setItemMeta(requestsMeta);
+        }
+        inventory.setItem(15, requests);
+
+        final ItemStack favorites = createItem(Material.NETHER_STAR, "§e⭐ Amis Favoris");
+        final ItemMeta favMeta = favorites.getItemMeta();
+        if (favMeta != null) {
+            favMeta.setLore(Arrays.asList(
+                    "§7Accès rapide à vos amis favoris",
+                    "",
+                    "§e▸ Téléportation prioritaire",
+                    "§e▸ Notifications spéciales",
+                    "",
+                    "§8» §eCliquez pour voir"
+            ));
+            favorites.setItemMeta(favMeta);
+        }
+        inventory.setItem(20, favorites);
+
+        final ItemStack settings = createItem(Material.REDSTONE_TORCH, "§6⚙️ Paramètres");
+        final ItemMeta settingsMeta = settings.getItemMeta();
+        if (settingsMeta != null) {
+            settingsMeta.setLore(Arrays.asList(
+                    "§7Configurez vos préférences",
+                    "",
+                    "§6▸ Notifications",
+                    "§6▸ Confidentialité",
+                    "§6▸ Permissions",
+                    "",
+                    "§8» §6Cliquez pour configurer"
+            ));
+            settings.setItemMeta(settingsMeta);
+        }
+        inventory.setItem(22, settings);
+
+        final ItemStack stats = createItem(Material.BOOK, "§b📊 Statistiques");
+        final ItemMeta statsMeta = stats.getItemMeta();
+        if (statsMeta != null) {
+            statsMeta.setLore(Arrays.asList(
+                    "§7Consultez vos statistiques détaillées",
+                    "",
+                    "§b▸ Analyses temporelles",
+                    "§b▸ Activité des amis",
+                    "§b▸ Comparaisons serveur",
+                    "",
+                    "§8» §bCliquez pour analyser"
+            ));
+            stats.setItemMeta(statsMeta);
+        }
+        inventory.setItem(24, stats);
+
+        final ItemStack blocked = createItem(Material.BARRIER, "§c🚫 Joueurs Bloqués");
+        final ItemMeta blockedMeta = blocked.getItemMeta();
+        if (blockedMeta != null) {
+            blockedMeta.setLore(Arrays.asList(
+                    "§7Gérez votre liste de blocage",
+                    "",
+                    "§c▸ Joueurs bloqués: §40",
+                    "",
+                    "§8» §cCliquez pour gérer"
+            ));
+            blocked.setItemMeta(blockedMeta);
+        }
+        inventory.setItem(29, blocked);
+
+        final ItemStack close = createItem(Material.BARRIER, "§c✗ Fermer");
+        final ItemMeta closeMeta = close.getItemMeta();
+        if (closeMeta != null) {
+            closeMeta.setLore(Arrays.asList(
+                    "§7Fermer le menu des amis",
+                    "",
+                    "§8» §cCliquez pour fermer"
+            ));
+            close.setItemMeta(closeMeta);
+        }
+        inventory.setItem(49, close);
     }
 
-    private ItemStack createItem(final FriendsMenuItem definition, final Map<String, String> placeholders) {
-        final ItemStack base = resolveItem(definition.getMaterialKey());
-        if (base == null) {
-            return null;
-        }
-        final ItemMeta meta = base.getItemMeta();
+    private ItemStack createItem(final Material material, final String name) {
+        final ItemStack item = new ItemStack(material);
+        final ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(colorize(apply(definition.getDisplayName(), placeholders)));
-            final List<String> lore = definition.getLore().stream()
-                    .map(line -> colorize(apply(line, placeholders)))
-                    .toList();
-            if (!lore.isEmpty()) {
-                meta.setLore(lore);
-            }
-            final boolean shouldEnchant = shouldApplyEnchantment(definition, placeholders);
-            if (shouldEnchant) {
-                boolean applied = addEnchantment(meta, Enchantment.UNBREAKING);
-                if (!applied) {
-                    final Enchantment legacy = Enchantment.getByName("DURABILITY");
-                    if (legacy != null) {
-                        applied = addEnchantment(meta, legacy);
-                    }
-                }
-                if (!applied) {
-                    for (Enchantment fallback : Enchantment.values()) {
-                        if (addEnchantment(meta, fallback)) {
-                            applied = true;
-                            break;
-                        }
-                    }
-                }
-                if (applied) {
-                    meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-                }
-            } else {
-                meta.removeEnchant(Enchantment.UNBREAKING);
-                final Enchantment legacy = Enchantment.getByName("DURABILITY");
-                if (legacy != null) {
-                    meta.removeEnchant(legacy);
-                }
-            }
-            base.setItemMeta(meta);
+            meta.setDisplayName(name);
+            item.setItemMeta(meta);
         }
-        return base;
+        return item;
     }
 
-    private boolean addEnchantment(final ItemMeta meta, final Enchantment enchantment) {
-        if (meta == null || enchantment == null) {
-            return false;
-        }
-        try {
-            return meta.addEnchant(enchantment, 1, true);
-        } catch (RuntimeException exception) {
-            return false;
-        }
-    }
-
-    private boolean shouldApplyEnchantment(final FriendsMenuItem definition, final Map<String, String> placeholders) {
-        if (!definition.isEnchanted()) {
-            return false;
-        }
-        final String requests = placeholders.get("nouvelles_demandes");
-        if (requests == null) {
-            return true;
-        }
-        try {
-            return Integer.parseInt(requests) > 0;
-        } catch (NumberFormatException exception) {
-            return true;
-        }
-    }
-
-    private ItemStack resolveItem(final String materialKey) {
-        if (materialKey == null || materialKey.isBlank()) {
-            return new ItemStack(Material.BARRIER);
-        }
-        final String normalized = materialKey.trim().toLowerCase(Locale.ROOT);
-        if (normalized.startsWith("hdb:")) {
-            return assetManager.getHead(normalized);
-        }
-        final Material material = Material.matchMaterial(normalized.toUpperCase(Locale.ROOT));
-        if (material == null) {
-            return new ItemStack(Material.BARRIER);
-        }
-        return new ItemStack(material);
-    }
-
-    private String apply(final String input, final Map<String, String> placeholders) {
-        if (input == null) {
-            return "";
-        }
-        String result = input;
-        for (Map.Entry<String, String> entry : placeholders.entrySet()) {
-            result = result.replace("{" + entry.getKey() + "}", entry.getValue());
-        }
-        return result;
-    }
-
-    private void playSound(final Player player, final Sound sound) {
-        playSound(player, sound, 1.0f);
-    }
-
-    private void playSound(final Player player, final Sound sound, final float pitch) {
-        if (player == null || sound == null) {
+    @EventHandler
+    public void onInventoryClick(final InventoryClickEvent event) {
+        if (!MENU_TITLE.equals(event.getView().getTitle())) {
             return;
         }
-        player.playSound(player.getLocation(), sound, 1.0f, pitch);
-    }
 
-    private void openProfileMenu(final Player player) {
-        if (player == null) {
+        event.setCancelled(true);
+
+        if (!(event.getWhoClicked() instanceof Player player) || viewer == null) {
             return;
         }
-        final MenuManager menuManager = plugin.getMenuManager();
-        if (menuManager == null) {
+        if (!player.getUniqueId().equals(viewer.getUniqueId())) {
             return;
         }
-        menuManager.openMenu(player, "profil_menu");
-    }
 
-    private boolean handleInternalAction(final Player player, final String action) {
-        if (action == null || action.isBlank()) {
-            return false;
-        }
-        return switch (action.toLowerCase(Locale.ROOT)) {
-            case "open_settings" -> {
-                openSettings(player);
-                yield true;
+        final int slot = event.getSlot();
+        switch (slot) {
+            case 11 -> openFriendsList(player);
+            case 13 -> openAddFriend(player);
+            case 15 -> openRequests(player);
+            case 20 -> openFavorites(player);
+            case 22 -> openSettings(player);
+            case 24 -> openStatistics(player);
+            case 29 -> openBlocked(player);
+            case 49 -> player.closeInventory();
+            default -> {
             }
-            case "open_statistics" -> {
-                openStatistics(player);
-                yield true;
-            }
-            case "open_blocked" -> {
-                openBlocked(player);
-                yield true;
-            }
-            case "open_favorites" -> {
-                openFavorites(player);
-                yield true;
-            }
-            default -> false;
-        };
-    }
-
-    private void openSettings(final Player player) {
-        try {
-            player.closeInventory();
-            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
-            Bukkit.getScheduler().runTaskLater(plugin, () ->
-                    new FriendSettingsMenu(plugin, friendsManager, player).open(), 3L);
-        } catch (Exception exception) {
-            player.sendMessage("§cErreur lors de l'ouverture des paramètres");
-            exception.printStackTrace();
         }
     }
 
-    private void openStatistics(final Player player) {
+    @EventHandler
+    public void onInventoryClose(final InventoryCloseEvent event) {
+        if (viewer == null) {
+            return;
+        }
+        if (!MENU_TITLE.equals(event.getView().getTitle())) {
+            return;
+        }
+        if (!event.getPlayer().getUniqueId().equals(viewer.getUniqueId())) {
+            return;
+        }
+        HandlerList.unregisterAll(this);
+        viewer = null;
+        inventory = null;
+    }
+
+    private void openFriendsList(final Player player) {
         try {
             player.closeInventory();
-            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
-            Bukkit.getScheduler().runTaskLater(plugin, () ->
-                    new FriendStatisticsMenu(plugin, friendsManager, player).open(), 3L);
+            player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> new FriendsListMenu(plugin, friendsManager, player), 3L);
         } catch (Exception exception) {
-            player.sendMessage("§cErreur lors de l'ouverture des statistiques");
-            exception.printStackTrace();
+            player.sendMessage("§cErreur lors de l'ouverture de la liste");
+            plugin.getLogger().log(Level.SEVERE, "Impossible d'ouvrir la liste des amis", exception);
         }
     }
 
-    private void openBlocked(final Player player) {
+    private void openAddFriend(final Player player) {
         try {
             player.closeInventory();
-            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
-            Bukkit.getScheduler().runTaskLater(plugin, () ->
-                    new BlockedPlayersMenu(plugin, friendsManager, player).open(), 3L);
+            player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> new AddFriendMenu(plugin, friendsManager, player).open(), 3L);
         } catch (Exception exception) {
-            player.sendMessage("§cErreur lors de l'ouverture de la liste des bloqués");
-            exception.printStackTrace();
+            player.sendMessage("§cErreur lors de l'ouverture du menu d'ajout");
+            plugin.getLogger().log(Level.SEVERE, "Impossible d'ouvrir le menu d'ajout d'amis", exception);
+        }
+    }
+
+    private void openRequests(final Player player) {
+        try {
+            player.closeInventory();
+            player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> new FriendRequestsMenu(plugin, friendsManager, player), 3L);
+        } catch (Exception exception) {
+            player.sendMessage("§cErreur lors de l'ouverture des demandes");
+            plugin.getLogger().log(Level.SEVERE, "Impossible d'ouvrir les demandes d'amis", exception);
         }
     }
 
     private void openFavorites(final Player player) {
         try {
             player.closeInventory();
-            player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
-            Bukkit.getScheduler().runTaskLater(plugin, () ->
-                    new FavoriteFriendsMenu(plugin, friendsManager, player), 3L);
+            player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> new FavoriteFriendsMenu(plugin, friendsManager, player), 3L);
         } catch (Exception exception) {
             player.sendMessage("§cErreur lors de l'ouverture des favoris");
-            exception.printStackTrace();
+            plugin.getLogger().log(Level.SEVERE, "Impossible d'ouvrir les amis favoris", exception);
         }
     }
 
-    private String colorize(final String input) {
-        if (input == null) {
-            return "";
+    private void openSettings(final Player player) {
+        try {
+            player.closeInventory();
+            player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> new FriendSettingsMenu(plugin, friendsManager, player).open(), 3L);
+        } catch (Exception exception) {
+            player.sendMessage("§cErreur lors de l'ouverture des paramètres");
+            plugin.getLogger().log(Level.SEVERE, "Impossible d'ouvrir les paramètres d'amis", exception);
         }
-        return ChatColor.translateAlternateColorCodes('&', input);
+    }
+
+    private void openStatistics(final Player player) {
+        try {
+            player.closeInventory();
+            player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> new FriendStatisticsMenu(plugin, friendsManager, player).open(), 3L);
+        } catch (Exception exception) {
+            player.sendMessage("§cErreur lors de l'ouverture des statistiques");
+            plugin.getLogger().log(Level.SEVERE, "Impossible d'ouvrir les statistiques d'amis", exception);
+        }
+    }
+
+    private void openBlocked(final Player player) {
+        try {
+            player.closeInventory();
+            player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> new BlockedPlayersMenu(plugin, friendsManager, player).open(), 3L);
+        } catch (Exception exception) {
+            player.sendMessage("§cErreur lors de l'ouverture des bloqués");
+            plugin.getLogger().log(Level.SEVERE, "Impossible d'ouvrir la liste des joueurs bloqués", exception);
+        }
     }
 }
-

--- a/src/main/java/com/lobby/friends/menu/FriendsMenuController.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMenuController.java
@@ -8,17 +8,14 @@ import com.lobby.menus.MenuManager;
 import org.bukkit.entity.Player;
 
 /**
- * Entry point used to open the friends main menu for players.
+ * Entry point used to open the redesigned friends main menu for players. The
+ * controller keeps the previous API surface so existing code paths continue to
+ * work while delegating the actual menu rendering to the new inventory classes.
  */
 public class FriendsMenuController {
 
     private final LobbyPlugin plugin;
-    private final MenuManager menuManager;
-    private final AssetManager assetManager;
-    private final FriendsDataProvider dataProvider;
     private final FriendsManager friendsManager;
-    private FriendsMenuActionHandler actionHandler;
-    private FriendsMenuConfiguration configuration;
 
     public FriendsMenuController(final LobbyPlugin plugin,
                                  final MenuManager menuManager,
@@ -27,29 +24,22 @@ public class FriendsMenuController {
                                  final FriendsManager friendsManager,
                                  final FriendsMenuActionHandler actionHandler) {
         this.plugin = plugin;
-        this.menuManager = menuManager;
-        this.assetManager = assetManager;
-        this.dataProvider = dataProvider;
         this.friendsManager = friendsManager;
-        this.actionHandler = actionHandler;
-        reload();
     }
 
     public void reload() {
-        configuration = FriendsMenuConfigurationLoader.load(plugin);
+        // Nothing to reload with the new inventory-driven implementation.
     }
 
     public void setActionHandler(final FriendsMenuActionHandler actionHandler) {
-        this.actionHandler = actionHandler;
+        // Kept for API compatibility; no longer used by the simplified menus.
     }
 
     public boolean openMainMenu(final Player player) {
-        if (player == null || configuration == null) {
+        if (player == null) {
             return false;
         }
-        final FriendsMainMenu menu = new FriendsMainMenu(plugin, assetManager, configuration, dataProvider, friendsManager, actionHandler);
-        menuManager.displayMenu(player, menu);
+        new FriendsMainMenu(plugin, friendsManager).open(player);
         return true;
     }
 }
-


### PR DESCRIPTION
## Summary
- redesign the friends main menu to fetch friend/request counts asynchronously and populate richer menu entries
- rebuild the paginated friends list with the new design, navigation controls, and direct friend interactions
- simplify the friends menu controller and update entry points to work with the new inventories

## Testing
- `mvn -q -DskipTests compile` *(fails: dependency downloads blocked with HTTP 403 from papermc repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d7cb57df9083298d6b65f018c09819