### PR TITLE
Fix FriendAddChatListener compatibility with FriendsManager

### DIFF
--- a/src/main/java/com/lobby/friends/listeners/FriendAddChatListener.java
+++ b/src/main/java/com/lobby/friends/listeners/FriendAddChatListener.java
@@ -2,6 +2,8 @@ package com.lobby.friends.listeners;
 
 import com.lobby.LobbyPlugin;
 import com.lobby.core.DatabaseManager;
+import com.lobby.friends.data.FriendData;
+import com.lobby.friends.data.FriendRequest;
 import com.lobby.friends.manager.FriendsManager;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -10,8 +12,10 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class FriendAddChatListener implements Listener {
@@ -43,7 +47,7 @@ public class FriendAddChatListener implements Listener {
 
         if (input.equalsIgnoreCase("annuler") || input.equalsIgnoreCase("cancel")) {
             pendingRequests.remove(playerUUID);
-            player.sendMessage("§c❌ Ajout d'ami annulé");
+            Bukkit.getScheduler().runTask(plugin, () -> player.sendMessage("§c❌ Ajout d'ami annulé"));
             return;
         }
 
@@ -54,7 +58,7 @@ public class FriendAddChatListener implements Listener {
             return;
         }
 
-        player.sendMessage("§c❌ Mode d'ajout non reconnu !");
+        Bukkit.getScheduler().runTask(plugin, () -> player.sendMessage("§c❌ Mode d'ajout non reconnu !"));
     }
 
     private void handleAddByName(final Player player, final String targetName) {
@@ -91,38 +95,60 @@ public class FriendAddChatListener implements Listener {
             return;
         }
 
-        if (friendsManager.areFriends(senderUUID, targetUUID)) {
-            sender.sendMessage("§c❌ Vous êtes déjà amis avec §e" + targetName + "§c !");
-            return;
-        }
-
-        if (friendsManager.hasPendingRequest(senderUUID, targetUUID)) {
-            sender.sendMessage("§c❌ Une demande d'ami est déjà en attente pour §e" + targetName + "§c !");
-            return;
-        }
-
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            final boolean success = friendsManager.sendFriendRequest(senderUUID, targetUUID);
-
-            Bukkit.getScheduler().runTask(plugin, () -> {
-                if (success) {
-                    sender.sendMessage("§a✅ Demande d'ami envoyée à §2" + targetName + "§a !");
-                    sender.sendMessage("§7La demande expire dans §a7 jours");
-
-                    final Player target = Bukkit.getPlayer(targetUUID);
-                    if (target != null) {
-                        target.sendMessage("§e📬 §6" + sender.getName() + "§e vous a envoyé une demande d'ami !");
-                        target.sendMessage("§7Tapez §a/friend accept " + sender.getName() + "§7 pour accepter");
-                        target.sendMessage("§7Ou ouvrez le menu amis §a/friends");
-                        target.playSound(target.getLocation(), "entity.experience_orb.pickup", 1.0f, 1.2f);
+        friendsManager.getFriends(sender)
+                .thenCompose(friends -> {
+                    if (isAlreadyFriend(friends, targetUUID)) {
+                        Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage("§c❌ Vous êtes déjà amis avec §e" + targetName + "§c !"));
+                        return CompletableFuture.completedFuture(null);
                     }
-                    return;
-                }
 
-                sender.sendMessage("§c❌ Erreur lors de l'envoi de la demande !");
-                sender.sendMessage("§7Veuillez réessayer plus tard");
-            });
-        });
+                    return friendsManager.getPendingRequests(sender).thenCompose(requests -> {
+                        if (hasIncomingRequest(requests, targetUUID)) {
+                            Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage("§c❌ Une demande de §e" + targetName + "§c est déjà en attente !"));
+                            return CompletableFuture.completedFuture(null);
+                        }
+
+                        return hasOutgoingRequest(sender, targetUUID).thenCompose(hasOutgoing -> {
+                            if (hasOutgoing) {
+                                Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage("§c❌ Vous avez déjà envoyé une demande à §e" + targetName + "§c !"));
+                                return CompletableFuture.completedFuture(null);
+                            }
+
+                            return friendsManager.sendFriendRequest(sender, targetName, "Demande d'ami");
+                        });
+                    });
+                })
+                .thenAccept(success -> {
+                    if (success == null) {
+                        return;
+                    }
+
+                    if (success) {
+                        Bukkit.getScheduler().runTask(plugin, () -> {
+                            sender.sendMessage("§a✅ Demande d'ami envoyée à §2" + targetName + "§a !");
+                            sender.sendMessage("§7La demande expire dans §a7 jours");
+
+                            final Player target = Bukkit.getPlayer(targetUUID);
+                            if (target != null) {
+                                target.sendMessage("§e📬 §6" + sender.getName() + "§e vous a envoyé une demande d'ami !");
+                                target.sendMessage("§7Tapez §a/friend accept " + sender.getName() + "§7 pour accepter");
+                                target.sendMessage("§7Ou ouvrez le menu amis §a/friends");
+                                target.playSound(target.getLocation(), "entity.experience_orb.pickup", 1.0f, 1.2f);
+                            }
+                        });
+                        return;
+                    }
+
+                    Bukkit.getScheduler().runTask(plugin, () -> {
+                        sender.sendMessage("§c❌ Erreur lors de l'envoi de la demande !");
+                        sender.sendMessage("§7Veuillez réessayer plus tard");
+                    });
+                })
+                .exceptionally(exception -> {
+                    plugin.getLogger().severe("Erreur lors de l'envoi de demande d'ami: " + exception.getMessage());
+                    Bukkit.getScheduler().runTask(plugin, () -> sender.sendMessage("§c❌ Erreur lors de l'envoi de la demande !"));
+                    return null;
+                });
     }
 
     public void enableAddMode(final Player player, final String mode) {
@@ -150,11 +176,19 @@ public class FriendAddChatListener implements Listener {
         }
 
         final DatabaseManager databaseManager = plugin.getDatabaseManager();
-        if (databaseManager == null) {
-            return null;
+        if (databaseManager != null) {
+            final UUID databaseUuid = databaseManager.getPlayerUUID(playerName);
+            if (databaseUuid != null) {
+                return databaseUuid;
+            }
         }
 
-        return databaseManager.getPlayerUUID(playerName);
+        try {
+            return Bukkit.getOfflinePlayer(playerName).getUniqueId();
+        } catch (final Exception exception) {
+            plugin.getLogger().warning("Impossible de trouver l'UUID pour " + playerName + ": " + exception.getMessage());
+            return null;
+        }
     }
 
     public boolean isInAddMode(final Player player) {
@@ -165,5 +199,36 @@ public class FriendAddChatListener implements Listener {
         if (pendingRequests.remove(player.getUniqueId()) != null) {
             player.sendMessage("§c❌ Ajout d'ami annulé");
         }
+    }
+
+    private boolean isAlreadyFriend(final List<FriendData> friends, final UUID targetUUID) {
+        if (friends == null) {
+            return false;
+        }
+        final String target = targetUUID.toString();
+        return friends.stream().anyMatch(data -> target.equalsIgnoreCase(data.getUuid()));
+    }
+
+    private boolean hasIncomingRequest(final List<FriendRequest> requests, final UUID targetUUID) {
+        if (requests == null) {
+            return false;
+        }
+        final String target = targetUUID.toString();
+        return requests.stream().anyMatch(request -> target.equalsIgnoreCase(request.getSenderUuid()));
+    }
+
+    private CompletableFuture<Boolean> hasOutgoingRequest(final Player sender, final UUID targetUUID) {
+        final Player target = Bukkit.getPlayer(targetUUID);
+        if (target == null) {
+            return CompletableFuture.completedFuture(false);
+        }
+
+        return friendsManager.getPendingRequests(target).thenApply(requests -> {
+            if (requests == null) {
+                return false;
+            }
+            final String senderId = sender.getUniqueId().toString();
+            return requests.stream().anyMatch(request -> senderId.equalsIgnoreCase(request.getSenderUuid()));
+        });
     }
 }


### PR DESCRIPTION
## Summary
- align FriendAddChatListener with the async FriendsManager API to restore compilation
- add guard rails for duplicate friend requests and enhanced player feedback
- keep name search responsive by looking up UUIDs via the database and offline cache

## Testing
- `mvn -q -e -DskipTests compile` *(fails: dependency download blocked by 403 from papermc repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d80bef449483299f02eedeb9a99a67