### PR TITLE
Fix friends menu construction and inventory title access

### DIFF
--- a/src/main/java/com/lobby/friends/menu/FavoriteFriendsMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FavoriteFriendsMenu.java
@@ -22,8 +22,11 @@ import java.util.List;
 
 public class FavoriteFriendsMenu extends BaseFriendsMenu {
 
+    private static final String BASE_TITLE = "§8» §eAmis Favoris";
+
     private Inventory inventory;
     private List<FriendData> favoriteFriends;
+    private String currentTitle = BASE_TITLE;
 
     // Slots pour favoris
     private final int[] favoriteSlots = {
@@ -77,8 +80,8 @@ public class FavoriteFriendsMenu extends BaseFriendsMenu {
         int favoriteCount = favoriteFriends.size();
         int favoriteLimit = 5;
         
-        String title = "§8» §eAmis Favoris (" + favoriteCount + "/" + favoriteLimit + ")";
-        this.inventory = Bukkit.createInventory(null, 54, title);
+        currentTitle = BASE_TITLE + " (" + favoriteCount + "/" + favoriteLimit + ")";
+        this.inventory = Bukkit.createInventory(null, 54, currentTitle);
         setupMenu();
     }
     
@@ -236,7 +239,7 @@ public class FavoriteFriendsMenu extends BaseFriendsMenu {
     @Override
     public void handleMenuClick(final InventoryClickEvent event) {
         final String title = event.getView().getTitle();
-        if (title == null || !title.contains("§8» §eAmis Favoris")) {
+        if (title == null || !title.contains(BASE_TITLE)) {
             return;
         }
         final Player clicker = getPlayer();
@@ -317,7 +320,7 @@ public class FavoriteFriendsMenu extends BaseFriendsMenu {
 
     @Override
     public void handleMenuClose(final InventoryCloseEvent event) {
-        if (event.getView().getTitle() == null || !event.getView().getTitle().contains("§8» §eAmis Favoris")) {
+        if (event.getView().getTitle() == null || !event.getView().getTitle().contains(BASE_TITLE)) {
             return;
         }
         inventory = null;
@@ -331,7 +334,7 @@ public class FavoriteFriendsMenu extends BaseFriendsMenu {
 
     @Override
     public String getTitle() {
-        return inventory != null ? inventory.getTitle() : "§8» §eAmis Favoris";
+        return currentTitle;
     }
 }
 

--- a/src/main/java/com/lobby/friends/menu/FriendRequestsMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FriendRequestsMenu.java
@@ -36,6 +36,7 @@ public class FriendRequestsMenu extends BaseFriendsMenu {
     private static final int[] GLASS_SLOTS = {0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 46, 52, 53};
 
     private Inventory inventory;
+    private String currentTitle = TITLE_PREFIX;
     private List<FriendRequest> allRequests = new ArrayList<>();
 
     public FriendRequestsMenu(final LobbyPlugin plugin,
@@ -66,8 +67,8 @@ public class FriendRequestsMenu extends BaseFriendsMenu {
     }
 
     private void createMenu() {
-        final String title = TITLE_PREFIX + " (" + allRequests.size() + ")";
-        inventory = Bukkit.createInventory(null, INVENTORY_SIZE, title);
+        currentTitle = TITLE_PREFIX + " (" + allRequests.size() + ")";
+        inventory = Bukkit.createInventory(null, INVENTORY_SIZE, currentTitle);
         setupMenu();
         final Player viewer = getPlayer();
         if (viewer != null && viewer.isOnline()) {
@@ -287,6 +288,6 @@ public class FriendRequestsMenu extends BaseFriendsMenu {
 
     @Override
     public String getTitle() {
-        return inventory != null ? inventory.getTitle() : TITLE_PREFIX;
+        return currentTitle;
     }
 }

--- a/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
+++ b/src/main/java/com/lobby/friends/menu/FriendsMainMenu.java
@@ -31,12 +31,6 @@ public class FriendsMainMenu extends BaseFriendsMenu {
     private int onlineFriends;
     private int pendingRequests;
 
-    public FriendsMainMenu(final LobbyPlugin plugin, final FriendsManager friendsManager) {
-        this.plugin = plugin;
-        this.friendsManager = friendsManager;
-        Bukkit.getPluginManager().registerEvents(this, plugin);
-    }
-
     public FriendsMainMenu(final LobbyPlugin plugin,
                            final FriendsManager friendsManager,
                            final FriendsMenuManager menuManager,


### PR DESCRIPTION
## Summary
- ensure FriendsMainMenu delegates initialization to BaseFriendsMenu
- cache generated titles in favorite and request menus instead of calling the removed Inventory#getTitle

## Testing
- mvn -q -DskipTests package *(fails: dependency downloads blocked by papermc repository 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ee4d1db48329b3af12847f1912d4