### PR TITLE
Implement centralized friends menu protection and configs

### DIFF
--- a/plugins/LobbyCore/friends/friends_favorites_menu.yml
+++ b/plugins/LobbyCore/friends/friends_favorites_menu.yml
@@ -1,0 +1,31 @@
+menu:
+  title: "§8» §6★ Amis Favoris"
+  size: 54
+
+glass_slots: [0,1,2,6,7,8,9,17,36,44,45,46,52,53]
+
+glass_item:
+  material: YELLOW_STAINED_GLASS_PANE
+  name: "§7"
+  lore: []
+
+navigation:
+  back:
+    slot: 45
+    material: ARROW
+    name: "§c« Retour"
+    actions: ["[MENU] friends_main_menu"]
+  close:
+    slot: 53
+    material: BARRIER
+    name: "§c✕ Fermer"
+    actions: ["[CLOSE]"]
+
+content_slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34,37,38,39,40,41,42,43]
+
+items:
+  refresh:
+    slot: 49
+    material: EMERALD
+    name: "§a⟲ Actualiser"
+    actions: ["[REFRESH]"]

--- a/plugins/LobbyCore/friends/friends_list_menu.yml
+++ b/plugins/LobbyCore/friends/friends_list_menu.yml
@@ -1,0 +1,31 @@
+menu:
+  title: "§8» §bListe de mes Amis"
+  size: 54
+
+glass_slots: [0,1,2,6,7,8,9,17,36,44,45,46,52,53]
+
+glass_item:
+  material: LIGHT_BLUE_STAINED_GLASS_PANE
+  name: "§7"
+  lore: []
+
+navigation:
+  back:
+    slot: 45
+    material: ARROW
+    name: "§c« Retour"
+    actions: ["[MENU] friends_main_menu"]
+  close:
+    slot: 53
+    material: BARRIER
+    name: "§c✕ Fermer"
+    actions: ["[CLOSE]"]
+
+content_slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34,37,38,39,40,41,42,43]
+
+items:
+  refresh:
+    slot: 49
+    material: CLOCK
+    name: "§b🔄 Actualiser"
+    actions: ["[REFRESH]"]

--- a/plugins/LobbyCore/friends/friends_main_menu.yml
+++ b/plugins/LobbyCore/friends/friends_main_menu.yml
@@ -1,0 +1,56 @@
+menu:
+  title: "§8» §bMes Amis"
+  size: 54
+
+glass_slots: [0,1,2,6,7,8,9,17,36,44,45,46,52,53]
+
+glass_item:
+  material: BLACK_STAINED_GLASS_PANE
+  name: "§7"
+  lore: []
+
+navigation:
+  back:
+    slot: 45
+    material: ARROW
+    name: "§c« Retour"
+    actions: ["[MENU] previous_menu"]
+  close:
+    slot: 53
+    material: BARRIER
+    name: "§c✕ Fermer"
+    actions: ["[CLOSE]"]
+
+content_slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34,37,38,39,40,41,42,43]
+
+items:
+  friends_list:
+    slot: 20
+    material: PLAYER_HEAD
+    name: "§b⚡ Liste d'Amis §7(§3%online%§7/§3%total%§7)"
+    actions: ["[MENU] friends_list_menu"]
+  favorites:
+    slot: 21
+    material: NETHER_STAR
+    name: "§6★ Amis Favoris §7(§e%favorites%§7)"
+    actions: ["[MENU] friends_favorites_menu"]
+  requests:
+    slot: 22
+    material: PAPER
+    name: "§e✉ Demandes Reçues §7(§c%pending%§7)"
+    actions: ["[MENU] friends_requests_menu"]
+  sent_requests:
+    slot: 23
+    material: FEATHER
+    name: "§a✈ Demandes Envoyées §7(§a%sent%§7)"
+    actions: ["[MENU] friends_sent_requests_menu"]
+  search:
+    slot: 24
+    material: COMPASS
+    name: "§9🔍 Rechercher un Ami"
+    actions: ["[MENU] friends_search_menu"]
+  settings:
+    slot: 40
+    material: REDSTONE
+    name: "§c⚙ Paramètres d'Amitié"
+    actions: ["[MENU] friends_settings_menu"]

--- a/plugins/LobbyCore/friends/friends_manage_menu.yml
+++ b/plugins/LobbyCore/friends/friends_manage_menu.yml
@@ -1,0 +1,41 @@
+menu:
+  title: "§8» §bGestion d'un Ami"
+  size: 54
+
+glass_slots: [0,1,2,6,7,8,9,17,36,44,45,46,52,53]
+
+glass_item:
+  material: GRAY_STAINED_GLASS_PANE
+  name: "§7"
+  lore: []
+
+navigation:
+  back:
+    slot: 45
+    material: ARROW
+    name: "§c« Retour"
+    actions: ["[MENU] friends_profile_menu"]
+  close:
+    slot: 53
+    material: BARRIER
+    name: "§c✕ Fermer"
+    actions: ["[CLOSE]"]
+
+content_slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34,37,38,39,40,41,42,43]
+
+items:
+  toggle_favorite:
+    slot: 20
+    material: NETHER_STAR
+    name: "§6Basculer Favori"
+    actions: ["[ACTION] toggle_favorite"]
+  send_message:
+    slot: 21
+    material: WRITABLE_BOOK
+    name: "§aEnvoyer un message"
+    actions: ["[ACTION] send_message"]
+  remove_friend:
+    slot: 22
+    material: BARRIER
+    name: "§cRetirer l'ami"
+    actions: ["[ACTION] remove_friend"]

--- a/plugins/LobbyCore/friends/friends_profile_menu.yml
+++ b/plugins/LobbyCore/friends/friends_profile_menu.yml
@@ -1,0 +1,41 @@
+menu:
+  title: "§8» §bProfil d'Ami"
+  size: 54
+
+glass_slots: [0,1,2,6,7,8,9,17,36,44,45,46,52,53]
+
+glass_item:
+  material: PURPLE_STAINED_GLASS_PANE
+  name: "§7"
+  lore: []
+
+navigation:
+  back:
+    slot: 45
+    material: ARROW
+    name: "§c« Retour"
+    actions: ["[MENU] friends_manage_menu"]
+  close:
+    slot: 53
+    material: BARRIER
+    name: "§c✕ Fermer"
+    actions: ["[CLOSE]"]
+
+content_slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34,37,38,39,40,41,42,43]
+
+items:
+  overview:
+    slot: 20
+    material: PLAYER_HEAD
+    name: "§bInformations générales"
+    actions: ["[ACTION] overview"]
+  statistics:
+    slot: 21
+    material: BOOK
+    name: "§eStatistiques"
+    actions: ["[ACTION] statistics"]
+  message:
+    slot: 22
+    material: WRITABLE_BOOK
+    name: "§aEnvoyer un message"
+    actions: ["[ACTION] send_message"]

--- a/plugins/LobbyCore/friends/friends_requests_menu.yml
+++ b/plugins/LobbyCore/friends/friends_requests_menu.yml
@@ -1,0 +1,31 @@
+menu:
+  title: "§8» §6Demandes d'Amitié"
+  size: 54
+
+glass_slots: [0,1,2,6,7,8,9,17,36,44,45,46,52,53]
+
+glass_item:
+  material: ORANGE_STAINED_GLASS_PANE
+  name: "§7"
+  lore: []
+
+navigation:
+  back:
+    slot: 45
+    material: ARROW
+    name: "§c« Retour"
+    actions: ["[MENU] friends_main_menu"]
+  close:
+    slot: 53
+    material: BARRIER
+    name: "§c✕ Fermer"
+    actions: ["[CLOSE]"]
+
+content_slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34,37,38,39,40,41,42,43]
+
+items:
+  refresh:
+    slot: 49
+    material: CLOCK
+    name: "§b🔄 Actualiser"
+    actions: ["[REFRESH]"]

--- a/plugins/LobbyCore/friends/friends_search_menu.yml
+++ b/plugins/LobbyCore/friends/friends_search_menu.yml
@@ -1,0 +1,41 @@
+menu:
+  title: "§8» §9Recherche d'Amis"
+  size: 54
+
+glass_slots: [0,1,2,6,7,8,9,17,36,44,45,46,52,53]
+
+glass_item:
+  material: BLUE_STAINED_GLASS_PANE
+  name: "§7"
+  lore: []
+
+navigation:
+  back:
+    slot: 45
+    material: ARROW
+    name: "§c« Retour"
+    actions: ["[MENU] friends_main_menu"]
+  close:
+    slot: 53
+    material: BARRIER
+    name: "§c✕ Fermer"
+    actions: ["[CLOSE]"]
+
+content_slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34,37,38,39,40,41,42,43]
+
+items:
+  manual_search:
+    slot: 20
+    material: COMPASS
+    name: "§bRecherche manuelle"
+    actions: ["[ACTION] manual_search"]
+  recent_players:
+    slot: 21
+    material: BOOK
+    name: "§eJoueurs récents"
+    actions: ["[ACTION] recent_players"]
+  suggestions:
+    slot: 22
+    material: PLAYER_HEAD
+    name: "§aSuggestions"
+    actions: ["[ACTION] suggestions"]

--- a/plugins/LobbyCore/friends/friends_sent_requests_menu.yml
+++ b/plugins/LobbyCore/friends/friends_sent_requests_menu.yml
@@ -1,0 +1,31 @@
+menu:
+  title: "§8» §aDemandes Envoyées"
+  size: 54
+
+glass_slots: [0,1,2,6,7,8,9,17,36,44,45,46,52,53]
+
+glass_item:
+  material: LIME_STAINED_GLASS_PANE
+  name: "§7"
+  lore: []
+
+navigation:
+  back:
+    slot: 45
+    material: ARROW
+    name: "§c« Retour"
+    actions: ["[MENU] friends_main_menu"]
+  close:
+    slot: 53
+    material: BARRIER
+    name: "§c✕ Fermer"
+    actions: ["[CLOSE]"]
+
+content_slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34,37,38,39,40,41,42,43]
+
+items:
+  refresh:
+    slot: 49
+    material: CLOCK
+    name: "§b🔄 Actualiser"
+    actions: ["[REFRESH]"]

--- a/plugins/LobbyCore/friends/friends_settings_menu.yml
+++ b/plugins/LobbyCore/friends/friends_settings_menu.yml
@@ -1,0 +1,54 @@
+menu:
+  title: "§8» §6Paramètres d'Amitié"
+  size: 54
+
+glass_slots: [0,1,2,6,7,8,9,17,36,44,45,46,52,53]
+
+glass_item:
+  material: RED_STAINED_GLASS_PANE
+  name: "§7"
+  lore: []
+
+navigation:
+  back:
+    slot: 45
+    material: ARROW
+    name: "§c« Retour"
+    actions: ["[MENU] friends_main_menu"]
+  close:
+    slot: 53
+    material: BARRIER
+    name: "§c✕ Fermer"
+    actions: ["[CLOSE]"]
+
+content_slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34,37,38,39,40,41,42,43]
+
+items:
+  friend_requests:
+    slot: 20
+    material: PAPER
+    name: "§bDemandes d'Amitié"
+    current_value: "%friend_requests_setting%"
+    values: ["EVERYONE","NONE"]
+    actions: ["[TOGGLE] friend_requests"]
+  notifications:
+    slot: 21
+    material: BELL
+    name: "§eNotifications"
+    current_value: "%notifications_setting%"
+    values: ["ENABLED","DISABLED"]
+    actions: ["[TOGGLE] notifications"]
+  online_status:
+    slot: 22
+    material: EMERALD_BLOCK
+    name: "§aStatut en Ligne"
+    current_value: "%online_status_setting%"
+    values: ["VISIBLE","INVISIBLE","FRIENDS_ONLY"]
+    actions: ["[TOGGLE] online_status"]
+  auto_accept_favorites:
+    slot: 23
+    material: NETHER_STAR
+    name: "§6Auto-accepter Favoris"
+    current_value: "%auto_accept_setting%"
+    values: ["ENABLED","DISABLED"]
+    actions: ["[TOGGLE] auto_accept_favorites"]

--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -21,6 +21,7 @@ import com.lobby.friends.commands.FriendsTestCommand;
 import com.lobby.friends.manager.FriendsManager;
 import com.lobby.friends.menu.DefaultFriendsMenuActionHandler;
 import com.lobby.friends.menu.FriendsMenuController;
+import com.lobby.friends.menu.FriendsMenuManager;
 import com.lobby.npcs.NPCInteractionHandler;
 import com.lobby.npcs.NPCManager;
 import com.lobby.events.PlayerJoinLeaveEvent;
@@ -72,6 +73,7 @@ public final class LobbyPlugin extends JavaPlugin {
     private DefaultFriendsDataProvider friendsDataProvider;
     private FriendsManager friendsManager;
     private FriendsMenuController friendsMenuController;
+    private FriendsMenuManager friendsMenuManager;
 
     public static LobbyPlugin getInstance() {
         return instance;
@@ -119,8 +121,10 @@ public final class LobbyPlugin extends JavaPlugin {
         confirmationManager = new ConfirmationManager(this);
         friendsDataProvider = new DefaultFriendsDataProvider();
         friendsManager = new FriendsManager(this);
+        friendsMenuManager = new FriendsMenuManager(this);
+        getServer().getPluginManager().registerEvents(friendsMenuManager, this);
         friendsMenuController = new FriendsMenuController(this, menuManager, assetManager, friendsDataProvider,
-                friendsManager, new DefaultFriendsMenuActionHandler(this, friendsManager));
+                friendsManager, friendsMenuManager, new DefaultFriendsMenuActionHandler(this, friendsManager));
         shopManager = new ShopManager(this);
         shopManager.initialize();
         shopCommands = new ShopCommands(this, shopManager);
@@ -303,6 +307,10 @@ public final class LobbyPlugin extends JavaPlugin {
 
     public DefaultFriendsDataProvider getFriendsDataProvider() {
         return friendsDataProvider;
+    }
+
+    public FriendsMenuManager getFriendsMenuManager() {
+        return friendsMenuManager;
     }
 
     public void reloadLobbyConfig() {

--- a/src/main/java/com/lobby/friends/commands/FriendsTestCommand.java
+++ b/src/main/java/com/lobby/friends/commands/FriendsTestCommand.java
@@ -8,6 +8,7 @@ import com.lobby.friends.menu.FavoriteFriendsMenu;
 import com.lobby.friends.menu.FriendRequestsMenu;
 import com.lobby.friends.menu.FriendSettingsMenu;
 import com.lobby.friends.menu.FriendsListMenu;
+import com.lobby.friends.menu.FriendsMenuManager;
 import com.lobby.friends.menu.statistics.FriendStatisticsMenu;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -48,6 +49,12 @@ public final class FriendsTestCommand implements CommandExecutor {
 
         final String subCommand = args[0].toLowerCase();
 
+        final FriendsMenuManager menuManager = plugin.getFriendsMenuManager();
+        if (menuManager == null) {
+            player.sendMessage("§cLe gestionnaire de menus d'amis est indisponible.");
+            return true;
+        }
+
         try {
             switch (subCommand) {
                 case "main" -> openMainMenu(player);
@@ -60,11 +67,11 @@ public final class FriendsTestCommand implements CommandExecutor {
                     player.sendMessage("§a✓ Menu d'ajout d'amis ouvert");
                 }
                 case "requests" -> {
-                    new FriendRequestsMenu(plugin, friendsManager, player).open();
+                    new FriendRequestsMenu(plugin, friendsManager, menuManager, player).open();
                     player.sendMessage("§a✓ Menu des demandes ouvert");
                 }
                 case "settings" -> {
-                    new FriendSettingsMenu(plugin, friendsManager, player).open();
+                    new FriendSettingsMenu(plugin, friendsManager, menuManager, player).open();
                     player.sendMessage("§a✓ Menu des paramètres ouvert");
                 }
                 case "stats" -> {
@@ -76,7 +83,7 @@ public final class FriendsTestCommand implements CommandExecutor {
                     player.sendMessage("§a✓ Menu des joueurs bloqués ouvert");
                 }
                 case "favorites" -> {
-                    new FavoriteFriendsMenu(plugin, friendsManager, player);
+                    new FavoriteFriendsMenu(plugin, friendsManager, menuManager, player).open();
                     player.sendMessage("§a✓ Menu des favoris ouvert");
                 }
                 case "all" -> testAllMenus(player);
@@ -122,6 +129,11 @@ public final class FriendsTestCommand implements CommandExecutor {
     }
 
     private void testMenuSequentially(final Player player, final int menuIndex) {
+        final FriendsMenuManager menuManager = plugin.getFriendsMenuManager();
+        if (menuManager == null) {
+            player.sendMessage("§cLe gestionnaire de menus d'amis est indisponible, test interrompu.");
+            return;
+        }
         final String[] menuNames = {
                 "Menu Principal",
                 "Liste des Amis",
@@ -146,11 +158,11 @@ public final class FriendsTestCommand implements CommandExecutor {
                 case 0 -> openMainMenu(player);
                 case 1 -> new FriendsListMenu(plugin, friendsManager, player);
                 case 2 -> new AddFriendMenu(plugin, friendsManager, player).open();
-                case 3 -> new FriendRequestsMenu(plugin, friendsManager, player).open();
-                case 4 -> new FriendSettingsMenu(plugin, friendsManager, player).open();
+                case 3 -> new FriendRequestsMenu(plugin, friendsManager, menuManager, player).open();
+                case 4 -> new FriendSettingsMenu(plugin, friendsManager, menuManager, player).open();
                 case 5 -> new FriendStatisticsMenu(plugin, friendsManager, player).open();
                 case 6 -> new BlockedPlayersMenu(plugin, friendsManager, player).open();
-                case 7 -> new FavoriteFriendsMenu(plugin, friendsManager, player);
+                case 7 -> new FavoriteFriendsMenu(plugin, friendsManager, menuManager, player).open();
                 default -> {
                     return;
                 }

--- a/src/main/java/com/lobby/friends/menu/AddFriendMenu.java
+++ b/src/main/java/com/lobby/friends/menu/AddFriendMenu.java
@@ -3,6 +3,7 @@ package com.lobby.friends.menu;
 import com.lobby.LobbyPlugin;
 import com.lobby.friends.manager.FriendsManager;
 import com.lobby.friends.menu.FriendsMainMenu;
+import com.lobby.friends.menu.FriendsMenuManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -271,6 +272,12 @@ public class AddFriendMenu implements Listener {
     private void handleBack() {
         player.closeInventory();
         player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
-        Bukkit.getScheduler().runTaskLater(plugin, () -> new FriendsMainMenu(plugin, friendsManager).open(player), 3L);
+        final FriendsMenuManager menuManager = plugin.getFriendsMenuManager();
+        if (menuManager == null) {
+            player.sendMessage("§cLe gestionnaire de menus d'amis est indisponible.");
+            return;
+        }
+        Bukkit.getScheduler().runTaskLater(plugin,
+                () -> new FriendsMainMenu(plugin, friendsManager, menuManager, player).open(), 3L);
     }
 }

--- a/src/main/java/com/lobby/friends/menu/BaseFriendsMenu.java
+++ b/src/main/java/com/lobby/friends/menu/BaseFriendsMenu.java
@@ -1,0 +1,125 @@
+package com.lobby.friends.menu;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.friends.manager.FriendsManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.Sound;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Base implementation shared by every friends related inventory. It delegates
+ * click and close handling to {@link FriendsMenuManager} so menus no longer
+ * need to register their own listeners which previously caused inventory state
+ * desynchronisation when players spam-clicked. The base class also exposes a
+ * {@link #safeRefresh()} helper that performs the close/reopen cycle on the
+ * main server thread while respecting a short delay to avoid duplicate
+ * InventoryClick events.
+ */
+public abstract class BaseFriendsMenu {
+
+    protected final LobbyPlugin plugin;
+    protected final FriendsManager friendsManager;
+    protected final FriendsMenuManager menuManager;
+    protected final Player player;
+
+    protected BaseFriendsMenu(final LobbyPlugin plugin,
+                              final FriendsManager friendsManager,
+                              final FriendsMenuManager menuManager,
+                              final Player player) {
+        this.plugin = plugin;
+        this.friendsManager = friendsManager;
+        this.menuManager = menuManager;
+        this.player = player;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Opens the menu for the associated player and registers it inside the
+     * {@link FriendsMenuManager}. Implementations should create their
+     * inventories and populate the default content from within
+     * {@link #openMenu()}.
+     */
+    public final void open() {
+        if (player == null || !player.isOnline()) {
+            return;
+        }
+        menuManager.registerMenu(player, this);
+        openMenu();
+    }
+
+    /**
+     * Called by {@link #open()} once the menu has been registered. Concrete
+     * implementations must create their inventory and call
+     * {@link Player#openInventory(Inventory)} from within this method.
+     */
+    protected abstract void openMenu();
+
+    /**
+     * @return the Bukkit inventory currently displayed to the player.
+     */
+    public abstract Inventory getInventory();
+
+    /**
+     * @return the translated title of the inventory.
+     */
+    public abstract String getTitle();
+
+    /**
+     * Called by {@link FriendsMenuManager} whenever the player interacts with
+     * the inventory. The event has already been cancelled so implementations
+     * only need to focus on handling the action.
+     */
+    public abstract void handleMenuClick(InventoryClickEvent event);
+
+    /**
+     * Invoked when the inventory is closed either manually by the player or as
+     * part of a refresh cycle. Subclasses can override to perform additional
+     * cleanup but should always call {@code super.handleMenuClose(event)} to
+     * unregister the menu.
+     */
+    public void handleMenuClose(final InventoryCloseEvent event) {
+        final UUID viewerId = event.getPlayer().getUniqueId();
+        menuManager.unregisterMenu(viewerId, this);
+    }
+
+    /**
+     * Schedules a safe refresh of the inventory by closing it and re-opening
+     * the menu after a short delay as recommended for Paper 1.21+. The delay
+     * prevents the server from processing stale click packets while the menu is
+     * rebuilding.
+     */
+    public void safeRefresh() {
+        menuManager.safeRefresh(this);
+    }
+
+    /**
+     * Called by {@link FriendsMenuManager#safeRefresh(BaseFriendsMenu)} once
+     * the close/reopen cycle needs to re-open the menu. The default
+     * implementation simply delegates to {@link #open()} but it can be
+     * overridden when menus require custom refresh behaviour.
+     */
+    public void reopen() {
+        open();
+    }
+
+    protected void playClickSound(final Sound sound, final float pitch) {
+        if (sound == null) {
+            return;
+        }
+        final BukkitScheduler scheduler = plugin.getServer().getScheduler();
+        scheduler.runTask(plugin, () -> player.playSound(player.getLocation(), sound, 1.0f, pitch));
+    }
+
+    protected static boolean titlesMatch(final String expected, final String actual) {
+        return Objects.equals(expected, actual);
+    }
+}

--- a/src/main/java/com/lobby/friends/menu/DefaultFriendsMenuActionHandler.java
+++ b/src/main/java/com/lobby/friends/menu/DefaultFriendsMenuActionHandler.java
@@ -3,6 +3,7 @@ package com.lobby.friends.menu;
 import com.lobby.LobbyPlugin;
 import com.lobby.friends.manager.FriendsManager;
 import com.lobby.friends.menu.statistics.FriendStatisticsMenu;
+import com.lobby.friends.menu.FriendsMenuManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -19,9 +20,11 @@ public class DefaultFriendsMenuActionHandler implements FriendsMenuActionHandler
 
     private final LobbyPlugin plugin;
     private final FriendsManager friendsManager;
+    private final FriendsMenuManager menuManager;
     public DefaultFriendsMenuActionHandler(final LobbyPlugin plugin, final FriendsManager friendsManager) {
         this.plugin = plugin;
         this.friendsManager = friendsManager;
+        this.menuManager = plugin.getFriendsMenuManager();
     }
 
     @Override
@@ -57,7 +60,11 @@ public class DefaultFriendsMenuActionHandler implements FriendsMenuActionHandler
 
     private boolean openFriendRequests(final Player player) {
         closeInventory(player);
-        runLater(player, () -> new FriendRequestsMenu(plugin, friendsManager, player));
+        if (menuManager == null) {
+            runLater(player, () -> player.sendMessage("§cLe système de menus d'amis est indisponible."));
+            return false;
+        }
+        runLater(player, () -> new FriendRequestsMenu(plugin, friendsManager, menuManager, player).open());
         return true;
     }
 
@@ -69,13 +76,21 @@ public class DefaultFriendsMenuActionHandler implements FriendsMenuActionHandler
 
     private boolean openSettings(final Player player) {
         closeInventory(player);
-        runLater(player, () -> new FriendSettingsMenu(plugin, friendsManager, player).open());
+        if (menuManager == null) {
+            runLater(player, () -> player.sendMessage("§cLes paramètres d'amis sont indisponibles."));
+            return false;
+        }
+        runLater(player, () -> new FriendSettingsMenu(plugin, friendsManager, menuManager, player).open());
         return true;
     }
 
     private boolean openFavorites(final Player player) {
         closeInventory(player);
-        runLater(player, () -> new FavoriteFriendsMenu(plugin, friendsManager, player));
+        if (menuManager == null) {
+            runLater(player, () -> player.sendMessage("§cLe gestionnaire de menus favoris est indisponible."));
+            return false;
+        }
+        runLater(player, () -> new FavoriteFriendsMenu(plugin, friendsManager, menuManager, player).open());
         return true;
     }
 

--- a/src/main/java/com/lobby/friends/menu/FavoriteFriendsMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FavoriteFriendsMenu.java
@@ -6,9 +6,8 @@ import com.lobby.friends.data.FriendData;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -21,11 +20,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class FavoriteFriendsMenu implements Listener {
-    
-    private final LobbyPlugin plugin;
-    private final FriendsManager friendsManager;
-    private final Player player;
+public class FavoriteFriendsMenu extends BaseFriendsMenu {
+
     private Inventory inventory;
     private List<FriendData> favoriteFriends;
 
@@ -37,22 +33,29 @@ public class FavoriteFriendsMenu implements Listener {
             37, 38, 39, 40, 41, 42, 43
     };
     
-    public FavoriteFriendsMenu(LobbyPlugin plugin, FriendsManager friendsManager, Player player) {
-        this.plugin = plugin;
-        this.friendsManager = friendsManager;
-        this.player = player;
+    public FavoriteFriendsMenu(final LobbyPlugin plugin,
+                               final FriendsManager friendsManager,
+                               final FriendsMenuManager menuManager,
+                               final Player player) {
+        super(plugin, friendsManager, menuManager, player);
         this.favoriteFriends = new ArrayList<>();
-        
-        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    @Override
+    protected void openMenu() {
         loadFavoritesAndCreateMenu();
     }
-    
+
     private void loadFavoritesAndCreateMenu() {
         friendsManager.getFavorites(player).thenAccept(favorites -> {
             this.favoriteFriends = favorites != null ? favorites : new ArrayList<>();
             Bukkit.getScheduler().runTask(plugin, () -> {
                 createMenu();
-                open();
+                final Player viewer = getPlayer();
+                if (viewer != null && viewer.isOnline()) {
+                    viewer.openInventory(inventory);
+                    viewer.playSound(viewer.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
+                }
             });
         }).exceptionally(throwable -> {
             plugin.getLogger().severe("Erreur chargement favoris: " + throwable.getMessage());
@@ -60,7 +63,11 @@ public class FavoriteFriendsMenu implements Listener {
                 player.sendMessage("§cErreur lors du chargement des favoris");
                 this.favoriteFriends = new ArrayList<>();
                 createMenu();
-                open();
+                final Player viewer = getPlayer();
+                if (viewer != null && viewer.isOnline()) {
+                    viewer.openInventory(inventory);
+                    viewer.playSound(viewer.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
+                }
             });
             return null;
         });
@@ -80,14 +87,14 @@ public class FavoriteFriendsMenu implements Listener {
 
         // Vitres dorées
         ItemStack goldGlass = createItem(Material.YELLOW_STAINED_GLASS_PANE, " ");
-        int[] goldSlots = {0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 46, 52, 53};
+        int[] goldSlots = {0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 46, 52, 53};
         for (int slot : goldSlots) {
             inventory.setItem(slot, goldGlass);
         }
-        
+
         // Afficher favoris
         displayFavorites();
-        
+
         // Actions et navigation
         setupActions();
     }
@@ -191,20 +198,31 @@ public class FavoriteFriendsMenu implements Listener {
     }
     
     private void setupActions() {
-        // Retour
-        ItemStack back = createItem(Material.BARRIER, "§e🏠 Retour Menu Principal");
+        ItemStack refresh = createItem(Material.EMERALD, "§a⟲ Actualiser");
+        ItemMeta refreshMeta = refresh.getItemMeta();
+        if (refreshMeta != null) {
+            refreshMeta.setLore(Arrays.asList(
+                    "§7Recharge la liste des favoris",
+                    "",
+                    "§8» §aCliquez pour mettre à jour"
+            ));
+            refresh.setItemMeta(refreshMeta);
+        }
+        inventory.setItem(49, refresh);
+
+        ItemStack back = createItem(Material.ARROW, "§c« Retour");
         ItemMeta backMeta = back.getItemMeta();
-        backMeta.setLore(Arrays.asList(
-            "§7Revenir au menu principal des amis",
-            "",
-            "§e▸ Total favoris: §6" + favoriteFriends.size(),
-            "",
-            "§8» §eCliquez pour retourner"
-        ));
-        back.setItemMeta(backMeta);
-        inventory.setItem(49, back);
+        if (backMeta != null) {
+            backMeta.setLore(Arrays.asList(
+                    "§7Revenir au menu principal",
+                    "",
+                    "§8» §cCliquez pour retourner"
+            ));
+            back.setItemMeta(backMeta);
+        }
+        inventory.setItem(45, back);
     }
-    
+
     private ItemStack createItem(Material material, String name) {
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
@@ -214,46 +232,36 @@ public class FavoriteFriendsMenu implements Listener {
         }
         return item;
     }
-    
-    public void open() {
-        if (inventory != null) {
-            player.openInventory(inventory);
-            player.playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
-        }
-    }
-    
-    @EventHandler
-    public void onInventoryClick(InventoryClickEvent event) {
-        String title = event.getView().getTitle();
-        if (!title.contains("§8» §eAmis Favoris")) {
+
+    @Override
+    public void handleMenuClick(final InventoryClickEvent event) {
+        final String title = event.getView().getTitle();
+        if (title == null || !title.contains("§8» §eAmis Favoris")) {
             return;
         }
-        
-        // CRITICAL: Protection IMMÉDIATE - PREMIÈRE LIGNE ABSOLUE
-        event.setCancelled(true);
-        
-        if (!(event.getWhoClicked() instanceof Player)) return;
-        Player clicker = (Player) event.getWhoClicked();
-        
-        if (!clicker.getUniqueId().equals(player.getUniqueId())) return;
-        
-        int slot = event.getSlot();
-        
+        final Player clicker = getPlayer();
+        if (clicker == null) {
+            return;
+        }
+
+        final int slot = event.getSlot();
+        if (slot == 45) {
+            clicker.closeInventory();
+            clicker.playSound(clicker.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
+            Bukkit.getScheduler().runTaskLater(plugin,
+                    () -> new FriendsMainMenu(plugin, friendsManager, menuManager, clicker).open(), 3L);
+            return;
+        }
         if (slot == 49) {
-            // Retour
-            player.closeInventory();
-            player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
-            
-            Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                new FriendsMainMenu(plugin, friendsManager).open(player);
-            }, 3L);
-        } else {
-            // Vérifier si c'est un slot de favori
-            for (int i = 0; i < favoriteSlots.length; i++) {
-                if (favoriteSlots[i] == slot && i < favoriteFriends.size()) {
-                    handleFavoriteClick(favoriteFriends.get(i), event);
-                    break;
-                }
+            clicker.playSound(clicker.getLocation(), Sound.BLOCK_ENCHANTMENT_TABLE_USE, 1.0f, 1.0f);
+            safeRefresh();
+            return;
+        }
+
+        for (int i = 0; i < favoriteSlots.length; i++) {
+            if (favoriteSlots[i] == slot && i < favoriteFriends.size()) {
+                handleFavoriteClick(favoriteFriends.get(i), event);
+                break;
             }
         }
     }
@@ -305,6 +313,25 @@ public class FavoriteFriendsMenu implements Listener {
                 });
                 break;
         }
+    }
+
+    @Override
+    public void handleMenuClose(final InventoryCloseEvent event) {
+        if (event.getView().getTitle() == null || !event.getView().getTitle().contains("§8» §eAmis Favoris")) {
+            return;
+        }
+        inventory = null;
+        super.handleMenuClose(event);
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    @Override
+    public String getTitle() {
+        return inventory != null ? inventory.getTitle() : "§8» §eAmis Favoris";
     }
 }
 

--- a/src/main/java/com/lobby/friends/menu/FriendRequestsMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FriendRequestsMenu.java
@@ -7,9 +7,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.HandlerList;
-import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
@@ -26,7 +23,7 @@ import java.util.UUID;
  * Ultra-protected friend requests menu providing immediate feedback while
  * keeping the menu contents guarded against any interaction exploits.
  */
-public class FriendRequestsMenu implements Listener {
+public class FriendRequestsMenu extends BaseFriendsMenu {
 
     private static final String TITLE_PREFIX = "§8» §6Demandes d'Amitié";
     private static final int INVENTORY_SIZE = 54;
@@ -38,20 +35,18 @@ public class FriendRequestsMenu implements Listener {
     };
     private static final int[] GLASS_SLOTS = {0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 46, 52, 53};
 
-    private final LobbyPlugin plugin;
-    private final FriendsManager friendsManager;
-    private final Player player;
-
     private Inventory inventory;
     private List<FriendRequest> allRequests = new ArrayList<>();
 
     public FriendRequestsMenu(final LobbyPlugin plugin,
                               final FriendsManager friendsManager,
+                              final FriendsMenuManager menuManager,
                               final Player player) {
-        this.plugin = plugin;
-        this.friendsManager = friendsManager;
-        this.player = player;
-        Bukkit.getPluginManager().registerEvents(this, plugin);
+        super(plugin, friendsManager, menuManager, player);
+    }
+
+    @Override
+    protected void openMenu() {
         loadRequestsAndCreateMenu();
     }
 
@@ -74,7 +69,11 @@ public class FriendRequestsMenu implements Listener {
         final String title = TITLE_PREFIX + " (" + allRequests.size() + ")";
         inventory = Bukkit.createInventory(null, INVENTORY_SIZE, title);
         setupMenu();
-        open();
+        final Player viewer = getPlayer();
+        if (viewer != null && viewer.isOnline()) {
+            viewer.openInventory(inventory);
+            viewer.playSound(viewer.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
+        }
     }
 
     private void setupMenu() {
@@ -189,45 +188,28 @@ public class FriendRequestsMenu implements Listener {
         return item;
     }
 
-    public void open() {
-        if (inventory == null) {
-            return;
-        }
-        player.openInventory(inventory);
-        player.playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
-    }
-
-    @EventHandler
-    public void onInventoryClick(final InventoryClickEvent event) {
+    @Override
+    public void handleMenuClick(final InventoryClickEvent event) {
         final String title = event.getView().getTitle();
         if (title == null || !title.contains(TITLE_PREFIX)) {
             return;
         }
-
-        event.setCancelled(true);
-        event.setResult(org.bukkit.event.Event.Result.DENY);
-
-        if (!(event.getWhoClicked() instanceof Player clicker)) {
-            return;
-        }
-        if (!clicker.getUniqueId().equals(player.getUniqueId())) {
+        final Player clicker = getPlayer();
+        if (clicker == null) {
             return;
         }
 
         final int slot = event.getSlot();
-        clicker.sendMessage("§7[DEBUG] Clic sur slot: " + slot);
-
         if (slot == 48) {
-            clicker.sendMessage("§b🔄 Actualisation des demandes...");
             clicker.playSound(clicker.getLocation(), Sound.BLOCK_ENCHANTMENT_TABLE_USE, 1.0f, 1.0f);
-            loadRequestsAndCreateMenu();
+            safeRefresh();
             return;
         }
         if (slot == 49) {
             clicker.closeInventory();
             clicker.playSound(clicker.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
             Bukkit.getScheduler().runTaskLater(plugin,
-                    () -> new FriendsMainMenu(plugin, friendsManager).open(clicker), 3L);
+                    () -> new FriendsMainMenu(plugin, friendsManager, menuManager, clicker).open(), 3L);
             return;
         }
 
@@ -259,6 +241,7 @@ public class FriendRequestsMenu implements Listener {
                         player.sendMessage("§a✓ Demande de " + request.getSenderName() + " acceptée !");
                         allRequests.remove(request);
                         setupMenu();
+                        clickerUpdate();
                     } else {
                         player.sendMessage("§cErreur lors de l'acceptation");
                     }
@@ -273,6 +256,7 @@ public class FriendRequestsMenu implements Listener {
                         player.sendMessage("§c✗ Demande de " + request.getSenderName() + " refusée");
                         allRequests.remove(request);
                         setupMenu();
+                        clickerUpdate();
                     } else {
                         player.sendMessage("§cErreur lors du refus de la demande");
                     }
@@ -280,17 +264,29 @@ public class FriendRequestsMenu implements Listener {
                 }));
     }
 
-    @EventHandler
-    public void onInventoryClose(final InventoryCloseEvent event) {
-        if (!(event.getPlayer() instanceof Player viewer)) {
-            return;
+    private void clickerUpdate() {
+        final Player viewer = getPlayer();
+        if (viewer != null) {
+            viewer.updateInventory();
         }
-        if (!viewer.getUniqueId().equals(player.getUniqueId())) {
-            return;
-        }
+    }
+
+    @Override
+    public void handleMenuClose(final InventoryCloseEvent event) {
         if (event.getView().getTitle() == null || !event.getView().getTitle().contains(TITLE_PREFIX)) {
             return;
         }
-        HandlerList.unregisterAll(this);
+        inventory = null;
+        super.handleMenuClose(event);
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    @Override
+    public String getTitle() {
+        return inventory != null ? inventory.getTitle() : TITLE_PREFIX;
     }
 }

--- a/src/main/java/com/lobby/friends/menu/FriendSettingsMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FriendSettingsMenu.java
@@ -7,9 +7,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.HandlerList;
-import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
@@ -25,25 +22,24 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * menu synchronises changes with the {@link FriendsManager} and persists them
  * asynchronously through the {@link com.lobby.friends.database.FriendsDatabase}.
  */
-public class FriendSettingsMenu implements Listener {
+public class FriendSettingsMenu extends BaseFriendsMenu {
 
     private static final String INVENTORY_TITLE = "§8» §6Paramètres d'Amitié";
     private static final int INVENTORY_SIZE = 54;
 
-    private final LobbyPlugin plugin;
-    private final FriendsManager friendsManager;
-    private final Player player;
     private Inventory inventory;
     private FriendSettings settings;
     private final AtomicBoolean opened = new AtomicBoolean(false);
 
     public FriendSettingsMenu(final LobbyPlugin plugin,
                               final FriendsManager friendsManager,
+                              final FriendsMenuManager menuManager,
                               final Player player) {
-        this.plugin = plugin;
-        this.friendsManager = friendsManager;
-        this.player = player;
-        Bukkit.getPluginManager().registerEvents(this, plugin);
+        super(plugin, friendsManager, menuManager, player);
+    }
+
+    @Override
+    protected void openMenu() {
         loadSettings();
     }
 
@@ -59,9 +55,16 @@ public class FriendSettingsMenu implements Listener {
                 }
                 setupMenu();
                 if (opened.compareAndSet(false, true)) {
-                    open();
+                    final Player viewer = getPlayer();
+                    if (viewer != null && viewer.isOnline()) {
+                        viewer.openInventory(inventory);
+                        viewer.playSound(viewer.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
+                    }
                 } else {
-                    player.updateInventory();
+                    final Player viewer = getPlayer();
+                    if (viewer != null) {
+                        viewer.updateInventory();
+                    }
                 }
             });
         }).exceptionally(throwable -> {
@@ -73,22 +76,20 @@ public class FriendSettingsMenu implements Listener {
                 }
                 setupMenu();
                 if (opened.compareAndSet(false, true)) {
-                    open();
+                    final Player viewer = getPlayer();
+                    if (viewer != null && viewer.isOnline()) {
+                        viewer.openInventory(inventory);
+                        viewer.playSound(viewer.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
+                    }
                 } else {
-                    player.updateInventory();
+                    final Player viewer = getPlayer();
+                    if (viewer != null) {
+                        viewer.updateInventory();
+                    }
                 }
             });
             return null;
         });
-    }
-
-    public void open() {
-        if (inventory == null) {
-            Bukkit.getScheduler().runTaskLater(plugin, this::open, 2L);
-            return;
-        }
-        player.openInventory(inventory);
-        player.playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
     }
 
     private void setupMenu() {
@@ -362,18 +363,15 @@ public class FriendSettingsMenu implements Listener {
         };
     }
 
-    @EventHandler
-    public void onInventoryClick(final InventoryClickEvent event) {
+    @Override
+    public void handleMenuClick(final InventoryClickEvent event) {
         if (!INVENTORY_TITLE.equals(event.getView().getTitle())) {
             return;
         }
-        if (!(event.getWhoClicked() instanceof Player clicker)) {
+        final Player clicker = getPlayer();
+        if (clicker == null) {
             return;
         }
-        if (!clicker.getUniqueId().equals(player.getUniqueId())) {
-            return;
-        }
-        event.setCancelled(true);
         final int slot = event.getSlot();
         switch (slot) {
             case 10 -> cycleSetting("notifications", Arrays.asList("ALL", "IMPORTANT", "FAVORITES", "NONE"));
@@ -450,25 +448,17 @@ public class FriendSettingsMenu implements Listener {
     private void handleBack() {
         player.closeInventory();
         player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 1.0f, 1.0f);
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            final FriendsMenuController controller = plugin.getFriendsMenuController();
-            if (controller != null) {
-                controller.openMainMenu(player);
-            }
-        }, 2L);
+        Bukkit.getScheduler().runTaskLater(plugin,
+                () -> new FriendsMainMenu(plugin, friendsManager, menuManager, player).open(), 3L);
     }
 
-    @EventHandler
-    public void onInventoryClose(final InventoryCloseEvent event) {
-        if (!(event.getPlayer() instanceof Player viewer)) {
+    @Override
+    public void handleMenuClose(final InventoryCloseEvent event) {
+        if (!INVENTORY_TITLE.equals(event.getView().getTitle())) {
             return;
         }
-        if (!viewer.getUniqueId().equals(player.getUniqueId())) {
-            return;
-        }
-        if (INVENTORY_TITLE.equals(event.getView().getTitle())) {
-            HandlerList.unregisterAll(this);
-        }
+        opened.set(false);
+        super.handleMenuClose(event);
     }
 
     private ItemStack createItem(final Material material, final String name) {
@@ -479,6 +469,16 @@ public class FriendSettingsMenu implements Listener {
             item.setItemMeta(meta);
         }
         return item;
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    @Override
+    public String getTitle() {
+        return INVENTORY_TITLE;
     }
 
     private String formatSettingName(final String setting) {

--- a/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
@@ -7,9 +7,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.HandlerList;
-import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
@@ -24,16 +21,12 @@ import java.util.logging.Level;
  * Modernised friends main menu that focuses on providing immediate feedback
  * to the player while asynchronous data is being fetched.
  */
-public class FriendsMainMenu implements Listener {
+public class FriendsMainMenu extends BaseFriendsMenu {
 
     private static final String MENU_TITLE = "§8» §aMenu des Amis";
     private static final int INVENTORY_SIZE = 54;
 
-    private final LobbyPlugin plugin;
-    private final FriendsManager friendsManager;
-
     private Inventory inventory;
-    private Player viewer;
     private int totalFriends;
     private int onlineFriends;
     private int pendingRequests;
@@ -44,16 +37,24 @@ public class FriendsMainMenu implements Listener {
         Bukkit.getPluginManager().registerEvents(this, plugin);
     }
 
-    public void open(final Player player) {
-        if (player == null) {
+    public FriendsMainMenu(final LobbyPlugin plugin,
+                           final FriendsManager friendsManager,
+                           final FriendsMenuManager menuManager,
+                           final Player player) {
+        super(plugin, friendsManager, menuManager, player);
+    }
+
+    @Override
+    protected void openMenu() {
+        final Player viewer = getPlayer();
+        if (viewer == null || !viewer.isOnline()) {
             return;
         }
-        this.viewer = player;
         this.inventory = Bukkit.createInventory(null, INVENTORY_SIZE, MENU_TITLE);
         setupMenuWithDefaults();
-        player.openInventory(inventory);
-        player.playSound(player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
-        loadDataAndCreateMenu(player);
+        viewer.openInventory(inventory);
+        viewer.playSound(viewer.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.5f);
+        loadDataAndCreateMenu(viewer);
     }
 
     private void loadDataAndCreateMenu(final Player player) {
@@ -88,11 +89,11 @@ public class FriendsMainMenu implements Listener {
                     if (throwable != null) {
                         plugin.getLogger().log(Level.SEVERE, "Erreur lors du chargement des données du menu des amis", throwable);
                     }
-                    if (viewer == null || !viewer.isOnline()) {
+                    if (player == null || !player.isOnline()) {
                         return;
                     }
                     setupMenuWithRealData();
-                    viewer.updateInventory();
+                    player.updateInventory();
                 }));
     }
 
@@ -254,50 +255,47 @@ public class FriendsMainMenu implements Listener {
         return item;
     }
 
-    @EventHandler
-    public void onInventoryClick(final InventoryClickEvent event) {
-        if (!MENU_TITLE.equals(event.getView().getTitle())) {
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    @Override
+    public String getTitle() {
+        return MENU_TITLE;
+    }
+
+    @Override
+    public void handleMenuClick(final InventoryClickEvent event) {
+        if (!titlesMatch(MENU_TITLE, event.getView().getTitle())) {
             return;
         }
-
-        event.setCancelled(true);
-
-        if (!(event.getWhoClicked() instanceof Player player) || viewer == null) {
+        final Player clicker = getPlayer();
+        if (clicker == null) {
             return;
         }
-        if (!player.getUniqueId().equals(viewer.getUniqueId())) {
-            return;
-        }
-
         final int slot = event.getSlot();
         switch (slot) {
-            case 11 -> openFriendsList(player);
-            case 13 -> openAddFriend(player);
-            case 15 -> openRequests(player);
-            case 20 -> openFavorites(player);
-            case 22 -> openSettings(player);
-            case 24 -> openStatistics(player);
-            case 29 -> openBlocked(player);
-            case 49 -> player.closeInventory();
+            case 11 -> openFriendsList(clicker);
+            case 13 -> openAddFriend(clicker);
+            case 15 -> openRequests(clicker);
+            case 20 -> openFavorites(clicker);
+            case 22 -> openSettings(clicker);
+            case 24 -> openStatistics(clicker);
+            case 29 -> openBlocked(clicker);
+            case 49 -> clicker.closeInventory();
             default -> {
             }
         }
     }
 
-    @EventHandler
-    public void onInventoryClose(final InventoryCloseEvent event) {
-        if (viewer == null) {
+    @Override
+    public void handleMenuClose(final InventoryCloseEvent event) {
+        if (!titlesMatch(MENU_TITLE, event.getView().getTitle())) {
             return;
         }
-        if (!MENU_TITLE.equals(event.getView().getTitle())) {
-            return;
-        }
-        if (!event.getPlayer().getUniqueId().equals(viewer.getUniqueId())) {
-            return;
-        }
-        HandlerList.unregisterAll(this);
-        viewer = null;
         inventory = null;
+        super.handleMenuClose(event);
     }
 
     private void openFriendsList(final Player player) {
@@ -326,7 +324,8 @@ public class FriendsMainMenu implements Listener {
         try {
             player.closeInventory();
             player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
-            Bukkit.getScheduler().runTaskLater(plugin, () -> new FriendRequestsMenu(plugin, friendsManager, player), 3L);
+            Bukkit.getScheduler().runTaskLater(plugin,
+                    () -> new FriendRequestsMenu(plugin, friendsManager, menuManager, player).open(), 3L);
         } catch (Exception exception) {
             player.sendMessage("§cErreur lors de l'ouverture des demandes");
             plugin.getLogger().log(Level.SEVERE, "Impossible d'ouvrir les demandes d'amis", exception);
@@ -337,7 +336,8 @@ public class FriendsMainMenu implements Listener {
         try {
             player.closeInventory();
             player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
-            Bukkit.getScheduler().runTaskLater(plugin, () -> new FavoriteFriendsMenu(plugin, friendsManager, player), 3L);
+            Bukkit.getScheduler().runTaskLater(plugin,
+                    () -> new FavoriteFriendsMenu(plugin, friendsManager, menuManager, player).open(), 3L);
         } catch (Exception exception) {
             player.sendMessage("§cErreur lors de l'ouverture des favoris");
             plugin.getLogger().log(Level.SEVERE, "Impossible d'ouvrir les amis favoris", exception);
@@ -348,7 +348,8 @@ public class FriendsMainMenu implements Listener {
         try {
             player.closeInventory();
             player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
-            Bukkit.getScheduler().runTaskLater(plugin, () -> new FriendSettingsMenu(plugin, friendsManager, player).open(), 3L);
+            Bukkit.getScheduler().runTaskLater(plugin,
+                    () -> new FriendSettingsMenu(plugin, friendsManager, menuManager, player).open(), 3L);
         } catch (Exception exception) {
             player.sendMessage("§cErreur lors de l'ouverture des paramètres");
             plugin.getLogger().log(Level.SEVERE, "Impossible d'ouvrir les paramètres d'amis", exception);

--- a/src/main/java/com/lobby/friends/menu/FriendsMenuController.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMenuController.java
@@ -16,15 +16,18 @@ public class FriendsMenuController {
 
     private final LobbyPlugin plugin;
     private final FriendsManager friendsManager;
+    private final FriendsMenuManager friendsMenuManager;
 
     public FriendsMenuController(final LobbyPlugin plugin,
                                  final MenuManager menuManager,
                                  final AssetManager assetManager,
                                  final FriendsDataProvider dataProvider,
                                  final FriendsManager friendsManager,
+                                 final FriendsMenuManager friendsMenuManager,
                                  final FriendsMenuActionHandler actionHandler) {
         this.plugin = plugin;
         this.friendsManager = friendsManager;
+        this.friendsMenuManager = friendsMenuManager;
     }
 
     public void reload() {
@@ -39,7 +42,7 @@ public class FriendsMenuController {
         if (player == null) {
             return false;
         }
-        new FriendsMainMenu(plugin, friendsManager).open(player);
+        new FriendsMainMenu(plugin, friendsManager, friendsMenuManager, player).open();
         return true;
     }
 }

--- a/src/main/java/com/lobby/friends/menu/FriendsMenuManager.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMenuManager.java
@@ -1,0 +1,106 @@
+package com.lobby.friends.menu;
+
+import com.lobby.LobbyPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Centralises every friends related inventory interaction. The manager runs at
+ * {@link EventPriority#HIGHEST} to ensure all move attempts are cancelled even
+ * when Paper processes asynchronous clicks. It also delegates the actual menu
+ * logic to {@link BaseFriendsMenu} instances registered via
+ * {@link #registerMenu(Player, BaseFriendsMenu)}.
+ */
+public class FriendsMenuManager implements Listener {
+
+    private final LobbyPlugin plugin;
+    private final Map<UUID, BaseFriendsMenu> openMenus = new ConcurrentHashMap<>();
+    private final Map<UUID, Long> lastClick = new ConcurrentHashMap<>();
+
+    public FriendsMenuManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void registerMenu(final Player player, final BaseFriendsMenu menu) {
+        if (player == null || menu == null) {
+            return;
+        }
+        openMenus.put(player.getUniqueId(), menu);
+    }
+
+    public void unregisterMenu(final UUID playerId, final BaseFriendsMenu menu) {
+        if (playerId == null) {
+            return;
+        }
+        openMenus.remove(playerId, menu);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    public void onInventoryClick(final InventoryClickEvent event) {
+        final HumanEntity clicker = event.getWhoClicked();
+        if (!(clicker instanceof Player player)) {
+            return;
+        }
+        final String title = event.getView().getTitle();
+        if (title == null || !title.contains("§8» §")) {
+            return;
+        }
+
+        event.setCancelled(true);
+        event.setResult(Event.Result.DENY);
+
+        final long now = System.currentTimeMillis();
+        final long last = lastClick.getOrDefault(player.getUniqueId(), 0L);
+        if (now - last < 100L) {
+            return;
+        }
+        lastClick.put(player.getUniqueId(), now);
+
+        final BaseFriendsMenu menu = openMenus.get(player.getUniqueId());
+        if (menu == null) {
+            return;
+        }
+
+        Bukkit.getScheduler().runTask(plugin, () -> menu.handleMenuClick(event));
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    public void onInventoryClose(final InventoryCloseEvent event) {
+        final HumanEntity human = event.getPlayer();
+        if (!(human instanceof Player player)) {
+            return;
+        }
+        final BaseFriendsMenu menu = openMenus.get(player.getUniqueId());
+        if (menu == null) {
+            return;
+        }
+        final String title = event.getView().getTitle();
+        if (title == null || !title.contains("§8» §")) {
+            unregisterMenu(player.getUniqueId(), menu);
+            return;
+        }
+        menu.handleMenuClose(event);
+    }
+
+    public void safeRefresh(final BaseFriendsMenu menu) {
+        final Player player = menu.getPlayer();
+        if (player == null || !player.isOnline()) {
+            return;
+        }
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            player.closeInventory();
+            Bukkit.getScheduler().runTaskLater(plugin, menu::reopen, 1L);
+        }, 1L);
+    }
+}

--- a/src/main/java/com/lobby/menus/ConfiguredMenu.java
+++ b/src/main/java/com/lobby/menus/ConfiguredMenu.java
@@ -3,6 +3,7 @@ package com.lobby.menus;
 import com.lobby.LobbyPlugin;
 import com.lobby.friends.manager.FriendsManager;
 import com.lobby.friends.menu.FriendsMainMenu;
+import com.lobby.friends.menu.FriendsMenuManager;
 import com.lobby.servers.ServerManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
@@ -260,9 +261,15 @@ public final class ConfiguredMenu implements Menu, InventoryHolder {
             player.sendMessage("§cLe système d'amis est indisponible pour le moment.");
             return;
         }
+        final FriendsMenuManager friendsMenuManager = plugin.getFriendsMenuManager();
+        if (friendsMenuManager == null) {
+            player.sendMessage("§cLe gestionnaire de menus d'amis est indisponible.");
+            return;
+        }
         player.closeInventory();
         player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1.0f, 1.0f);
-        Bukkit.getScheduler().runTaskLater(plugin, () -> new FriendsMainMenu(plugin, friendsManager).open(player), 3L);
+        Bukkit.getScheduler().runTaskLater(plugin,
+                () -> new FriendsMainMenu(plugin, friendsManager, friendsMenuManager, player).open(), 3L);
     }
 
     private Map<String, String> buildPlaceholderMap(final Player player) {


### PR DESCRIPTION
## Summary
- centralize friends inventory handling through a shared BaseFriendsMenu and FriendsMenuManager with anti-spam safeguards
- refactor main, favorites, requests, and settings friend menus to use the shared infrastructure and improved navigation/refresh logic
- add YAML configuration templates for all friends menus and ensure plugin components and commands rely on the new manager

## Testing
- mvn -q -DskipTests package *(fails: cannot download Paper/PlaceholderAPI artifacts from papermc repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e7d8e27c8329b54950e03a5243f7