### PR TITLE
Enable chat-based block reason updates

### DIFF
--- a/src/main/java/com/lobby/core/DatabaseManager.java
+++ b/src/main/java/com/lobby/core/DatabaseManager.java
@@ -71,6 +71,39 @@ public class DatabaseManager {
         }
     }
 
+    public String getPlayerName(final UUID playerUUID) {
+        if (playerUUID == null) {
+            return null;
+        }
+
+        final String[] possibleQueries = {
+                "SELECT username FROM players WHERE player_uuid = ? ORDER BY last_seen DESC LIMIT 1",
+                "SELECT name FROM player_data WHERE uuid = ? ORDER BY last_login DESC LIMIT 1",
+                "SELECT player_name FROM lobby_players WHERE player_id = ? ORDER BY join_date DESC LIMIT 1"
+        };
+
+        for (final String query : possibleQueries) {
+            try (Connection connection = getConnection();
+                 PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setString(1, playerUUID.toString());
+
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    if (resultSet.next()) {
+                        final String value = resultSet.getString(1);
+                        if (value != null && !value.trim().isEmpty()) {
+                            return value.trim();
+                        }
+                    }
+                }
+            } catch (final SQLException exception) {
+                plugin.getLogger().fine("Requête échouée: " + query + " - " + exception.getMessage());
+            }
+        }
+
+        plugin.getLogger().warning("Impossible de récupérer le nom pour UUID: " + playerUUID);
+        return null;
+    }
+
     public DatabaseType getDatabaseType() {
         return databaseType;
     }

--- a/src/main/java/com/lobby/friends/listeners/FriendAddChatListener.java
+++ b/src/main/java/com/lobby/friends/listeners/FriendAddChatListener.java
@@ -4,8 +4,10 @@ import com.lobby.LobbyPlugin;
 import com.lobby.core.DatabaseManager;
 import com.lobby.friends.data.FriendData;
 import com.lobby.friends.data.FriendRequest;
+import com.lobby.friends.manager.BlockedPlayersManager;
 import com.lobby.friends.manager.FriendCodeManager;
 import com.lobby.friends.manager.FriendsManager;
+import com.lobby.friends.menu.BlockedPlayersMenu;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -33,6 +35,7 @@ public class FriendAddChatListener implements Listener {
     private final FriendsManager friendsManager;
     private final Map<UUID, String> pendingRequests = new ConcurrentHashMap<>();
     private final Map<UUID, String> messageTargets = new ConcurrentHashMap<>();
+    private final Map<UUID, UUID> pendingBlockReasons = new ConcurrentHashMap<>();
 
     public FriendAddChatListener(final LobbyPlugin plugin) {
         this.plugin = plugin;
@@ -54,6 +57,12 @@ public class FriendAddChatListener implements Listener {
         if (messageTargets.containsKey(playerUUID)) {
             event.setCancelled(true);
             handlePrivateMessageInput(player, event.getMessage());
+            return;
+        }
+
+        if (pendingBlockReasons.containsKey(playerUUID)) {
+            event.setCancelled(true);
+            handleBlockReasonChange(event);
             return;
         }
 
@@ -85,6 +94,137 @@ public class FriendAddChatListener implements Listener {
         }
 
         Bukkit.getScheduler().runTask(plugin, () -> player.sendMessage("§c❌ Mode d'ajout non reconnu !"));
+    }
+
+    public void activateBlockReasonMode(final Player player, final UUID blockedPlayerUUID) {
+        if (player == null || blockedPlayerUUID == null) {
+            return;
+        }
+
+        final UUID playerUUID = player.getUniqueId();
+        pendingBlockReasons.put(playerUUID, blockedPlayerUUID);
+
+        final String blockedPlayerName = getPlayerName(blockedPlayerUUID);
+
+        player.sendMessage("§e📝 §6Modification de la raison de blocage");
+        player.sendMessage("§7Joueur bloqué: §c" + blockedPlayerName);
+        player.sendMessage("");
+        player.sendMessage("§6Tapez la nouvelle raison de blocage :");
+        player.sendMessage("§7Exemple: §eComportement toxique en jeu");
+        player.sendMessage("§7Exemple: §eSpam de messages répétés");
+        player.sendMessage("§7Exemple: §eLanguage inapproprié");
+        player.sendMessage("");
+        player.sendMessage("§7Tapez §c'annuler'§7 pour annuler la modification");
+
+        plugin.getLogger().info("Mode modification raison activé pour " + player.getName()
+                + " -> " + blockedPlayerName);
+
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (pendingBlockReasons.containsKey(playerUUID)) {
+                pendingBlockReasons.remove(playerUUID);
+                player.sendMessage("§c⏰ §7Modification de raison expirée - §cAucun changement effectué");
+            }
+        }, 20L * 60);
+    }
+
+    private void handleBlockReasonChange(final AsyncPlayerChatEvent event) {
+        final Player player = event.getPlayer();
+        final UUID playerUUID = player.getUniqueId();
+        final String rawMessage = event.getMessage();
+        final String newReason = rawMessage == null ? "" : rawMessage.trim();
+
+        final UUID blockedPlayerUUID = pendingBlockReasons.remove(playerUUID);
+        if (blockedPlayerUUID == null) {
+            plugin.getLogger().warning("Aucune cible pour la modification de raison de " + player.getName());
+            return;
+        }
+
+        final String blockedPlayerName = getPlayerName(blockedPlayerUUID);
+
+        plugin.getLogger().info("Tentative modification raison par " + player.getName()
+                + " pour " + blockedPlayerName + ": " + newReason);
+
+        if ("annuler".equalsIgnoreCase(newReason) || "cancel".equalsIgnoreCase(newReason)) {
+            player.sendMessage("§c❌ Modification de raison annulée");
+            player.sendMessage("§7Aucun changement n'a été effectué");
+            return;
+        }
+
+        if (newReason.length() < 3) {
+            player.sendMessage("§c❌ La raison doit contenir au moins 3 caractères !");
+            player.sendMessage("§7Tapez une raison plus détaillée pour justifier le blocage");
+            activateBlockReasonMode(player, blockedPlayerUUID);
+            return;
+        }
+
+        if (newReason.length() > 100) {
+            player.sendMessage("§c❌ La raison ne peut pas dépasser 100 caractères !");
+            player.sendMessage("§7Actuel: " + newReason.length() + " caractères");
+            player.sendMessage("§7Tapez une raison plus courte et concise");
+            activateBlockReasonMode(player, blockedPlayerUUID);
+            return;
+        }
+
+        final BlockedPlayersManager blockedPlayersManager = plugin.getBlockedPlayersManager();
+        if (blockedPlayersManager == null
+                || !blockedPlayersManager.isPlayerBlocked(playerUUID, blockedPlayerUUID)) {
+            player.sendMessage("§c❌ Ce joueur n'est plus bloqué !");
+            player.sendMessage("§7Impossible de modifier la raison d'un joueur non-bloqué");
+            return;
+        }
+
+        player.sendMessage("§e⏳ Mise à jour de la raison en cours...");
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final boolean success = blockedPlayersManager.updateBlockReason(playerUUID, blockedPlayerUUID, newReason);
+
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (success) {
+                    player.sendMessage("§a✅ §2Raison de blocage mise à jour avec succès !");
+                    player.sendMessage("§7Joueur: §c" + blockedPlayerName);
+                    player.sendMessage("§7Nouvelle raison: §f\"" + newReason + "\"");
+                    player.sendMessage("§7Mise à jour: §a" + getCurrentTimestamp());
+
+                    player.playSound(player.getLocation(), "block.note_block.chime", 0.7f, 1.2f);
+
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                        try {
+                            player.sendMessage("§7Réouverture du menu des joueurs bloqués...");
+                            new BlockedPlayersMenu(plugin, friendsManager, player).open();
+                        } catch (final Exception exception) {
+                            plugin.getLogger().warning("Erreur réouverture menu bloqués: " + exception.getMessage());
+                            player.sendMessage("§7Utilisez §e/friends blocked§7 pour voir vos joueurs bloqués");
+                        }
+                    }, 40L);
+                } else {
+                    player.sendMessage("§c❌ §4Erreur lors de la mise à jour de la raison !");
+                    player.sendMessage("§7La base de données n'a pas pu être mise à jour");
+                    player.sendMessage("§7Veuillez réessayer plus tard ou contacter un administrateur");
+                    player.playSound(player.getLocation(), "block.note_block.bass", 0.7f, 0.8f);
+                }
+            });
+        });
+    }
+
+    public boolean isInBlockReasonMode(final Player player) {
+        return player != null && pendingBlockReasons.containsKey(player.getUniqueId());
+    }
+
+    public void cancelBlockReasonMode(final Player player) {
+        if (player == null) {
+            return;
+        }
+        final UUID removed = pendingBlockReasons.remove(player.getUniqueId());
+        if (removed != null) {
+            player.sendMessage("§c❌ Modification de raison annulée pour " + getPlayerName(removed));
+        }
+    }
+
+    public UUID getCurrentBlockReasonTarget(final Player player) {
+        if (player == null) {
+            return null;
+        }
+        return pendingBlockReasons.get(player.getUniqueId());
     }
 
     private void handlePrivateMessageInput(final Player player, final String rawInput) {
@@ -186,9 +326,51 @@ public class FriendAddChatListener implements Listener {
                 return;
             }
 
-            Bukkit.getScheduler().runTask(plugin, () ->
-                    processFriendRequest(player, targetUuid, targetName));
+        Bukkit.getScheduler().runTask(plugin, () ->
+                processFriendRequest(player, targetUuid, targetName));
         });
+    }
+
+    private String getPlayerName(final UUID playerUUID) {
+        if (playerUUID == null) {
+            return "Joueur-inconnu";
+        }
+
+        final Player onlinePlayer = Bukkit.getPlayer(playerUUID);
+        if (onlinePlayer != null) {
+            return onlinePlayer.getName();
+        }
+
+        final DatabaseManager databaseManager = plugin.getDatabaseManager();
+        if (databaseManager != null) {
+            try {
+                final String databaseName = databaseManager.getPlayerName(playerUUID);
+                if (databaseName != null && !databaseName.isBlank()) {
+                    return databaseName.trim();
+                }
+            } catch (final Exception exception) {
+                plugin.getLogger().warning("Erreur récupération nom pour " + playerUUID + ": "
+                        + exception.getMessage());
+            }
+        }
+
+        try {
+            final String offlineName = Bukkit.getOfflinePlayer(playerUUID).getName();
+            if (offlineName != null && !offlineName.isBlank()) {
+                return offlineName;
+            }
+        } catch (final Exception exception) {
+            plugin.getLogger().warning("Erreur OfflinePlayer pour " + playerUUID + ": " + exception.getMessage());
+        }
+
+        return "Joueur-" + playerUUID.toString().substring(0, 8);
+    }
+
+    private String getCurrentTimestamp() {
+        final java.time.LocalDateTime now = java.time.LocalDateTime.now();
+        final java.time.format.DateTimeFormatter formatter =
+                java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+        return now.format(formatter);
     }
 
     private void processFriendRequest(final Player sender, final UUID targetUUID, final String targetName) {

--- a/src/main/java/com/lobby/friends/menu/BlockedPlayersMenu.java
+++ b/src/main/java/com/lobby/friends/menu/BlockedPlayersMenu.java
@@ -1,14 +1,19 @@
 package com.lobby.friends.menu;
 
 import com.lobby.LobbyPlugin;
+import com.lobby.core.DatabaseManager;
+import com.lobby.friends.listeners.FriendAddChatListener;
+import com.lobby.friends.manager.BlockedPlayersManager;
 import com.lobby.friends.manager.FriendsManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -17,36 +22,41 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 
-import java.time.Duration;
-import java.time.Instant;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
-/**
- * Interactive interface allowing players to review and manage their blocked
- * players list. The backend integration is not yet implemented, therefore the
- * menu currently relies on deterministic mock data while keeping the
- * presentation logic production-ready.
- */
 public class BlockedPlayersMenu implements Listener {
 
     private static final String INVENTORY_TITLE = "§8» §cJoueurs Bloqués";
+    private static final String OPTIONS_TITLE_PREFIX = "§8» §4Options pour ";
     private static final int INVENTORY_SIZE = 54;
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.FRENCH)
-            .withZone(ZoneId.systemDefault());
-
+    private static final DateTimeFormatter DISPLAY_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("dd/MM/yyyy à HH:mm", Locale.FRENCH)
+                    .withZone(ZoneId.systemDefault());
     private final LobbyPlugin plugin;
     private final FriendsManager friendsManager;
+    private final BlockedPlayersManager blockedPlayersManager;
+    private final DatabaseManager databaseManager;
     private final Player player;
     private final Inventory inventory;
-    private final List<BlockedPlayerData> blockedPlayers = new ArrayList<>();
     private final int[] blockedSlots = {10, 11, 12, 13, 14, 15, 16, 19, 20, 21, 22, 23, 24, 25,
             28, 29, 30, 31, 32, 33, 34, 37, 38, 39, 40, 41, 42, 43};
 
+    private final Map<Integer, UUID> slotToBlocked = new HashMap<>();
+    private final Map<UUID, BlockedEntry> blockedEntries = new LinkedHashMap<>();
+
+    private UUID optionsTarget;
     private boolean unregistered;
 
     public BlockedPlayersMenu(final LobbyPlugin plugin,
@@ -55,6 +65,8 @@ public class BlockedPlayersMenu implements Listener {
         this.plugin = plugin;
         this.friendsManager = friendsManager;
         this.player = player;
+        this.blockedPlayersManager = plugin.getBlockedPlayersManager();
+        this.databaseManager = plugin.getDatabaseManager();
         this.inventory = Bukkit.createInventory(null, INVENTORY_SIZE, INVENTORY_TITLE);
         Bukkit.getPluginManager().registerEvents(this, plugin);
         loadBlockedPlayers();
@@ -62,11 +74,44 @@ public class BlockedPlayersMenu implements Listener {
     }
 
     private void loadBlockedPlayers() {
-        blockedPlayers.clear();
-        // TODO: Récupérer depuis la base de données.
-        blockedPlayers.add(new BlockedPlayerData("SpammerBot", "Spam de messages", System.currentTimeMillis() - 86_400_000L));
-        blockedPlayers.add(new BlockedPlayerData("ToxicPlayer", "Harcèlement", System.currentTimeMillis() - 172_800_000L));
-        blockedPlayers.add(new BlockedPlayerData("Griefer", "Destruction de parcelles", System.currentTimeMillis() - 259_200_000L));
+        blockedEntries.clear();
+        slotToBlocked.clear();
+
+        if (blockedPlayersManager == null || player == null) {
+            return;
+        }
+
+        final Set<UUID> blockedPlayers = blockedPlayersManager.getBlockedPlayers(player.getUniqueId());
+        if (blockedPlayers == null || blockedPlayers.isEmpty()) {
+            return;
+        }
+
+        final List<BlockedEntry> entries = new ArrayList<>();
+        for (final UUID blockedUUID : blockedPlayers) {
+            final BlockedPlayersManager.BlockInfo info =
+                    blockedPlayersManager.getBlockInfo(player.getUniqueId(), blockedUUID);
+            final String reason = info != null && info.getReason() != null && !info.getReason().isBlank()
+                    ? info.getReason()
+                    : "Aucune raison spécifiée";
+            final Timestamp blockedAt = info != null ? info.getBlockedAt() : null;
+            final Timestamp updatedAt = info != null ? info.getUpdatedAt() : null;
+            entries.add(new BlockedEntry(blockedUUID, resolvePlayerName(blockedUUID), reason, blockedAt, updatedAt));
+        }
+
+        entries.sort((first, second) -> Long.compare(getSortTimestamp(second), getSortTimestamp(first)));
+
+        for (final BlockedEntry entry : entries) {
+            blockedEntries.put(entry.uuid(), entry);
+        }
+    }
+
+    private long getSortTimestamp(final BlockedEntry entry) {
+        final Timestamp updated = entry.updatedAt();
+        if (updated != null) {
+            return updated.getTime();
+        }
+        final Timestamp blockedAt = entry.blockedAt();
+        return blockedAt != null ? blockedAt.getTime() : 0L;
     }
 
     private void setupMenu() {
@@ -79,13 +124,15 @@ public class BlockedPlayersMenu implements Listener {
     private void fillDecorations() {
         final ItemStack redGlass = createItem(Material.RED_STAINED_GLASS_PANE, " ");
         final int[] glassSlots = {0, 1, 2, 6, 7, 8, 9, 17, 36, 44, 45, 46, 52, 53};
-        for (int slot : glassSlots) {
+        for (final int slot : glassSlots) {
             inventory.setItem(slot, redGlass);
         }
     }
 
     private void displayBlockedPlayers() {
-        if (blockedPlayers.isEmpty()) {
+        slotToBlocked.clear();
+
+        if (blockedEntries.isEmpty()) {
             final ItemStack noBlocked = createItem(Material.PAPER, "§7§lAucun joueur bloqué");
             final ItemMeta meta = noBlocked.getItemMeta();
             if (meta != null) {
@@ -106,49 +153,56 @@ public class BlockedPlayersMenu implements Listener {
             return;
         }
 
-        for (int i = 0; i < blockedSlots.length && i < blockedPlayers.size(); i++) {
-            final BlockedPlayerData data = blockedPlayers.get(i);
-            inventory.setItem(blockedSlots[i], createBlockedPlayerItem(data));
+        int index = 0;
+        for (final BlockedEntry entry : blockedEntries.values()) {
+            if (index >= blockedSlots.length) {
+                break;
+            }
+            final int slot = blockedSlots[index++];
+            slotToBlocked.put(slot, entry.uuid());
+            inventory.setItem(slot, createBlockedPlayerItem(entry));
         }
     }
 
-    private ItemStack createBlockedPlayerItem(final BlockedPlayerData blockedData) {
+    private ItemStack createBlockedPlayerItem(final BlockedEntry entry) {
         final ItemStack head = new ItemStack(Material.PLAYER_HEAD);
         final ItemMeta baseMeta = head.getItemMeta();
         if (!(baseMeta instanceof SkullMeta meta)) {
             return head;
         }
 
-        meta.setDisplayName("§8§l" + blockedData.getPlayerName() + " §c🚫");
+        meta.setDisplayName("§c🚫 " + entry.name());
+
         final List<String> lore = new ArrayList<>();
         lore.add("§7Joueur bloqué");
         lore.add("");
-        lore.add("§7Informations du blocage:");
-        lore.add("§8▸ §7Date: §c" + formatBlockDate(blockedData.getBlockDate()));
-        lore.add("§8▸ §7Raison: §e" + blockedData.getReason());
-        lore.add("§8▸ §7Temps écoulé: §8" + getTimeElapsed(blockedData.getBlockDate()));
+        lore.add("§8▸ §7Raison: §f\"" + entry.reason() + "\"");
+        lore.add("§8▸ §7Bloqué le: §f" + formatDate(entry.blockedAt()));
+        lore.add("§8▸ §7Dernière modification: §f" + formatDate(entry.updatedAt()));
         lore.add("");
-        lore.add("§7Restrictions actives:");
-        lore.add("§8▸ §c✗ Messages privés");
-        lore.add("§8▸ §c✗ Demandes d'amitié");
-        lore.add("§8▸ §c✗ Visibilité de votre statut");
+        lore.add("§7Actions rapides:");
+        lore.add("§8• §eClic gauche §7→ Voir détails");
+        lore.add("§8• §eClic droit §7→ Modifier raison");
+        lore.add("§8• §eClic milieu §7→ Débloquer");
+        lore.add("§8• §eShift+Clic droit §7→ Options avancées");
         lore.add("");
-        lore.add("§8▸ §aClique gauche §8: §2Débloquer");
-        lore.add("§8▸ §cClique droit §8: §4Modifier la raison");
+        lore.add("§8UUID:" + entry.uuid());
+
         meta.setLore(lore);
+        meta.setOwningPlayer(Bukkit.getOfflinePlayer(entry.uuid()));
         head.setItemMeta(meta);
         return head;
     }
 
     private void setupActions() {
-        if (!blockedPlayers.isEmpty()) {
+        if (!blockedEntries.isEmpty()) {
             final ItemStack unblockAll = createItem(Material.EMERALD, "§a§l✓ Débloquer Tous");
             final ItemMeta unblockMeta = unblockAll.getItemMeta();
             if (unblockMeta != null) {
                 unblockMeta.setLore(Arrays.asList(
                         "§7Débloquer tous les joueurs bloqués",
                         "",
-                        "§a▸ Joueurs à débloquer: §2" + blockedPlayers.size(),
+                        "§a▸ Joueurs à débloquer: §2" + blockedEntries.size(),
                         "",
                         "§8» §aCliquez pour débloquer tous"
                 ));
@@ -182,24 +236,6 @@ public class BlockedPlayersMenu implements Listener {
         inventory.setItem(49, back);
     }
 
-    private String formatBlockDate(final long timestamp) {
-        return DATE_FORMATTER.format(Instant.ofEpochMilli(timestamp));
-    }
-
-    private String getTimeElapsed(final long timestamp) {
-        final Duration duration = Duration.ofMillis(System.currentTimeMillis() - timestamp);
-        final long days = duration.toDays();
-        if (days > 0) {
-            return days + " jour(s)";
-        }
-        final long hours = duration.toHours();
-        if (hours > 0) {
-            return hours + " heure(s)";
-        }
-        final long minutes = Math.max(1, duration.toMinutes());
-        return minutes + " minute(s)";
-    }
-
     private ItemStack createItem(final Material material, final String name) {
         final ItemStack item = new ItemStack(material);
         final ItemMeta meta = item.getItemMeta();
@@ -211,75 +247,294 @@ public class BlockedPlayersMenu implements Listener {
     }
 
     public void open() {
+        if (player == null || !player.isOnline()) {
+            return;
+        }
         player.openInventory(inventory);
         playSound(Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.5f);
     }
 
     @EventHandler
     public void onInventoryClick(final InventoryClickEvent event) {
-        if (!INVENTORY_TITLE.equals(event.getView().getTitle())) {
+        final String title = event.getView().getTitle();
+        if (title == null) {
             return;
         }
-        event.setCancelled(true);
+
         if (!(event.getWhoClicked() instanceof Player clicker)) {
             return;
         }
+
+        if (title.equals(INVENTORY_TITLE)) {
+            handleMainMenuClick(event, clicker);
+            return;
+        }
+
+        if (title.startsWith(OPTIONS_TITLE_PREFIX)) {
+            handleOptionsMenuClick(event, clicker);
+        }
+    }
+
+    private void handleMainMenuClick(final InventoryClickEvent event, final Player clicker) {
         if (!clicker.getUniqueId().equals(player.getUniqueId())) {
             return;
         }
 
+        event.setCancelled(true);
+        event.setResult(Event.Result.DENY);
+
         final int slot = event.getSlot();
-        if (slot == 47 && !blockedPlayers.isEmpty()) {
+        if (slot == 47 && !blockedEntries.isEmpty()) {
             handleUnblockAll();
             return;
         }
+
         if (slot == 48) {
             handleRefresh();
             return;
         }
+
         if (slot == 49) {
             handleBack();
             return;
         }
 
-        for (int i = 0; i < blockedSlots.length; i++) {
-            if (blockedSlots[i] == slot && i < blockedPlayers.size()) {
-                handleBlockedPlayerClick(blockedPlayers.get(i), event);
-                break;
-            }
+        final ItemStack clickedItem = event.getCurrentItem();
+        if (clickedItem == null || clickedItem.getType() == Material.AIR || !clickedItem.hasItemMeta()) {
+            return;
         }
+
+        final UUID blockedUUID = slotToBlocked.getOrDefault(slot, extractBlockedPlayerUUID(clickedItem));
+        if (blockedUUID == null) {
+            plugin.getLogger().warning("Impossible d'extraire UUID du joueur bloqué depuis l'item");
+            return;
+        }
+
+        final ClickType clickType = event.getClick();
+        handleBlockedPlayerInteraction(clicker, blockedUUID, clickType);
+    }
+
+    private void handleBlockedPlayerInteraction(final Player player,
+                                                final UUID blockedUUID,
+                                                final ClickType clickType) {
+        final String blockedName = resolvePlayerName(blockedUUID);
+        plugin.getLogger().info("Interaction blocage " + blockedName + " par " + player.getName()
+                + " - Type: " + clickType);
+
+        switch (clickType) {
+            case LEFT -> showBlockDetails(player, blockedUUID);
+            case RIGHT -> {
+                player.closeInventory();
+                player.sendMessage("§e⚙ Modification de la raison de blocage pour §6" + blockedName + "§e...");
+                Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                    final FriendAddChatListener chatListener = plugin.getFriendAddChatListener();
+                    if (chatListener != null) {
+                        chatListener.activateBlockReasonMode(player, blockedUUID);
+                    } else {
+                        player.sendMessage("§c❌ Système de chat indisponible");
+                    }
+                }, 3L);
+            }
+            case MIDDLE -> {
+                player.closeInventory();
+                confirmUnblock(player, blockedUUID);
+            }
+            case SHIFT_RIGHT -> openBlockOptionsMenu(player, blockedUUID);
+            default -> showBlockMenuHelp(player);
+        }
+    }
+
+    private void handleOptionsMenuClick(final InventoryClickEvent event, final Player clicker) {
+        if (!clicker.getUniqueId().equals(player.getUniqueId())) {
+            return;
+        }
+
+        event.setCancelled(true);
+        event.setResult(Event.Result.DENY);
+
+        if (optionsTarget == null) {
+            return;
+        }
+
+        final int slot = event.getSlot();
+        final UUID blockedUUID = optionsTarget;
+        final String blockedName = resolvePlayerName(blockedUUID);
+
+        switch (slot) {
+            case 11 -> {
+                clicker.closeInventory();
+                clicker.sendMessage("§e⚙ Modification de la raison de blocage pour §6" + blockedName + "§e...");
+                Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                    final FriendAddChatListener chatListener = plugin.getFriendAddChatListener();
+                    if (chatListener != null) {
+                        chatListener.activateBlockReasonMode(clicker, blockedUUID);
+                    } else {
+                        clicker.sendMessage("§c❌ Système de chat indisponible");
+                    }
+                }, 3L);
+            }
+            case 13 -> showBlockDetails(clicker, blockedUUID);
+            case 15 -> {
+                clicker.closeInventory();
+                unblockPlayer(clicker, blockedUUID, blockedName);
+            }
+            case 22 -> {
+                clicker.closeInventory();
+                Bukkit.getScheduler().runTaskLater(plugin, this::reopenMainInventory, 2L);
+            }
+            default -> showBlockMenuHelp(clicker);
+        }
+    }
+
+    private void showBlockDetails(final Player player, final UUID blockedUUID) {
+        if (blockedPlayersManager == null) {
+            player.sendMessage("§c❌ Informations de blocage indisponibles !");
+            return;
+        }
+
+        final BlockedPlayersManager.BlockInfo info =
+                blockedPlayersManager.getBlockInfo(player.getUniqueId(), blockedUUID);
+        if (info == null) {
+            player.sendMessage("§c❌ Informations de blocage introuvables !");
+            return;
+        }
+
+        final String blockedName = resolvePlayerName(blockedUUID);
+        player.sendMessage("§c🚫 §4=== DÉTAILS DU BLOCAGE ===");
+        player.sendMessage("§8▸ §7Joueur bloqué: §c" + blockedName);
+        player.sendMessage("§8▸ §7Raison actuelle: §f\"" + info.getReason() + "\"");
+        player.sendMessage("§8▸ §7Bloqué le: §f" + formatDate(info.getBlockedAt()));
+        player.sendMessage("§8▸ §7Dernière modification: §f" + formatDate(info.getUpdatedAt()));
+        player.sendMessage("§c==============================");
+        player.sendMessage("");
+        player.sendMessage("§7Actions disponibles:");
+        player.sendMessage("§8• §eClic droit §7→ Modifier la raison");
+        player.sendMessage("§8• §eClic milieu §7→ Débloquer ce joueur");
+        player.sendMessage("§8• §eShift+Clic droit §7→ Options avancées");
+        player.sendMessage("");
+    }
+
+    private void confirmUnblock(final Player player, final UUID blockedUUID) {
+        final String blockedName = resolvePlayerName(blockedUUID);
+        player.sendMessage("§e⚠ §6Confirmation de déblocage");
+        player.sendMessage("§7Joueur: §c" + blockedName);
+        player.sendMessage("§7Êtes-vous sûr de vouloir débloquer ce joueur ?");
+        player.sendMessage("");
+        player.sendMessage("§7Tapez §a/friends unblock " + blockedName + "§7 pour confirmer");
+        player.sendMessage("§7Ou §cCliquez ailleurs§7 pour annuler");
+    }
+
+    private void openBlockOptionsMenu(final Player player, final UUID blockedUUID) {
+        final String blockedName = resolvePlayerName(blockedUUID);
+        final Inventory optionsMenu = Bukkit.createInventory(null, 27, OPTIONS_TITLE_PREFIX + blockedName);
+
+        final ItemStack glass = new ItemStack(Material.RED_STAINED_GLASS_PANE);
+        final ItemMeta glassMeta = glass.getItemMeta();
+        if (glassMeta != null) {
+            glassMeta.setDisplayName("§7");
+            glass.setItemMeta(glassMeta);
+        }
+        final int[] borders = {0, 1, 2, 6, 7, 8, 9, 17, 18, 19, 25, 26};
+        for (final int slot : borders) {
+            optionsMenu.setItem(slot, glass);
+        }
+
+        optionsMenu.setItem(11, createOptionItem(Material.WRITABLE_BOOK, "§e📝 Modifier la raison", List.of(
+                "§7Changer la raison du blocage",
+                "",
+                "§e▸ Raison actuelle visible dans les détails",
+                "§e▸ Nouvelle raison via chat",
+                "§e▸ Historique conservé",
+                "",
+                "§8» §eCliquez pour modifier"
+        )));
+
+        optionsMenu.setItem(13, createOptionItem(Material.BOOK, "§b📊 Voir les détails", List.of(
+                "§7Afficher toutes les informations de blocage",
+                "",
+                "§b▸ Raison complète",
+                "§b▸ Date et heure",
+                "§b▸ Historique des modifications",
+                "",
+                "§8» §bCliquez pour voir"
+        )));
+
+        optionsMenu.setItem(15, createOptionItem(Material.EMERALD, "§a✅ Débloquer", List.of(
+                "§7Débloquer " + blockedName,
+                "",
+                "§a▸ Le joueur pourra à nouveau vous contacter",
+                "§a▸ Les restrictions seront levées",
+                "§a▸ Action immédiate",
+                "",
+                "§8» §aCliquez pour débloquer"
+        )));
+
+        optionsMenu.setItem(22, createOptionItem(Material.ARROW, "§c« Retour aux joueurs bloqués", List.of(
+                "§7Revenir à la liste principale",
+                "",
+                "§8» §cCliquez pour revenir"
+        )));
+
+        optionsTarget = blockedUUID;
+        player.openInventory(optionsMenu);
+    }
+
+    private ItemStack createOptionItem(final Material material, final String name, final List<String> lore) {
+        final ItemStack item = new ItemStack(material);
+        final ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return item;
     }
 
     private void handleUnblockAll() {
-        final int count = blockedPlayers.size();
-        if (count == 0) {
+        if (blockedEntries.isEmpty() || blockedPlayersManager == null) {
             return;
         }
-        player.sendMessage("§a✅ Déblocage de tous les joueurs (" + count + ")...");
-        playSound(Sound.ENTITY_PLAYER_LEVELUP, 1.0f);
-        blockedPlayers.clear();
-        setupMenu();
-        player.updateInventory();
-        player.sendMessage("§a✓ " + count + " joueur(s) débloqué(s) avec succès !");
+
+        final List<UUID> targets = new ArrayList<>(blockedEntries.keySet());
+        player.sendMessage("§e⏳ Déblocage de " + targets.size() + " joueur(s) en cours...");
+
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            int success = 0;
+            for (final UUID target : targets) {
+                if (blockedPlayersManager.unblockPlayer(player.getUniqueId(), target)) {
+                    success++;
+                }
+            }
+
+            final int finalSuccess = success;
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                player.sendMessage("§a✅ " + finalSuccess + " joueur(s) débloqué(s) avec succès !");
+                loadBlockedPlayers();
+                setupMenu();
+                player.updateInventory();
+            });
+        });
     }
 
-    private void handleBlockedPlayerClick(final BlockedPlayerData blockedData,
-                                          final InventoryClickEvent event) {
-        if (event.getClick().isLeftClick()) {
-            player.sendMessage("§a✓ " + blockedData.getPlayerName() + " a été débloqué");
-            playSound(Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f);
-            blockedPlayers.remove(blockedData);
-            setupMenu();
-            player.updateInventory();
+    private void unblockPlayer(final Player player, final UUID blockedUUID, final String blockedName) {
+        if (blockedPlayersManager == null) {
+            player.sendMessage("§c❌ Système de blocage indisponible !");
             return;
         }
 
-        if (event.getClick().isRightClick()) {
-            player.closeInventory();
-            player.sendMessage("§e✏️ Modification raison pour " + blockedData.getPlayerName());
-            player.sendMessage("§7Tapez la nouvelle raison dans le chat:");
-            playSound(Sound.BLOCK_NOTE_BLOCK_PLING, 1.5f);
-        }
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            final boolean success = blockedPlayersManager.unblockPlayer(player.getUniqueId(), blockedUUID);
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                if (success) {
+                    player.sendMessage("§a✅ §2" + blockedName + " débloqué avec succès !");
+                    loadBlockedPlayers();
+                    setupMenu();
+                    player.updateInventory();
+                } else {
+                    player.sendMessage("§c❌ Impossible de débloquer " + blockedName + "");
+                }
+            });
+        });
     }
 
     private void handleRefresh() {
@@ -310,7 +565,9 @@ public class BlockedPlayersMenu implements Listener {
         if (!viewer.getUniqueId().equals(player.getUniqueId())) {
             return;
         }
-        if (INVENTORY_TITLE.equals(event.getView().getTitle())) {
+
+        final String title = event.getView().getTitle();
+        if (title != null && (title.equals(INVENTORY_TITLE) || title.startsWith(OPTIONS_TITLE_PREFIX))) {
             unregister();
         }
     }
@@ -330,6 +587,23 @@ public class BlockedPlayersMenu implements Listener {
         unregistered = true;
     }
 
+    private void reopenMainInventory() {
+        loadBlockedPlayers();
+        setupMenu();
+        open();
+    }
+
+    private void showBlockMenuHelp(final Player player) {
+        player.sendMessage("§e📖 §6Aide du menu Joueurs Bloqués");
+        player.sendMessage("");
+        player.sendMessage("§7Types de clics disponibles:");
+        player.sendMessage("§8• §eClic gauche §7→ Voir les détails du blocage");
+        player.sendMessage("§8• §eClic droit §7→ Modifier la raison du blocage");
+        player.sendMessage("§8• §eClic milieu §7→ Débloquer le joueur");
+        player.sendMessage("§8• §eShift+Clic droit §7→ Menu d'options avancées");
+        player.sendMessage("");
+    }
+
     private void playSound(final Sound sound, final float pitch) {
         if (sound == null || player == null) {
             return;
@@ -337,31 +611,70 @@ public class BlockedPlayersMenu implements Listener {
         player.playSound(player.getLocation(), sound, 1.0f, pitch);
     }
 
-    private static class BlockedPlayerData {
-        private final String playerName;
-        private String reason;
-        private final long blockDate;
-
-        BlockedPlayerData(final String playerName, final String reason, final long blockDate) {
-            this.playerName = playerName;
-            this.reason = reason;
-            this.blockDate = blockDate;
+    private String resolvePlayerName(final UUID playerUUID) {
+        if (playerUUID == null) {
+            return "Joueur-inconnu";
         }
 
-        public String getPlayerName() {
-            return playerName;
+        final Player online = Bukkit.getPlayer(playerUUID);
+        if (online != null) {
+            return online.getName();
         }
 
-        public String getReason() {
-            return reason;
+        if (databaseManager != null) {
+            try {
+                final String dbName = databaseManager.getPlayerName(playerUUID);
+                if (dbName != null && !dbName.isBlank()) {
+                    return dbName;
+                }
+            } catch (final Exception exception) {
+                plugin.getLogger().warning("Erreur récupération nom pour " + playerUUID + ": "
+                        + exception.getMessage());
+            }
         }
 
-        public long getBlockDate() {
-            return blockDate;
+        try {
+            final String offline = Bukkit.getOfflinePlayer(playerUUID).getName();
+            if (offline != null && !offline.isBlank()) {
+                return offline;
+            }
+        } catch (final Exception exception) {
+            plugin.getLogger().warning("Erreur OfflinePlayer pour " + playerUUID + ": " + exception.getMessage());
         }
 
-        public void setReason(final String reason) {
-            this.reason = reason;
+        return "Joueur-" + playerUUID.toString().substring(0, 8);
+    }
+
+    private String formatDate(final Timestamp timestamp) {
+        if (timestamp == null) {
+            return "Inconnue";
         }
+        final LocalDateTime dateTime = timestamp.toLocalDateTime();
+        return DISPLAY_DATE_FORMATTER.format(dateTime);
+    }
+
+    private UUID extractBlockedPlayerUUID(final ItemStack item) {
+        final ItemMeta meta = item.getItemMeta();
+        if (meta == null || meta.getLore() == null) {
+            return null;
+        }
+
+        for (final String loreLine : meta.getLore()) {
+            if (loreLine.contains("UUID:")) {
+                final String clean = loreLine.replaceAll("§[0-9a-fk-or]", "");
+                if (clean.startsWith("UUID:")) {
+                    final String rawUuid = clean.substring(5).trim();
+                    try {
+                        return UUID.fromString(rawUuid);
+                    } catch (final IllegalArgumentException exception) {
+                        plugin.getLogger().warning("UUID invalide dans lore: " + rawUuid);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private record BlockedEntry(UUID uuid, String name, String reason, Timestamp blockedAt, Timestamp updatedAt) {
     }
 }


### PR DESCRIPTION
## Summary
- add a chat-based workflow to edit block reasons with validation, async persistence, and automatic menu reopen
- expose a DatabaseManager helper to resolve player names by UUID for menus and logs
- rebuild the blocked players menu to use live data, surface block details, and provide shortcuts for editing or unblocking

## Testing
- `mvn -q -DskipTests package` *(fails: repository access forbidden for Paper/PlaceholderAPI)*

------
https://chatgpt.com/codex/tasks/task_e_68d833671de8832982531216e19e5af9