### PR TITLE
Implement reflective HeadDatabase fallback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>me.arcaniax</groupId>
-            <artifactId>HeadDatabase-API</artifactId>
-            <version>1.3.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>8.0.33</version>

--- a/src/main/java/com/lobby/friends/utils/HeadManager.java
+++ b/src/main/java/com/lobby/friends/utils/HeadManager.java
@@ -2,11 +2,11 @@ package com.lobby.friends.utils;
 
 import com.lobby.LobbyPlugin;
 import com.lobby.heads.HeadDatabaseManager;
-import me.arcaniax.hdb.api.HeadDatabaseAPI;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -21,7 +21,8 @@ public class HeadManager {
 
     private final LobbyPlugin plugin;
     private final HeadDatabaseManager lobbyHeadManager;
-    private HeadDatabaseAPI headAPI;
+    private Object headApiInstance;
+    private Method getItemHeadMethod;
     private boolean headDatabaseAvailable;
 
     public HeadManager(final LobbyPlugin plugin) {
@@ -37,26 +38,29 @@ public class HeadManager {
         final Logger logger = plugin.getLogger();
         try {
             if (plugin.getServer().getPluginManager().getPlugin("HeadDatabase") != null) {
-                headAPI = new HeadDatabaseAPI();
+                final Class<?> apiClass = Class.forName("me.arcaniax.hdb.api.HeadDatabaseAPI");
+                headApiInstance = apiClass.getDeclaredConstructor().newInstance();
+                getItemHeadMethod = apiClass.getMethod("getItemHead", String.class);
                 headDatabaseAvailable = true;
-                logger.info("HeadDatabase détecté et intégré avec succès !");
+                logger.info("HeadDatabase détecté et disponible !");
                 return true;
             }
-            logger.warning("HeadDatabase non détecté - utilisation des items par défaut");
+            logger.info("HeadDatabase non détecté - utilisation des items par défaut");
+        } catch (final ClassNotFoundException exception) {
+            logger.warning("HeadDatabase API non trouvée - fonctionnement avec items par défaut");
         } catch (final Exception exception) {
             logger.warning("Erreur lors de l'initialisation de HeadDatabase: " + exception.getMessage());
         }
         headDatabaseAvailable = false;
+        headApiInstance = null;
+        getItemHeadMethod = null;
         return false;
     }
 
     public ItemStack createCustomHead(final String headId, final String name, final List<String> lore) {
         if (headDatabaseAvailable && headId != null && !headId.isBlank()) {
             try {
-                ItemStack head = null;
-                if (headAPI != null) {
-                    head = headAPI.getItemHead(headId);
-                }
+                ItemStack head = tryLoadHeadFromApi(headId);
                 if (head == null && lobbyHeadManager != null) {
                     head = lobbyHeadManager.getHead("hdb:" + headId, Material.PLAYER_HEAD);
                 }
@@ -78,7 +82,7 @@ public class HeadManager {
                 plugin.getLogger().warning("Impossible de charger la tête HeadDatabase ID: " + headId + " - " + exception.getMessage());
             }
         }
-        return createFallbackItem(name, lore, Material.PLAYER_HEAD);
+        return createFallbackItem(name, lore, getMaterialFromHeadId(headId));
     }
 
     public ItemStack createFallbackItem(final String name, final List<String> lore, final Material material) {
@@ -97,14 +101,56 @@ public class HeadManager {
         return item;
     }
 
+    public ItemStack createMappedItem(final String headId, final String name, final List<String> lore) {
+        return createFallbackItem(name, lore, getMaterialFromHeadId(headId));
+    }
+
+    private ItemStack tryLoadHeadFromApi(final String headId) throws Exception {
+        if (headApiInstance == null || getItemHeadMethod == null) {
+            return null;
+        }
+        final Object result = getItemHeadMethod.invoke(headApiInstance, headId);
+        if (result instanceof ItemStack itemStack) {
+            return itemStack;
+        }
+        return null;
+    }
+
+    private Material getMaterialFromHeadId(final String headId) {
+        if (headId == null || headId.isBlank()) {
+            return Material.PLAYER_HEAD;
+        }
+        return switch (headId) {
+            case "1420" -> Material.SPYGLASS;
+            case "4579" -> Material.TRIPWIRE_HOOK;
+            case "3644" -> Material.CLOCK;
+            case "2118" -> Material.REDSTONE_LAMP;
+            case "8665" -> Material.HEART_OF_THE_SEA;
+            case "160" -> Material.BOOK;
+            case "5568" -> Material.PAPER;
+            case "4120" -> Material.BELL;
+            case "2177" -> Material.WRITABLE_BOOK;
+            case "7129" -> Material.NETHER_STAR;
+            case "1393" -> Material.PLAYER_HEAD;
+            case "3045" -> Material.MAP;
+            case "5021" -> Material.DIAMOND;
+            case "4654" -> Material.EMERALD;
+            case "9056" -> Material.REDSTONE_BLOCK;
+            case "1085" -> Material.LIME_DYE;
+            case "622" -> Material.REDSTONE;
+            case "2287" -> Material.FEATHER;
+            default -> Material.PLAYER_HEAD;
+        };
+    }
+
     public boolean isHeadDatabaseAvailable() {
         return headDatabaseAvailable;
     }
 
     public String getHeadDatabaseStatus() {
         return headDatabaseAvailable
-                ? "§a✅ HeadDatabase actif"
-                : "§c❌ HeadDatabase indisponible - utilisation des items par défaut";
+                ? "§a✅ HeadDatabase actif - Têtes personnalisées disponibles"
+                : "§e⚠ HeadDatabase indisponible - Utilisation des matériaux mappés";
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the direct HeadDatabase API dependency from the build to avoid unavailable artifacts
- rework the friends HeadManager to use reflection for HeadDatabase access and map popular head IDs to vanilla materials when unavailable

## Testing
- mvn clean compile *(fails: upstream repositories return HTTP 403 while resolving Paper and PlaceholderAPI)*

------
https://chatgpt.com/codex/tasks/task_e_68d81a8f89a88329bff5ab9d5ce1ce86