### PR TITLE
Add chat listener to drive friend requests

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -18,6 +18,7 @@ import com.lobby.menus.prompt.ChatPromptManager;
 import com.lobby.menus.confirmation.ConfirmationManager;
 import com.lobby.friends.DefaultFriendsDataProvider;
 import com.lobby.friends.commands.FriendsTestCommand;
+import com.lobby.friends.listeners.FriendAddChatListener;
 import com.lobby.friends.manager.FriendsConfigGenerator;
 import com.lobby.friends.manager.FriendsManager;
 import com.lobby.friends.menu.DefaultFriendsMenuActionHandler;
@@ -75,6 +76,7 @@ public final class LobbyPlugin extends JavaPlugin {
     private FriendsManager friendsManager;
     private FriendsMenuController friendsMenuController;
     private FriendsMenuManager friendsMenuManager;
+    private FriendAddChatListener friendAddChatListener;
 
     public static LobbyPlugin getInstance() {
         return instance;
@@ -122,6 +124,9 @@ public final class LobbyPlugin extends JavaPlugin {
         confirmationManager = new ConfirmationManager(this);
         friendsDataProvider = new DefaultFriendsDataProvider();
         friendsManager = new FriendsManager(this);
+        friendAddChatListener = new FriendAddChatListener(this);
+        getServer().getPluginManager().registerEvents(friendAddChatListener, this);
+        getLogger().info("Listener d'ajout d'amis enregistré !");
         new FriendsConfigGenerator(this).generate();
         friendsMenuManager = new FriendsMenuManager(this);
         getServer().getPluginManager().registerEvents(friendsMenuManager, this);
@@ -212,6 +217,7 @@ public final class LobbyPlugin extends JavaPlugin {
         }
         friendsMenuController = null;
         friendsDataProvider = null;
+        friendAddChatListener = null;
         instance = null;
     }
 
@@ -313,6 +319,10 @@ public final class LobbyPlugin extends JavaPlugin {
 
     public FriendsMenuManager getFriendsMenuManager() {
         return friendsMenuManager;
+    }
+
+    public FriendAddChatListener getFriendAddChatListener() {
+        return friendAddChatListener;
     }
 
     public void reloadLobbyConfig() {

--- a/src/main/java/com/lobby/core/DatabaseManager.java
+++ b/src/main/java/com/lobby/core/DatabaseManager.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.logging.Level;
 
 public class DatabaseManager {
@@ -199,6 +200,24 @@ public class DatabaseManager {
 
         plugin.getLogger().info("Database initialization completed successfully!");
         return true;
+    }
+
+    public UUID getPlayerUUID(final String playerName) {
+        final String query = "SELECT uuid FROM players WHERE username = ? ORDER BY last_seen DESC LIMIT 1";
+
+        try (Connection connection = getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerName);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return UUID.fromString(resultSet.getString("uuid"));
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().severe("Erreur lors de la recherche UUID pour " + playerName + ": " + exception.getMessage());
+        }
+
+        return null;
     }
 
     private void createCoreTablesWithoutFK() throws SQLException {

--- a/src/main/java/com/lobby/friends/listeners/FriendAddChatListener.java
+++ b/src/main/java/com/lobby/friends/listeners/FriendAddChatListener.java
@@ -1,0 +1,169 @@
+package com.lobby.friends.listeners;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.core.DatabaseManager;
+import com.lobby.friends.manager.FriendsManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class FriendAddChatListener implements Listener {
+
+    private static final String MODE_SEARCH_PLAYER_NAME = "search_player_name";
+
+    private final LobbyPlugin plugin;
+    private final FriendsManager friendsManager;
+    private final Map<UUID, String> pendingRequests = new ConcurrentHashMap<>();
+
+    public FriendAddChatListener(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        this.friendsManager = plugin.getFriendsManager();
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerChat(final AsyncPlayerChatEvent event) {
+        final Player player = event.getPlayer();
+        final UUID playerUUID = player.getUniqueId();
+
+        if (!pendingRequests.containsKey(playerUUID)) {
+            return;
+        }
+
+        event.setCancelled(true);
+
+        final String mode = pendingRequests.get(playerUUID);
+        final String input = event.getMessage().trim();
+
+        if (input.equalsIgnoreCase("annuler") || input.equalsIgnoreCase("cancel")) {
+            pendingRequests.remove(playerUUID);
+            player.sendMessage("§c❌ Ajout d'ami annulé");
+            return;
+        }
+
+        pendingRequests.remove(playerUUID);
+
+        if (MODE_SEARCH_PLAYER_NAME.equals(mode)) {
+            handleAddByName(player, input);
+            return;
+        }
+
+        player.sendMessage("§c❌ Mode d'ajout non reconnu !");
+    }
+
+    private void handleAddByName(final Player player, final String targetName) {
+        if (targetName.length() < 3 || targetName.length() > 16) {
+            player.sendMessage("§c❌ Nom d'utilisateur invalide ! (3-16 caractères requis)");
+            return;
+        }
+
+        if (!targetName.matches("[a-zA-Z0-9_]+")) {
+            player.sendMessage("§c❌ Le nom ne peut contenir que des lettres, chiffres et _ !");
+            return;
+        }
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final UUID targetUUID = getPlayerUUID(targetName);
+
+            if (targetUUID == null) {
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    player.sendMessage("§c❌ Joueur '" + targetName + "' introuvable !");
+                    player.sendMessage("§7Vérifiez l'orthographe du nom d'utilisateur");
+                });
+                return;
+            }
+
+            Bukkit.getScheduler().runTask(plugin, () -> processFriendRequest(player, targetUUID, targetName));
+        });
+    }
+
+    private void processFriendRequest(final Player sender, final UUID targetUUID, final String targetName) {
+        final UUID senderUUID = sender.getUniqueId();
+
+        if (targetUUID.equals(senderUUID)) {
+            sender.sendMessage("§c❌ Vous ne pouvez pas vous ajouter vous-même !");
+            return;
+        }
+
+        if (friendsManager.areFriends(senderUUID, targetUUID)) {
+            sender.sendMessage("§c❌ Vous êtes déjà amis avec §e" + targetName + "§c !");
+            return;
+        }
+
+        if (friendsManager.hasPendingRequest(senderUUID, targetUUID)) {
+            sender.sendMessage("§c❌ Une demande d'ami est déjà en attente pour §e" + targetName + "§c !");
+            return;
+        }
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final boolean success = friendsManager.sendFriendRequest(senderUUID, targetUUID);
+
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (success) {
+                    sender.sendMessage("§a✅ Demande d'ami envoyée à §2" + targetName + "§a !");
+                    sender.sendMessage("§7La demande expire dans §a7 jours");
+
+                    final Player target = Bukkit.getPlayer(targetUUID);
+                    if (target != null) {
+                        target.sendMessage("§e📬 §6" + sender.getName() + "§e vous a envoyé une demande d'ami !");
+                        target.sendMessage("§7Tapez §a/friend accept " + sender.getName() + "§7 pour accepter");
+                        target.sendMessage("§7Ou ouvrez le menu amis §a/friends");
+                        target.playSound(target.getLocation(), "entity.experience_orb.pickup", 1.0f, 1.2f);
+                    }
+                    return;
+                }
+
+                sender.sendMessage("§c❌ Erreur lors de l'envoi de la demande !");
+                sender.sendMessage("§7Veuillez réessayer plus tard");
+            });
+        });
+    }
+
+    public void enableAddMode(final Player player, final String mode) {
+        final UUID playerUUID = player.getUniqueId();
+        pendingRequests.put(playerUUID, mode);
+
+        if (MODE_SEARCH_PLAYER_NAME.equals(mode)) {
+            player.sendMessage("§e🔍 §6Tapez le nom exact du joueur à ajouter:");
+            player.sendMessage("§7Exemple: §aSteve §7ou §aPlayer123");
+            player.sendMessage("§7Tapez §c'annuler'§7 pour annuler");
+        }
+
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (pendingRequests.containsKey(playerUUID)) {
+                pendingRequests.remove(playerUUID);
+                player.sendMessage("§c⏰ Temps d'attente écoulé - Ajout d'ami annulé");
+            }
+        }, 20L * 30);
+    }
+
+    private UUID getPlayerUUID(final String playerName) {
+        final Player onlinePlayer = Bukkit.getPlayerExact(playerName);
+        if (onlinePlayer != null) {
+            return onlinePlayer.getUniqueId();
+        }
+
+        final DatabaseManager databaseManager = plugin.getDatabaseManager();
+        if (databaseManager == null) {
+            return null;
+        }
+
+        return databaseManager.getPlayerUUID(playerName);
+    }
+
+    public boolean isInAddMode(final Player player) {
+        return pendingRequests.containsKey(player.getUniqueId());
+    }
+
+    public void cancelAddMode(final Player player) {
+        if (pendingRequests.remove(player.getUniqueId()) != null) {
+            player.sendMessage("§c❌ Ajout d'ami annulé");
+        }
+    }
+}

--- a/src/main/java/com/lobby/friends/menu/AddFriendMenu.java
+++ b/src/main/java/com/lobby/friends/menu/AddFriendMenu.java
@@ -1,6 +1,7 @@
 package com.lobby.friends.menu;
 
 import com.lobby.LobbyPlugin;
+import com.lobby.friends.listeners.FriendAddChatListener;
 import com.lobby.friends.manager.FriendsManager;
 import com.lobby.friends.menu.FriendsMainMenu;
 import com.lobby.friends.menu.FriendsMenuManager;
@@ -234,9 +235,12 @@ public class AddFriendMenu implements Listener {
 
     private void handleSearch() {
         player.closeInventory();
-        player.sendMessage("§b🔍 Recherche de joueur");
-        player.sendMessage("§7Tapez le nom du joueur dans le chat:");
-        player.sendMessage("§7(ou tapez 'cancel' pour annuler)");
+        final FriendAddChatListener listener = plugin.getFriendAddChatListener();
+        if (listener == null) {
+            player.sendMessage("§cLe système d'ajout via le chat est indisponible.");
+            return;
+        }
+        listener.enableAddMode(player, "search_player_name");
         player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1.0f, 1.5f);
     }
 


### PR DESCRIPTION
## Summary
- add a dedicated FriendAddChatListener to capture chat input for friend name search and deliver requests
- register the listener in LobbyPlugin, expose it for menus, and add a database lookup for offline players
- hook the AddFriendMenu search action into the listener-driven workflow

## Testing
- `mvn -q -DskipTests package` *(fails: remote PaperMC repository returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d8096ca8f883298a9b63b15f68186b