### PR TITLE
Implement unique friend code generation and lookup

### DIFF
--- a/src/main/java/com/lobby/LobbyPlugin.java
+++ b/src/main/java/com/lobby/LobbyPlugin.java
@@ -19,6 +19,7 @@ import com.lobby.menus.confirmation.ConfirmationManager;
 import com.lobby.friends.DefaultFriendsDataProvider;
 import com.lobby.friends.commands.FriendsTestCommand;
 import com.lobby.friends.listeners.FriendAddChatListener;
+import com.lobby.friends.manager.FriendCodeManager;
 import com.lobby.friends.manager.FriendsConfigGenerator;
 import com.lobby.friends.manager.FriendsManager;
 import com.lobby.friends.menu.DefaultFriendsMenuActionHandler;
@@ -73,6 +74,7 @@ public final class LobbyPlugin extends JavaPlugin {
     private NametagManager nametagManager;
     private TablistManager tablistManager;
     private DefaultFriendsDataProvider friendsDataProvider;
+    private FriendCodeManager friendCodeManager;
     private FriendsManager friendsManager;
     private FriendsMenuController friendsMenuController;
     private FriendsMenuManager friendsMenuManager;
@@ -123,6 +125,8 @@ public final class LobbyPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(chatPromptManager, this);
         confirmationManager = new ConfirmationManager(this);
         friendsDataProvider = new DefaultFriendsDataProvider();
+        friendCodeManager = new FriendCodeManager(this);
+        getLogger().info("Gestionnaire de codes d'amis initialisé !");
         friendsManager = new FriendsManager(this);
         friendAddChatListener = new FriendAddChatListener(this);
         getServer().getPluginManager().registerEvents(friendAddChatListener, this);
@@ -146,7 +150,7 @@ public final class LobbyPlugin extends JavaPlugin {
 
         registerCommands();
 
-        getServer().getPluginManager().registerEvents(new PlayerJoinLeaveEvent(playerDataManager, economyManager), this);
+        getServer().getPluginManager().registerEvents(new PlayerJoinLeaveEvent(this, playerDataManager, economyManager), this);
         getServer().getPluginManager().registerEvents(new LobbyPlayerListener(lobbyManager), this);
         getServer().getPluginManager().registerEvents(new LobbyItemListener(lobbyManager, lobbyManager.getItemManager()), this);
         getServer().getPluginManager().registerEvents(new LobbyProtectionListener(lobbyManager), this);
@@ -323,6 +327,10 @@ public final class LobbyPlugin extends JavaPlugin {
 
     public FriendAddChatListener getFriendAddChatListener() {
         return friendAddChatListener;
+    }
+
+    public FriendCodeManager getFriendCodeManager() {
+        return friendCodeManager;
     }
 
     public void reloadLobbyConfig() {

--- a/src/main/java/com/lobby/events/PlayerJoinLeaveEvent.java
+++ b/src/main/java/com/lobby/events/PlayerJoinLeaveEvent.java
@@ -1,5 +1,6 @@
 package com.lobby.events;
 
+import com.lobby.LobbyPlugin;
 import com.lobby.core.PlayerDataManager;
 import com.lobby.economy.EconomyManager;
 import com.lobby.utils.MessageUtils;
@@ -10,12 +11,18 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
+import java.util.UUID;
+
 public class PlayerJoinLeaveEvent implements Listener {
 
+    private final LobbyPlugin plugin;
     private final PlayerDataManager playerDataManager;
     private final EconomyManager economyManager;
 
-    public PlayerJoinLeaveEvent(final PlayerDataManager playerDataManager, final EconomyManager economyManager) {
+    public PlayerJoinLeaveEvent(final LobbyPlugin plugin,
+                                final PlayerDataManager playerDataManager,
+                                final EconomyManager economyManager) {
+        this.plugin = plugin;
         this.playerDataManager = playerDataManager;
         this.economyManager = economyManager;
     }
@@ -29,6 +36,31 @@ public class PlayerJoinLeaveEvent implements Listener {
             economyManager.handlePlayerJoin(player.getUniqueId(), player.getName());
         }
         broadcastConnectionMessage("&7[&a+&7] &a" + player.getName());
+
+        final UUID playerUuid = player.getUniqueId();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            if (plugin.getFriendCodeManager() == null) {
+                return;
+            }
+
+            final String existingCode = plugin.getFriendCodeManager().getPlayerCode(playerUuid);
+            if (existingCode != null) {
+                return;
+            }
+
+            final String newCode = plugin.getFriendCodeManager().generateUniqueCode(playerUuid);
+            if (newCode == null) {
+                return;
+            }
+
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                final Player online = Bukkit.getPlayer(playerUuid);
+                if (online != null) {
+                    online.sendMessage("§a✅ Votre code d'ami a été généré : §2" + newCode);
+                    online.sendMessage("§7Partagez-le pour que d'autres puissent vous ajouter !");
+                }
+            });
+        });
     }
 
     @EventHandler

--- a/src/main/java/com/lobby/friends/listeners/FriendAddChatListener.java
+++ b/src/main/java/com/lobby/friends/listeners/FriendAddChatListener.java
@@ -4,6 +4,7 @@ import com.lobby.LobbyPlugin;
 import com.lobby.core.DatabaseManager;
 import com.lobby.friends.data.FriendData;
 import com.lobby.friends.data.FriendRequest;
+import com.lobby.friends.manager.FriendCodeManager;
 import com.lobby.friends.manager.FriendsManager;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -12,7 +13,12 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -21,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class FriendAddChatListener implements Listener {
 
     private static final String MODE_SEARCH_PLAYER_NAME = "search_player_name";
+    private static final String MODE_FRIEND_CODE = "friend_code";
 
     private final LobbyPlugin plugin;
     private final FriendsManager friendsManager;
@@ -58,6 +65,11 @@ public class FriendAddChatListener implements Listener {
             return;
         }
 
+        if (MODE_FRIEND_CODE.equals(mode)) {
+            handleAddByCode(player, input);
+            return;
+        }
+
         Bukkit.getScheduler().runTask(plugin, () -> player.sendMessage("§c❌ Mode d'ajout non reconnu !"));
     }
 
@@ -84,6 +96,50 @@ public class FriendAddChatListener implements Listener {
             }
 
             Bukkit.getScheduler().runTask(plugin, () -> processFriendRequest(player, targetUUID, targetName));
+        });
+    }
+
+    private void handleAddByCode(final Player player, final String rawInput) {
+        final FriendCodeManager friendCodeManager = plugin.getFriendCodeManager();
+        if (friendCodeManager == null) {
+            Bukkit.getScheduler().runTask(plugin, () ->
+                    player.sendMessage("§c❌ Le système de codes d'amis est indisponible."));
+            return;
+        }
+
+        final String normalized = normalizeFriendCode(rawInput);
+        if (normalized == null) {
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                player.sendMessage("§c❌ Format de code invalide !");
+                player.sendMessage("§7Le format correct est §dXXXX-YYYY§7.");
+            });
+            return;
+        }
+
+        final UUID senderUuid = player.getUniqueId();
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final UUID targetUuid = friendCodeManager.getPlayerByCode(normalized);
+            if (targetUuid == null) {
+                Bukkit.getScheduler().runTask(plugin, () ->
+                        player.sendMessage("§c❌ Code d'ami invalide ou inexistant !"));
+                return;
+            }
+
+            if (targetUuid.equals(senderUuid)) {
+                Bukkit.getScheduler().runTask(plugin, () ->
+                        player.sendMessage("§c❌ Vous ne pouvez pas utiliser votre propre code !"));
+                return;
+            }
+
+            final String targetName = fetchPlayerName(targetUuid);
+            if (targetName == null) {
+                Bukkit.getScheduler().runTask(plugin, () ->
+                        player.sendMessage("§c❌ Impossible de trouver le joueur associé à ce code."));
+                return;
+            }
+
+            Bukkit.getScheduler().runTask(plugin, () ->
+                    processFriendRequest(player, targetUuid, targetName));
         });
     }
 
@@ -155,10 +211,45 @@ public class FriendAddChatListener implements Listener {
         final UUID playerUUID = player.getUniqueId();
         pendingRequests.put(playerUUID, mode);
 
-        if (MODE_SEARCH_PLAYER_NAME.equals(mode)) {
-            player.sendMessage("§e🔍 §6Tapez le nom exact du joueur à ajouter:");
-            player.sendMessage("§7Exemple: §aSteve §7ou §aPlayer123");
-            player.sendMessage("§7Tapez §c'annuler'§7 pour annuler");
+        switch (mode) {
+            case MODE_SEARCH_PLAYER_NAME -> {
+                player.sendMessage("§e🔍 §6Tapez le nom exact du joueur à ajouter:");
+                player.sendMessage("§7Exemple: §aSteve §7ou §aPlayer123");
+                player.sendMessage("§7Tapez §c'annuler'§7 pour annuler");
+            }
+            case MODE_FRIEND_CODE -> {
+                player.sendMessage("§d💾 Ajout via code d'ami activé !");
+                player.sendMessage("§7Saisissez un code au format §dXXXX-YYYY§7.");
+                player.sendMessage("§7Tapez §c'annuler'§7 pour annuler");
+
+                final FriendCodeManager codeManager = plugin.getFriendCodeManager();
+                if (codeManager == null) {
+                    player.sendMessage("§c❌ Le système de codes d'amis est indisponible.");
+                    break;
+                }
+
+                Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+                    String code = codeManager.getPlayerCode(playerUUID);
+                    if (code == null) {
+                        code = codeManager.generateUniqueCode(playerUUID);
+                    }
+                    final String resolvedCode = code;
+                    Bukkit.getScheduler().runTask(plugin, () -> {
+                        if (!player.isOnline()) {
+                            return;
+                        }
+                        if (!MODE_FRIEND_CODE.equals(pendingRequests.get(playerUUID))) {
+                            return;
+                        }
+                        if (resolvedCode != null) {
+                            player.sendMessage("§d▸ Votre code : §f" + resolvedCode);
+                        } else {
+                            player.sendMessage("§c❌ Impossible de récupérer votre code d'ami pour le moment.");
+                        }
+                    });
+                });
+            }
+            default -> player.sendMessage("§c❌ Mode d'ajout non reconnu !");
         }
 
         Bukkit.getScheduler().runTaskLater(plugin, () -> {
@@ -167,6 +258,49 @@ public class FriendAddChatListener implements Listener {
                 player.sendMessage("§c⏰ Temps d'attente écoulé - Ajout d'ami annulé");
             }
         }, 20L * 30);
+    }
+
+    public void enableFriendCodeMode(final Player player) {
+        enableAddMode(player, MODE_FRIEND_CODE);
+    }
+
+    private String normalizeFriendCode(final String input) {
+        if (input == null) {
+            return null;
+        }
+
+        String sanitized = input.trim().toUpperCase(Locale.ROOT).replace(" ", "");
+        if (sanitized.length() == 8 && !sanitized.contains("-")) {
+            sanitized = sanitized.substring(0, 4) + "-" + sanitized.substring(4);
+        }
+
+        if (!sanitized.matches("[A-Z0-9]{4}-[A-Z0-9]{4}")) {
+            return null;
+        }
+
+        return sanitized;
+    }
+
+    private String fetchPlayerName(final UUID uuid) {
+        final DatabaseManager databaseManager = plugin.getDatabaseManager();
+        if (databaseManager == null) {
+            return null;
+        }
+
+        final String query = "SELECT username FROM players WHERE uuid = ? ORDER BY last_seen DESC LIMIT 1";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, uuid.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getString("username");
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().severe("Erreur recherche nom pour UUID " + uuid + ": " + exception.getMessage());
+        }
+
+        return null;
     }
 
     private UUID getPlayerUUID(final String playerName) {

--- a/src/main/java/com/lobby/friends/manager/FriendCodeManager.java
+++ b/src/main/java/com/lobby/friends/manager/FriendCodeManager.java
@@ -1,0 +1,262 @@
+package com.lobby.friends.manager;
+
+import com.lobby.LobbyPlugin;
+import com.lobby.core.DatabaseManager;
+import com.lobby.core.DatabaseManager.DatabaseType;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.logging.Level;
+
+/**
+ * Handles creation, persistence and lookup of friend invitation codes.
+ * Codes are cached in memory for fast lookups and synchronised with the
+ * database to ensure uniqueness across the network.
+ */
+public class FriendCodeManager {
+
+    private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final int CODE_LENGTH = 8;
+    private static final int CODE_SECTION_LENGTH = 4;
+    private static final int MAX_GENERATION_ATTEMPTS = 100;
+
+    private final LobbyPlugin plugin;
+    private final DatabaseManager databaseManager;
+    private final Map<UUID, String> codeCache = new ConcurrentHashMap<>();
+
+    public FriendCodeManager(final LobbyPlugin plugin) {
+        this.plugin = plugin;
+        this.databaseManager = plugin.getDatabaseManager();
+
+        createTable();
+        loadCodesCache();
+    }
+
+    private void createTable() {
+        final DatabaseType databaseType = databaseManager.getDatabaseType();
+        final String createTableSql;
+        if (databaseType == DatabaseType.MYSQL) {
+            createTableSql = """
+                    CREATE TABLE IF NOT EXISTS friend_codes (
+                        player_uuid VARCHAR(36) PRIMARY KEY,
+                        code VARCHAR(9) UNIQUE NOT NULL,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+                    )
+                    """;
+        } else {
+            createTableSql = """
+                    CREATE TABLE IF NOT EXISTS friend_codes (
+                        player_uuid TEXT PRIMARY KEY,
+                        code TEXT UNIQUE NOT NULL,
+                        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                    )
+                    """;
+        }
+
+        try (Connection connection = databaseManager.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate(createTableSql);
+            statement.executeUpdate("CREATE INDEX IF NOT EXISTS idx_friend_code ON friend_codes(code)");
+            plugin.getLogger().info("Table friend_codes créée avec succès");
+        } catch (final SQLException exception) {
+            plugin.getLogger().log(Level.SEVERE, "Erreur création table friend_codes", exception);
+        }
+    }
+
+    public String generateUniqueCode(final UUID playerUuid) {
+        if (playerUuid == null) {
+            return null;
+        }
+
+        final String existing = getPlayerCode(playerUuid);
+        if (existing != null) {
+            return existing;
+        }
+
+        String newCode = null;
+        int attempts = 0;
+
+        while (attempts < MAX_GENERATION_ATTEMPTS) {
+            newCode = generateRandomCode();
+            if (!isCodeAlreadyUsed(newCode)) {
+                break;
+            }
+            attempts++;
+        }
+
+        if (attempts >= MAX_GENERATION_ATTEMPTS) {
+            plugin.getLogger().severe("Impossible de générer un code unique après " + MAX_GENERATION_ATTEMPTS + " tentatives !");
+            return null;
+        }
+
+        if (saveFriendCode(playerUuid, newCode)) {
+            codeCache.put(playerUuid, newCode);
+            plugin.getLogger().info("Code d'ami généré pour " + playerUuid + ": " + newCode);
+            return newCode;
+        }
+
+        return null;
+    }
+
+    private String generateRandomCode() {
+        final ThreadLocalRandom random = ThreadLocalRandom.current();
+        final char[] buffer = new char[CODE_LENGTH + 1];
+
+        for (int index = 0; index < CODE_SECTION_LENGTH; index++) {
+            buffer[index] = CHARACTERS.charAt(random.nextInt(CHARACTERS.length()));
+        }
+
+        buffer[CODE_SECTION_LENGTH] = '-';
+
+        for (int index = CODE_SECTION_LENGTH + 1; index < buffer.length; index++) {
+            buffer[index] = CHARACTERS.charAt(random.nextInt(CHARACTERS.length()));
+        }
+
+        return new String(buffer);
+    }
+
+    private boolean isCodeAlreadyUsed(final String code) {
+        final String query = "SELECT 1 FROM friend_codes WHERE code = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, normalize(code));
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().severe("Erreur vérification code: " + exception.getMessage());
+            return true;
+        }
+    }
+
+    private boolean saveFriendCode(final UUID playerUuid, final String code) {
+        final DatabaseType databaseType = databaseManager.getDatabaseType();
+        final String sql;
+        if (databaseType == DatabaseType.MYSQL) {
+            sql = "INSERT INTO friend_codes (player_uuid, code) VALUES (?, ?) " +
+                    "ON DUPLICATE KEY UPDATE code = VALUES(code), updated_at = CURRENT_TIMESTAMP";
+        } else {
+            sql = "INSERT INTO friend_codes (player_uuid, code) VALUES (?, ?) " +
+                    "ON CONFLICT(player_uuid) DO UPDATE SET code = excluded.code, updated_at = CURRENT_TIMESTAMP";
+        }
+
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, playerUuid.toString());
+            statement.setString(2, normalize(code));
+            return statement.executeUpdate() > 0;
+        } catch (final SQLException exception) {
+            plugin.getLogger().severe("Erreur sauvegarde code: " + exception.getMessage());
+            return false;
+        }
+    }
+
+    public String getPlayerCode(final UUID playerUuid) {
+        if (playerUuid == null) {
+            return null;
+        }
+        final String cached = codeCache.get(playerUuid);
+        if (cached != null) {
+            return cached;
+        }
+
+        final String query = "SELECT code FROM friend_codes WHERE player_uuid = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUuid.toString());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    final String code = resultSet.getString("code");
+                    if (code != null) {
+                        codeCache.put(playerUuid, code);
+                    }
+                    return code;
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().severe("Erreur récupération code: " + exception.getMessage());
+        }
+        return null;
+    }
+
+    public UUID getPlayerByCode(final String code) {
+        if (code == null || code.isEmpty()) {
+            return null;
+        }
+
+        final String normalized = normalize(code);
+        if (!normalized.matches("[A-Z0-9]{4}-[A-Z0-9]{4}")) {
+            return null;
+        }
+
+        final String query = "SELECT player_uuid FROM friend_codes WHERE code = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, normalized);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return UUID.fromString(resultSet.getString("player_uuid"));
+                }
+            }
+        } catch (final SQLException exception) {
+            plugin.getLogger().severe("Erreur recherche par code: " + exception.getMessage());
+        }
+        return null;
+    }
+
+    private void loadCodesCache() {
+        final String query = "SELECT player_uuid, code FROM friend_codes";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query);
+             ResultSet resultSet = statement.executeQuery()) {
+            int loadedCodes = 0;
+            while (resultSet.next()) {
+                final UUID uuid = UUID.fromString(resultSet.getString("player_uuid"));
+                final String code = resultSet.getString("code");
+                if (code != null) {
+                    codeCache.put(uuid, code);
+                    loadedCodes++;
+                }
+            }
+            plugin.getLogger().info("Chargé " + loadedCodes + " codes d'amis en cache");
+        } catch (final SQLException exception) {
+            plugin.getLogger().severe("Erreur chargement codes: " + exception.getMessage());
+        }
+    }
+
+    public String regenerateCode(final UUID playerUuid) {
+        if (playerUuid == null) {
+            return null;
+        }
+        codeCache.remove(playerUuid);
+
+        final String query = "DELETE FROM friend_codes WHERE player_uuid = ?";
+        try (Connection connection = databaseManager.getConnection();
+             PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, playerUuid.toString());
+            statement.executeUpdate();
+        } catch (final SQLException exception) {
+            plugin.getLogger().severe("Erreur suppression ancien code: " + exception.getMessage());
+        }
+
+        return generateUniqueCode(playerUuid);
+    }
+
+    public String getCachedCode(final UUID playerUuid) {
+        return codeCache.get(playerUuid);
+    }
+
+    private String normalize(final String code) {
+        return code == null ? null : code.trim().toUpperCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/com/lobby/friends/menu/AddFriendMenu.java
+++ b/src/main/java/com/lobby/friends/menu/AddFriendMenu.java
@@ -2,6 +2,7 @@ package com.lobby.friends.menu;
 
 import com.lobby.LobbyPlugin;
 import com.lobby.friends.listeners.FriendAddChatListener;
+import com.lobby.friends.manager.FriendCodeManager;
 import com.lobby.friends.manager.FriendsManager;
 import com.lobby.friends.menu.FriendsMainMenu;
 import com.lobby.friends.menu.FriendsMenuManager;
@@ -18,7 +19,9 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Menu dedicated to the different options available when adding a friend.
@@ -107,21 +110,20 @@ public class AddFriendMenu implements Listener {
         inventory.setItem(NEARBY_SLOT, nearby);
 
         final ItemStack importCode = createItem(Material.WRITABLE_BOOK, "§d💾 Code d'Ami");
-        final ItemMeta importMeta = importCode.getItemMeta();
-        if (importMeta != null) {
-            final String code = "#" + player.getName().toUpperCase().substring(0, Math.min(4, player.getName().length())) + "1234";
-            importMeta.setLore(Arrays.asList(
-                    "§7Utilisez un code d'ami pour",
-                    "§7ajouter rapidement quelqu'un",
-                    "",
-                    "§d▸ Votre code: §f" + code,
-                    "§d▸ Saisissez un code reçu",
-                    "",
-                    "§8» §dCliquez pour utiliser un code"
-            ));
-            importCode.setItemMeta(importMeta);
-        }
         inventory.setItem(IMPORT_SLOT, importCode);
+
+        final FriendCodeManager codeManager = plugin.getFriendCodeManager();
+        if (codeManager == null) {
+            updateFriendCodeItem(null, "§cGestionnaire de codes indisponible.");
+        } else {
+            final String cachedCode = codeManager.getCachedCode(player.getUniqueId());
+            if (cachedCode != null) {
+                updateFriendCodeItem(cachedCode, null);
+            } else {
+                updateFriendCodeItem(null, "§7Chargement du code...");
+            }
+            loadFriendCodeAsync(codeManager);
+        }
 
         setPendingItem(0);
 
@@ -171,6 +173,61 @@ public class AddFriendMenu implements Listener {
             pending.setItemMeta(pendingMeta);
         }
         inventory.setItem(PENDING_SLOT, pending);
+    }
+
+    private void loadFriendCodeAsync(final FriendCodeManager codeManager) {
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            String code = codeManager.getPlayerCode(player.getUniqueId());
+            if (code == null) {
+                code = codeManager.generateUniqueCode(player.getUniqueId());
+            }
+            final String resolvedCode = code;
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (!player.isOnline()) {
+                    return;
+                }
+                if (resolvedCode != null) {
+                    updateFriendCodeItem(resolvedCode, null);
+                } else {
+                    updateFriendCodeItem(null, "§cImpossible de récupérer votre code.");
+                }
+            });
+        });
+    }
+
+    private void updateFriendCodeItem(final String friendCode, final String statusLine) {
+        final ItemStack item = inventory.getItem(IMPORT_SLOT);
+        if (item == null || item.getType() == Material.AIR) {
+            return;
+        }
+        final ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return;
+        }
+
+        final List<String> lore = new ArrayList<>();
+        lore.add("§7Utilisez un code d'ami pour");
+        lore.add("§7ajouter rapidement quelqu'un");
+        lore.add("");
+
+        if (friendCode != null) {
+            lore.add("§d▸ Votre code: §f" + friendCode);
+        } else {
+            lore.add("§d▸ Votre code: §c(indisponible)");
+        }
+
+        if (statusLine != null && !statusLine.isEmpty()) {
+            lore.add(statusLine);
+        } else {
+            lore.add("§d▸ Saisissez un code reçu");
+        }
+
+        lore.add("");
+        lore.add("§8» §dCliquez pour utiliser un code");
+
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+        inventory.setItem(IMPORT_SLOT, item);
     }
 
     private ItemStack createItem(final Material material, final String name) {
@@ -279,10 +336,12 @@ public class AddFriendMenu implements Listener {
 
     private void handleFriendCode() {
         player.closeInventory();
-        player.sendMessage("§d💾 Code d'ami:");
-        player.sendMessage("§7Votre code: §f#" + player.getName().toUpperCase().substring(0, Math.min(4, player.getName().length())) + "1234");
-        player.sendMessage("§7Tapez le code d'un ami pour l'ajouter:");
-        player.sendMessage("§7(ou tapez 'cancel' pour annuler)");
+        final FriendAddChatListener listener = plugin.getFriendAddChatListener();
+        if (listener == null) {
+            player.sendMessage("§cLe système de codes d'amis est indisponible.");
+            return;
+        }
+        listener.enableFriendCodeMode(player);
         player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1.0f, 1.5f);
     }
 


### PR DESCRIPTION
## Summary
- add a FriendCodeManager that persists unique XXXX-YYYY friend codes and caches them
- initialize friend code support during plugin startup and generate codes for new players on join
- integrate friend code lookup with the add-friend chat listener and menu so players can view and use their codes

## Testing
- `mvn -q -DskipTests package` *(fails: dependency downloads blocked by 403 responses from papermc repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d80f0d00d48329b0528a4f8d8c0d05